### PR TITLE
Phase 5: Signal AI — Claude API integration and chat panel

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,3 +3,4 @@ pub mod library;
 pub mod project;
 pub mod save;
 pub mod schematic;
+pub mod signal;

--- a/src-tauri/src/commands/signal.rs
+++ b/src-tauri/src/commands/signal.rs
@@ -1,0 +1,228 @@
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+
+// Claude API configuration
+static API_KEY: std::sync::LazyLock<Mutex<Option<String>>> =
+    std::sync::LazyLock::new(|| Mutex::new(None));
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub role: String,    // "user" | "assistant"
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchematicContext {
+    pub component_count: usize,
+    pub wire_count: usize,
+    pub net_count: usize,
+    pub selected_components: Vec<SelectedComponent>,
+    pub erc_errors: usize,
+    pub erc_warnings: usize,
+    pub paper_size: String,
+    pub title: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SelectedComponent {
+    pub reference: String,
+    pub value: String,
+    pub footprint: String,
+    pub lib_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ClaudeRequest {
+    model: String,
+    max_tokens: u32,
+    system: String,
+    messages: Vec<ClaudeMessage>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ClaudeMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeResponse {
+    content: Vec<ClaudeContent>,
+    #[allow(dead_code)]
+    model: String,
+    #[allow(dead_code)]
+    stop_reason: Option<String>,
+    usage: ClaudeUsage,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeContent {
+    #[allow(dead_code)]
+    #[serde(rename = "type")]
+    content_type: String,
+    text: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ClaudeUsage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SignalResponse {
+    pub message: String,
+    pub usage: ClaudeUsage,
+}
+
+fn build_system_prompt(context: &SchematicContext) -> String {
+    let mut system = String::from(
+        "You are Signal, an AI design assistant integrated into Signex EDA (Electronic Design Automation). \
+         You help hardware engineers with schematic design, component selection, ERC troubleshooting, \
+         and circuit analysis. You are knowledgeable about electronics, PCB design, and KiCad file formats.\n\n\
+         Guidelines:\n\
+         - Be concise and technical. Hardware engineers don't need hand-holding.\n\
+         - When suggesting components, include specific part numbers and values.\n\
+         - When explaining circuits, use standard EE terminology.\n\
+         - Reference designators (R1, C1, U1) when discussing specific components.\n\
+         - If asked about ERC violations, explain the root cause and suggest fixes.\n\
+         - Format responses with markdown for readability.\n\n"
+    );
+
+    system.push_str("Current schematic context:\n");
+    system.push_str(&format!("- Title: {}\n", if context.title.is_empty() { "Untitled" } else { &context.title }));
+    system.push_str(&format!("- Paper: {}\n", context.paper_size));
+    system.push_str(&format!("- Components: {}, Wires: {}, Nets: {}\n",
+        context.component_count, context.wire_count, context.net_count));
+
+    if context.erc_errors > 0 || context.erc_warnings > 0 {
+        system.push_str(&format!("- ERC: {} errors, {} warnings\n",
+            context.erc_errors, context.erc_warnings));
+    }
+
+    if !context.selected_components.is_empty() {
+        system.push_str("\nSelected components:\n");
+        for comp in &context.selected_components {
+            system.push_str(&format!("- {} = {} ({})\n",
+                comp.reference, comp.value, comp.footprint));
+        }
+    }
+
+    system
+}
+
+/// Set the Claude API key
+#[tauri::command]
+pub fn set_api_key(key: String) -> Result<(), String> {
+    let mut api_key = API_KEY.lock().unwrap_or_else(|e| e.into_inner());
+    *api_key = if key.is_empty() { None } else { Some(key) };
+    Ok(())
+}
+
+/// Check if API key is configured
+#[tauri::command]
+pub fn has_api_key() -> bool {
+    let api_key = API_KEY.lock().unwrap_or_else(|e| e.into_inner());
+    api_key.is_some()
+}
+
+/// Send a message to Claude and get a response
+#[tauri::command]
+pub async fn signal_chat(
+    messages: Vec<ChatMessage>,
+    context: SchematicContext,
+) -> Result<SignalResponse, String> {
+    let api_key = {
+        let guard = API_KEY.lock().unwrap_or_else(|e| e.into_inner());
+        guard.clone().ok_or_else(|| "API key not configured. Set it in Preferences > Signal AI.".to_string())?
+    };
+
+    let system = build_system_prompt(&context);
+
+    let claude_messages: Vec<ClaudeMessage> = messages
+        .iter()
+        .map(|m| ClaudeMessage {
+            role: m.role.clone(),
+            content: m.content.clone(),
+        })
+        .collect();
+
+    let request = ClaudeRequest {
+        model: "claude-sonnet-4-20250514".to_string(),
+        max_tokens: 4096,
+        system,
+        messages: claude_messages,
+    };
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post("https://api.anthropic.com/v1/messages")
+        .header("x-api-key", &api_key)
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json")
+        .json(&request)
+        .send()
+        .await
+        .map_err(|e| format!("Network error: {}", e))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!("Claude API error ({}): {}", status, body));
+    }
+
+    let claude_response: ClaudeResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+    let message = claude_response
+        .content
+        .iter()
+        .filter_map(|c| c.text.as_ref())
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Ok(SignalResponse {
+        message,
+        usage: claude_response.usage,
+    })
+}
+
+/// Quick analysis: send schematic context and get design review
+#[tauri::command]
+pub async fn signal_review(
+    context: SchematicContext,
+) -> Result<SignalResponse, String> {
+    let review_message = ChatMessage {
+        role: "user".to_string(),
+        content: "Review this schematic design. Check for common issues like:\n\
+            - Missing bypass capacitors\n\
+            - Incorrect pull-up/pull-down values\n\
+            - Power rail issues\n\
+            - Signal integrity concerns\n\
+            - Component selection suggestions\n\
+            Provide a brief, actionable review.".to_string(),
+    };
+
+    signal_chat(vec![review_message], context).await
+}
+
+/// Quick fix: suggest fix for a specific ERC violation
+#[tauri::command]
+pub async fn signal_fix_erc(
+    violation_message: String,
+    context: SchematicContext,
+) -> Result<SignalResponse, String> {
+    let fix_message = ChatMessage {
+        role: "user".to_string(),
+        content: format!(
+            "I have this ERC violation: \"{}\"\n\nExplain what's wrong and suggest a specific fix. \
+             Be concise — just the cause and the fix.",
+            violation_message
+        ),
+    };
+
+    signal_chat(vec![fix_message], context).await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 mod commands;
 mod engine;
 
-use commands::{export, library, project, save, schematic};
+use commands::{export, library, project, save, schematic, signal};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -23,6 +23,11 @@ pub fn run() {
             export::generate_bom_configured,
             export::export_netlist,
             export::export_netlist_xml,
+            signal::set_api_key,
+            signal::has_api_key,
+            signal::signal_chat,
+            signal::signal_review,
+            signal::signal_fix_erc,
         ])
         .run(tauri::generate_context!())
         .unwrap_or_else(|e| {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,8 +12,7 @@ import { FilterPanel } from "@/panels/FilterPanel";
 import { ListPanel } from "@/panels/ListPanel";
 import { NavigatorPanel } from "@/panels/NavigatorPanel";
 import { ComponentSearch } from "@/components/ComponentSearch";
-// Signal panel available for AI integration (Phase 1 stub)
-// import { SignalPanel } from "@/panels/SignalPanel";
+import { SignalPanel } from "@/panels/SignalPanel";
 import { EditorCanvas } from "@/canvas/EditorCanvas";
 import { LibraryEditorCanvas } from "@/canvas/LibraryEditorCanvas";
 import { ExportPdfDialog } from "@/components/ExportPdfDialog";
@@ -184,7 +183,7 @@ function App() {
   const [showParamManager, setShowParamManager] = useState(false);
   const [leftTab, setLeftTab] = useState<"projects" | "components" | "navigator">("projects");
   const [rightTab, setRightTab] = useState<"properties" | "filter" | "list">("properties");
-  const [bottomTab, setBottomTab] = useState<"messages" | "output-jobs">("messages");
+  const [bottomTab, setBottomTab] = useState<"messages" | "output-jobs" | "signal">("messages");
   const libEditorActive = useLibraryEditorStore((s) => s.active);
 
   const leftCollapsed = useLayoutStore((s) => s.leftCollapsed);
@@ -248,6 +247,13 @@ function App() {
           !(e.target instanceof HTMLInputElement) && !(e.target instanceof HTMLTextAreaElement)) {
         e.preventDefault();
         setShowFindSimilar(true);
+      }
+      // Ctrl+Shift+A — Open Signal AI panel
+      if (e.key === "A" && e.ctrlKey && e.shiftKey &&
+          !(e.target instanceof HTMLInputElement) && !(e.target instanceof HTMLTextAreaElement)) {
+        e.preventDefault();
+        setBottomTab("signal");
+        if (useLayoutStore.getState().bottomCollapsed) useLayoutStore.getState().toggleBottom();
       }
     };
     window.addEventListener("keydown", handler);
@@ -317,12 +323,12 @@ function App() {
               <ResizeHandle direction="vertical" onMouseDown={(e) => bottomResize.onMouseDown(e, bottomPanelHeight)} />
               <div className="bg-bg-secondary shrink-0" style={{ height: bottomPanelHeight }}>
                 <div className="flex items-center h-8 bg-bg-tertiary border-b border-border-subtle select-none">
-                  {(["messages", "output-jobs"] as const).map(t => (
+                  {(["messages", "output-jobs", "signal"] as const).map(t => (
                     <button key={t}
                       className={cn("flex-1 h-full text-[10px] font-semibold uppercase tracking-wider transition-colors",
                         bottomTab === t ? "text-text-secondary border-b-2 border-accent" : "text-text-muted/40 hover:text-text-muted/70")}
                       onClick={() => setBottomTab(t)}>
-                      {t === "messages" ? "Messages" : "Output Jobs"}
+                      {t === "messages" ? "Messages" : t === "output-jobs" ? "Output Jobs" : "Signal"}
                     </button>
                   ))}
                   <button onClick={toggleBottom}
@@ -333,6 +339,7 @@ function App() {
                 <div className="overflow-y-auto" style={{ height: bottomPanelHeight - 32 }}>
                   {bottomTab === "messages" && <MessagesPanel />}
                   {bottomTab === "output-jobs" && <OutputJobsPanel />}
+                  {bottomTab === "signal" && <SignalPanel />}
                 </div>
               </div>
             </>

--- a/src/panels/MessagesPanel.tsx
+++ b/src/panels/MessagesPanel.tsx
@@ -1,15 +1,58 @@
 import { useState } from "react";
-import { CheckCircle2, AlertTriangle, XCircle, Play, Trash2, Download } from "lucide-react";
+import { CheckCircle2, AlertTriangle, XCircle, Play, Trash2, Download, Zap } from "lucide-react";
 import { useSchematicStore } from "@/stores/schematic";
 import { useEditorStore, type ErcMarker } from "@/stores/editor";
+import { useSignalStore } from "@/stores/signal";
 import { runErc, type ErcViolation } from "@/lib/erc";
 import { generateErcHtmlReport } from "@/lib/ercReport";
+import { invoke } from "@tauri-apps/api/core";
 import { cn } from "@/lib/utils";
 
 export function MessagesPanel() {
   const data = useSchematicStore((s) => s.data);
   const [violations, setViolations] = useState<ErcViolation[]>([]);
   const [lastRun, setLastRun] = useState<string | null>(null);
+
+  const askSignalFix = async (violation: ErcViolation) => {
+    const store = useSignalStore.getState();
+    store.addMessage({ role: "user", content: `Fix this ERC violation: "${violation.message}" (${violation.type.replace(/_/g, " ")})` });
+
+    store.addMessage({ role: "assistant", content: "", loading: true } as import("@/stores/signal").SignalMessage);
+    store.setLoading(true);
+
+    try {
+      const schData = useSchematicStore.getState().data;
+      const ercMarkers = useEditorStore.getState().ercMarkers;
+      const context = {
+        component_count: schData?.symbols.filter((s) => !s.is_power).length || 0,
+        wire_count: schData?.wires.length || 0,
+        net_count: schData?.labels.length || 0,
+        selected_components: [] as { reference: string; value: string; footprint: string; lib_id: string }[],
+        erc_errors: ercMarkers.filter((m) => m.severity === "error").length,
+        erc_warnings: ercMarkers.filter((m) => m.severity === "warning").length,
+        paper_size: schData?.paper_size || "A4",
+        title: schData?.title_block?.title || "",
+      };
+      const response = await invoke<{ message: string; usage: { input_tokens: number; output_tokens: number } }>(
+        "signal_fix_erc", { violationMessage: violation.message, context }
+      );
+      // Find and update the loading message
+      const msgs = useSignalStore.getState().messages;
+      const loadingMsg = msgs.find((m) => m.loading);
+      if (loadingMsg) {
+        store.updateMessage(loadingMsg.id, { content: response.message, loading: false, usage: response.usage });
+      }
+      store.addTokens(response.usage.input_tokens, response.usage.output_tokens);
+    } catch (e) {
+      const msgs = useSignalStore.getState().messages;
+      const loadingMsg = msgs.find((m) => m.loading);
+      if (loadingMsg) {
+        store.updateMessage(loadingMsg.id, { content: `Error: ${e}`, loading: false, role: "system" });
+      }
+    } finally {
+      store.setLoading(false);
+    }
+  };
 
   const handleRunErc = () => {
     if (!data) return;
@@ -129,8 +172,21 @@ export function MessagesPanel() {
                 )}>
                   {v.message}
                 </div>
-                <div className="text-[9px] text-text-muted/40 mt-0.5">
-                  {v.type.replace(/_/g, " ")}
+                <div className="flex items-center gap-2 mt-0.5">
+                  <span className="text-[9px] text-text-muted/40">
+                    {v.type.replace(/_/g, " ")}
+                  </span>
+                  {useSignalStore.getState().apiKeySet && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        askSignalFix(v);
+                      }}
+                      className="text-[9px] text-accent/50 hover:text-accent transition-colors flex items-center gap-0.5"
+                      title="Ask Signal for a fix">
+                      <Zap size={8} /> Fix
+                    </button>
+                  )}
                 </div>
               </div>
             </button>

--- a/src/panels/SignalPanel.tsx
+++ b/src/panels/SignalPanel.tsx
@@ -1,31 +1,418 @@
-import { Zap } from "lucide-react";
+import { useState, useRef, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Zap, Send, Trash2, Key, AlertCircle, Cpu, FileSearch, Loader2 } from "lucide-react";
+import { useSignalStore } from "@/stores/signal";
+import { useSchematicStore } from "@/stores/schematic";
+import { useEditorStore } from "@/stores/editor";
+import { cn } from "@/lib/utils";
+import type { SignalMessage } from "@/stores/signal";
+
+function buildContext() {
+  const data = useSchematicStore.getState().data;
+  const selectedIds = useSchematicStore.getState().selectedIds;
+  const ercMarkers = useEditorStore.getState().ercMarkers;
+
+  if (!data) {
+    return {
+      component_count: 0, wire_count: 0, net_count: 0,
+      selected_components: [], erc_errors: 0, erc_warnings: 0,
+      paper_size: "A4", title: "",
+    };
+  }
+
+  const selectedComponents = data.symbols
+    .filter((s) => selectedIds.has(s.uuid) && !s.is_power)
+    .map((s) => ({
+      reference: s.reference,
+      value: s.value,
+      footprint: s.footprint,
+      lib_id: s.lib_id,
+    }));
+
+  return {
+    component_count: data.symbols.filter((s) => !s.is_power).length,
+    wire_count: data.wires.length,
+    net_count: data.labels.length,
+    selected_components: selectedComponents,
+    erc_errors: ercMarkers.filter((m) => m.severity === "error").length,
+    erc_warnings: ercMarkers.filter((m) => m.severity === "warning").length,
+    paper_size: data.paper_size,
+    title: data.title_block?.title || "",
+  };
+}
 
 export function SignalPanel() {
-  return (
-    <div className="flex flex-col h-full">
-      <div className="flex-1 flex flex-col items-center justify-center gap-3 p-6 text-text-muted text-xs">
-        <Zap size={24} className="text-accent/40" />
-        <span className="text-text-muted/50 font-medium">Signal</span>
-        <span className="text-text-muted/30 text-[11px] text-center">
-          AI-powered design assistant. Coming in Phase 1.
+  const messages = useSignalStore((s) => s.messages);
+  const apiKeySet = useSignalStore((s) => s.apiKeySet);
+  const isLoading = useSignalStore((s) => s.isLoading);
+  const totalTokens = useSignalStore((s) => s.totalTokens);
+  const [input, setInput] = useState("");
+  const [showKeyInput, setShowKeyInput] = useState(false);
+  const [apiKey, setApiKey] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Check API key on mount
+  useEffect(() => {
+    invoke<boolean>("has_api_key").then((has) => {
+      useSignalStore.getState().setApiKeySet(has);
+    });
+  }, []);
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  const saveApiKey = async () => {
+    try {
+      await invoke("set_api_key", { key: apiKey });
+      useSignalStore.getState().setApiKeySet(true);
+      setShowKeyInput(false);
+      setApiKey("");
+    } catch (e) {
+      console.error("Failed to set API key:", e);
+    }
+  };
+
+  const sendMessage = async () => {
+    const text = input.trim();
+    if (!text || isLoading) return;
+
+    setInput("");
+    const store = useSignalStore.getState();
+
+    // Add user message
+    store.addMessage({ role: "user", content: text });
+
+    // Add loading placeholder
+    const loadingId = crypto.randomUUID();
+    store.addMessage({ role: "assistant", content: "", loading: true, id: loadingId } as SignalMessage);
+    store.setLoading(true);
+
+    try {
+      const chatMessages = [...store.messages.filter((m) => !m.loading), { role: "user", content: text }]
+        .map((m) => ({ role: m.role, content: m.content }));
+
+      const context = buildContext();
+      const response = await invoke<{ message: string; usage: { input_tokens: number; output_tokens: number } }>(
+        "signal_chat", { messages: chatMessages, context }
+      );
+
+      store.updateMessage(loadingId, {
+        content: response.message,
+        loading: false,
+        usage: response.usage,
+      });
+      store.addTokens(response.usage.input_tokens, response.usage.output_tokens);
+    } catch (e) {
+      store.updateMessage(loadingId, {
+        content: `Error: ${e instanceof Error ? e.message : String(e)}`,
+        loading: false,
+        role: "system",
+      });
+    } finally {
+      store.setLoading(false);
+    }
+  };
+
+  const runDesignReview = async () => {
+    const store = useSignalStore.getState();
+    store.addMessage({ role: "user", content: "Review my schematic design" });
+
+    const loadingId = crypto.randomUUID();
+    store.addMessage({ role: "assistant", content: "", loading: true, id: loadingId } as SignalMessage);
+    store.setLoading(true);
+
+    try {
+      const context = buildContext();
+      const response = await invoke<{ message: string; usage: { input_tokens: number; output_tokens: number } }>(
+        "signal_review", { context }
+      );
+      store.updateMessage(loadingId, {
+        content: response.message,
+        loading: false,
+        usage: response.usage,
+      });
+      store.addTokens(response.usage.input_tokens, response.usage.output_tokens);
+    } catch (e) {
+      store.updateMessage(loadingId, {
+        content: `Error: ${e instanceof Error ? e.message : String(e)}`,
+        loading: false,
+        role: "system",
+      });
+    } finally {
+      store.setLoading(false);
+    }
+  };
+
+  // No API key state
+  if (!apiKeySet && !showKeyInput) {
+    return (
+      <div className="flex flex-col h-full items-center justify-center gap-4 p-6 text-xs">
+        <Zap size={28} className="text-accent/60" />
+        <span className="text-text-secondary font-semibold text-sm">Signal AI</span>
+        <span className="text-text-muted/50 text-center text-[11px] max-w-[200px]">
+          AI-powered design assistant. Enter your Anthropic API key to get started.
+        </span>
+        <button onClick={() => setShowKeyInput(true)}
+          className="flex items-center gap-2 px-4 py-2 rounded bg-accent/20 text-accent hover:bg-accent/30 transition-colors text-[11px] font-medium">
+          <Key size={14} /> Set API Key
+        </button>
+      </div>
+    );
+  }
+
+  // API key input state
+  if (showKeyInput) {
+    return (
+      <div className="flex flex-col h-full items-center justify-center gap-3 p-6 text-xs">
+        <Key size={20} className="text-accent/60" />
+        <span className="text-text-secondary font-semibold">Anthropic API Key</span>
+        <input
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Enter") saveApiKey(); }}
+          placeholder="sk-ant-..."
+          className="w-full max-w-[280px] bg-bg-surface border border-border-subtle rounded px-3 py-2 text-[11px] font-mono text-text-primary outline-none focus:border-accent"
+        />
+        <div className="flex gap-2">
+          <button onClick={() => setShowKeyInput(false)}
+            className="px-3 py-1.5 rounded text-[11px] bg-bg-hover text-text-muted hover:text-text-secondary transition-colors">
+            Cancel
+          </button>
+          <button onClick={saveApiKey} disabled={!apiKey.startsWith("sk-")}
+            className="px-3 py-1.5 rounded text-[11px] bg-accent/20 text-accent hover:bg-accent/30 transition-colors disabled:opacity-40">
+            Save
+          </button>
+        </div>
+        <span className="text-text-muted/30 text-[10px] text-center max-w-[250px]">
+          Key is stored in memory only. It's never saved to disk or sent anywhere except the Anthropic API.
         </span>
       </div>
-      <div className="border-t border-border-subtle p-2">
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full text-xs">
+      {/* Toolbar */}
+      <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border-subtle shrink-0">
+        <Zap size={12} className="text-accent" />
+        <span className="text-[10px] font-semibold text-accent uppercase tracking-wider">Signal</span>
+        <div className="flex-1" />
+        <button onClick={runDesignReview} disabled={isLoading} title="Design Review"
+          className="p-1 rounded text-text-muted/50 hover:text-accent hover:bg-accent/10 transition-colors disabled:opacity-30">
+          <FileSearch size={13} />
+        </button>
+        <button onClick={() => useSignalStore.getState().clearHistory()} title="Clear History"
+          className="p-1 rounded text-text-muted/50 hover:text-error hover:bg-error/10 transition-colors">
+          <Trash2 size={13} />
+        </button>
+        <button onClick={() => setShowKeyInput(true)} title="Change API Key"
+          className="p-1 rounded text-text-muted/50 hover:text-text-secondary transition-colors">
+          <Key size={13} />
+        </button>
+        {totalTokens > 0 && (
+          <span className="text-[9px] text-text-muted/30 font-mono tabular-nums">
+            {(totalTokens / 1000).toFixed(1)}k
+          </span>
+        )}
+      </div>
+
+      {/* Messages */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto p-3 space-y-3">
+        {messages.length === 0 && (
+          <div className="flex flex-col items-center justify-center h-full gap-3 text-text-muted/30">
+            <Zap size={20} />
+            <span className="text-[11px]">Ask Signal about your design</span>
+            <div className="flex flex-wrap gap-1.5 justify-center max-w-[250px]">
+              {["Review my design", "Suggest bypass caps", "Fix ERC errors", "Component alternatives"].map((q) => (
+                <button key={q} onClick={() => { setInput(q); inputRef.current?.focus(); }}
+                  className="px-2 py-1 rounded bg-bg-surface border border-border-subtle text-[10px] text-text-muted hover:text-accent hover:border-accent/30 transition-colors">
+                  {q}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {messages.map((msg) => (
+          <MessageBubble key={msg.id} message={msg} />
+        ))}
+      </div>
+
+      {/* Input */}
+      <div className="border-t border-border-subtle p-2 shrink-0">
         <div className="flex gap-2">
           <input
+            ref={inputRef}
             type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              e.stopPropagation();
+              if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); }
+            }}
             placeholder="Ask Signal about your design..."
-            className="flex-1 bg-bg-surface border border-border-subtle rounded px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted/40 outline-none focus:border-accent/50"
-            disabled
+            className="flex-1 bg-bg-surface border border-border-subtle rounded px-3 py-1.5 text-[11px] text-text-primary placeholder:text-text-muted/40 outline-none focus:border-accent/50"
+            disabled={isLoading}
           />
-          <button
-            className="px-3 py-1.5 bg-accent/10 text-accent/40 rounded text-xs cursor-not-allowed"
-            disabled
-          >
-            Send
+          <button onClick={sendMessage} disabled={isLoading || !input.trim()}
+            className={cn(
+              "px-3 py-1.5 rounded text-[11px] transition-colors flex items-center gap-1",
+              isLoading ? "bg-accent/10 text-accent/40" : "bg-accent/20 text-accent hover:bg-accent/30"
+            )}>
+            {isLoading ? <Loader2 size={12} className="animate-spin" /> : <Send size={12} />}
           </button>
         </div>
       </div>
     </div>
   );
+}
+
+function MessageBubble({ message }: { message: SignalMessage }) {
+  const isUser = message.role === "user";
+  const isSystem = message.role === "system";
+
+  if (message.loading) {
+    return (
+      <div className="flex items-center gap-2 text-accent/60">
+        <Loader2 size={14} className="animate-spin" />
+        <span className="text-[11px]">Signal is thinking...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-1", isUser ? "items-end" : "items-start")}>
+      <div className={cn(
+        "rounded-lg px-3 py-2 max-w-[90%] text-[11px] leading-relaxed",
+        isUser
+          ? "bg-accent/15 text-text-primary"
+          : isSystem
+            ? "bg-error/10 text-error border border-error/20"
+            : "bg-bg-surface border border-border-subtle text-text-secondary"
+      )}>
+        {isSystem && (
+          <div className="flex items-center gap-1 mb-1 text-[10px] text-error/70">
+            <AlertCircle size={10} /> Error
+          </div>
+        )}
+        {!isUser && !isSystem && (
+          <div className="flex items-center gap-1 mb-1 text-[10px] text-accent/50">
+            <Cpu size={10} /> Signal
+          </div>
+        )}
+        <div className="whitespace-pre-wrap break-words">
+          {renderMarkdown(message.content)}
+        </div>
+      </div>
+      {message.usage && (
+        <span className="text-[9px] text-text-muted/20 font-mono px-1">
+          {message.usage.input_tokens + message.usage.output_tokens} tokens
+        </span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Minimal markdown rendering — bold, inline code, code blocks, lists
+ */
+function renderMarkdown(text: string): React.ReactNode {
+  if (!text) return null;
+
+  const parts: React.ReactNode[] = [];
+  const lines = text.split("\n");
+  let inCodeBlock = false;
+  let codeContent = "";
+  let codeKey = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (line.startsWith("```")) {
+      if (inCodeBlock) {
+        parts.push(
+          <pre key={`code-${codeKey++}`} className="bg-bg-primary rounded p-2 my-1 text-[10px] font-mono overflow-x-auto border border-border-subtle">
+            {codeContent}
+          </pre>
+        );
+        codeContent = "";
+        inCodeBlock = false;
+      } else {
+        inCodeBlock = true;
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      codeContent += (codeContent ? "\n" : "") + line;
+      continue;
+    }
+
+    // Headers
+    if (line.startsWith("### ")) {
+      parts.push(<div key={i} className="font-semibold text-text-primary mt-2 mb-0.5">{line.slice(4)}</div>);
+    } else if (line.startsWith("## ")) {
+      parts.push(<div key={i} className="font-bold text-text-primary mt-2 mb-0.5">{line.slice(3)}</div>);
+    } else if (line.startsWith("# ")) {
+      parts.push(<div key={i} className="font-bold text-text-primary text-xs mt-2 mb-1">{line.slice(2)}</div>);
+    } else if (line.startsWith("- ") || line.startsWith("* ")) {
+      parts.push(<div key={i} className="pl-3">{"\u2022 "}{formatInline(line.slice(2))}</div>);
+    } else if (/^\d+\.\s/.test(line)) {
+      const match = line.match(/^(\d+\.)\s(.*)$/);
+      if (match) parts.push(<div key={i} className="pl-3">{match[1]} {formatInline(match[2])}</div>);
+    } else if (line.trim() === "") {
+      parts.push(<div key={i} className="h-1" />);
+    } else {
+      parts.push(<div key={i}>{formatInline(line)}</div>);
+    }
+  }
+
+  return <>{parts}</>;
+}
+
+function formatInline(text: string): React.ReactNode {
+  // Bold, inline code
+  const parts: React.ReactNode[] = [];
+  let remaining = text;
+  let key = 0;
+
+  while (remaining.length > 0) {
+    // Inline code
+    const codeMatch = remaining.match(/^(.*?)`([^`]+)`(.*)$/);
+    if (codeMatch) {
+      if (codeMatch[1]) parts.push(formatBold(codeMatch[1], key++));
+      parts.push(
+        <code key={`ic-${key++}`} className="bg-bg-primary px-1 py-0.5 rounded text-accent font-mono text-[10px]">
+          {codeMatch[2]}
+        </code>
+      );
+      remaining = codeMatch[3];
+      continue;
+    }
+    parts.push(formatBold(remaining, key++));
+    break;
+  }
+  return <>{parts}</>;
+}
+
+function formatBold(text: string, key: number): React.ReactNode {
+  const parts: React.ReactNode[] = [];
+  const boldRegex = /\*\*(.+?)\*\*/g;
+  let lastIndex = 0;
+  let match;
+
+  while ((match = boldRegex.exec(text)) !== null) {
+    if (match.index > lastIndex) parts.push(text.slice(lastIndex, match.index));
+    parts.push(<strong key={`b-${key}-${match.index}`}>{match[1]}</strong>);
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < text.length) parts.push(text.slice(lastIndex));
+  if (parts.length === 0) return text;
+  return <>{parts}</>;
 }

--- a/src/stores/signal.ts
+++ b/src/stores/signal.ts
@@ -1,0 +1,72 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export interface SignalMessage {
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  timestamp: number;
+  usage?: { input_tokens: number; output_tokens: number };
+  loading?: boolean;
+}
+
+interface SignalState {
+  messages: SignalMessage[];
+  apiKeySet: boolean;
+  isLoading: boolean;
+  totalTokens: number;
+
+  addMessage: (msg: Omit<SignalMessage, "id" | "timestamp">) => void;
+  updateMessage: (id: string, updates: Partial<SignalMessage>) => void;
+  removeMessage: (id: string) => void;
+  clearHistory: () => void;
+  setApiKeySet: (v: boolean) => void;
+  setLoading: (v: boolean) => void;
+  addTokens: (input: number, output: number) => void;
+}
+
+export const useSignalStore = create<SignalState>()(
+  persist(
+    (set) => ({
+      messages: [],
+      apiKeySet: false,
+      isLoading: false,
+      totalTokens: 0,
+
+      addMessage: (msg) =>
+        set((s) => ({
+          messages: [
+            ...s.messages,
+            { ...msg, id: crypto.randomUUID(), timestamp: Date.now() },
+          ],
+        })),
+
+      updateMessage: (id, updates) =>
+        set((s) => ({
+          messages: s.messages.map((m) =>
+            m.id === id ? { ...m, ...updates } : m
+          ),
+        })),
+
+      removeMessage: (id) =>
+        set((s) => ({ messages: s.messages.filter((m) => m.id !== id) })),
+
+      clearHistory: () => set({ messages: [], totalTokens: 0 }),
+
+      setApiKeySet: (v) => set({ apiKeySet: v }),
+
+      setLoading: (v) => set({ isLoading: v }),
+
+      addTokens: (input, output) =>
+        set((s) => ({ totalTokens: s.totalTokens + input + output })),
+    }),
+    {
+      name: "signex-signal",
+      partialize: (state) => ({
+        messages: state.messages.filter((m) => !m.loading),
+        apiKeySet: state.apiKeySet,
+        totalTokens: state.totalTokens,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
Rust backend (signal.rs):
- Claude API client via reqwest with Messages API
- System prompt with schematic context (components, wires, nets, ERC, selection)
- signal_chat: full conversation with context
- signal_review: one-click design review
- signal_fix_erc: targeted ERC violation fix suggestions
- API key management (set_api_key, has_api_key) — stored in memory only

Frontend:
- Signal store (Zustand + persist): chat history, token tracking, API key state
- Signal panel: full chat UI with markdown rendering (bold, code, headers, lists)
- API key setup flow with clear privacy messaging
- Quick action buttons: Design Review, suggested prompts
- Token usage counter
- Ctrl+Shift+A shortcut to open Signal panel
- Signal tab in bottom panel alongside Messages and Output Jobs

ERC integration:
- "Ask Signal" fix button on each ERC violation in Messages panel
- Sends violation context to Claude for targeted fix suggestions

Context extraction:
- Schematic context built from live state: component count, wire count, selected components (ref/value/footprint), ERC error/warning counts