### PR TITLE
Signal AI improvements: streaming, rich context, tool use, visual con…

### DIFF
--- a/src-tauri/src/commands/signal.rs
+++ b/src-tauri/src/commands/signal.rs
@@ -1,13 +1,16 @@
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
+use tauri::Emitter;
 
 // Claude API configuration
 static API_KEY: std::sync::LazyLock<Mutex<Option<String>>> =
     std::sync::LazyLock::new(|| Mutex::new(None));
 
+const DEFAULT_MODEL: &str = "claude-sonnet-4-20250514";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
-    pub role: String,    // "user" | "assistant"
+    pub role: String,
     pub content: String,
 }
 
@@ -21,6 +24,10 @@ pub struct SchematicContext {
     pub erc_warnings: usize,
     pub paper_size: String,
     pub title: String,
+    #[serde(default)]
+    pub detailed_context: Option<String>,
+    #[serde(default)]
+    pub design_brief: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,18 +38,24 @@ pub struct SelectedComponent {
     pub lib_id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+// --- Claude API types ---
+
+#[derive(Debug, Serialize)]
 struct ClaudeRequest {
     model: String,
     max_tokens: u32,
     system: String,
-    messages: Vec<ClaudeMessage>,
+    messages: Vec<ClaudeApiMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<ToolDef>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct ClaudeMessage {
+struct ClaudeApiMessage {
     role: String,
-    content: String,
+    content: serde_json::Value, // String or array of content blocks
 }
 
 #[derive(Debug, Deserialize)]
@@ -50,20 +63,22 @@ struct ClaudeResponse {
     content: Vec<ClaudeContent>,
     #[allow(dead_code)]
     model: String,
-    #[allow(dead_code)]
     stop_reason: Option<String>,
     usage: ClaudeUsage,
 }
 
 #[derive(Debug, Deserialize)]
 struct ClaudeContent {
-    #[allow(dead_code)]
     #[serde(rename = "type")]
     content_type: String,
     text: Option<String>,
+    // Tool use fields
+    id: Option<String>,
+    name: Option<String>,
+    input: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClaudeUsage {
     pub input_tokens: u32,
     pub output_tokens: u32,
@@ -73,45 +88,213 @@ pub struct ClaudeUsage {
 pub struct SignalResponse {
     pub message: String,
     pub usage: ClaudeUsage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    pub input: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+struct ToolDef {
+    name: String,
+    description: String,
+    input_schema: serde_json::Value,
+}
+
+// --- Streaming event payloads ---
+
+#[derive(Debug, Clone, Serialize)]
+struct StreamDelta {
+    text: String,
+    message_id: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StreamDone {
+    message_id: String,
+    usage: ClaudeUsage,
+    tool_calls: Vec<ToolCall>,
+    stop_reason: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StreamError {
+    message_id: String,
+    error: String,
+}
+
+// --- Tool definitions ---
+
+fn get_tool_definitions() -> Vec<ToolDef> {
+    vec![
+        ToolDef {
+            name: "add_component".to_string(),
+            description: "Add a component to the schematic at a specific position".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "reference_prefix": { "type": "string", "description": "Component prefix (R, C, U, L, D, Q, etc.)" },
+                    "value": { "type": "string", "description": "Component value (10k, 100nF, STM32F4, etc.)" },
+                    "x": { "type": "number", "description": "X position in mm" },
+                    "y": { "type": "number", "description": "Y position in mm" }
+                },
+                "required": ["reference_prefix", "value", "x", "y"]
+            }),
+        },
+        ToolDef {
+            name: "add_wire".to_string(),
+            description: "Draw a wire between two points on the schematic".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "start_x": { "type": "number" }, "start_y": { "type": "number" },
+                    "end_x": { "type": "number" }, "end_y": { "type": "number" }
+                },
+                "required": ["start_x", "start_y", "end_x", "end_y"]
+            }),
+        },
+        ToolDef {
+            name: "set_component_value".to_string(),
+            description: "Change the value of an existing component by its reference designator".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "reference": { "type": "string", "description": "Component reference (R1, C2, U3)" },
+                    "value": { "type": "string", "description": "New value" }
+                },
+                "required": ["reference", "value"]
+            }),
+        },
+        ToolDef {
+            name: "add_net_label".to_string(),
+            description: "Place a net label at a position on the schematic".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "text": { "type": "string", "description": "Net name (VCC, GND, SDA, etc.)" },
+                    "x": { "type": "number" }, "y": { "type": "number" }
+                },
+                "required": ["text", "x", "y"]
+            }),
+        },
+        ToolDef {
+            name: "run_erc".to_string(),
+            description: "Run Electrical Rules Check and return the results".to_string(),
+            input_schema: serde_json::json!({ "type": "object", "properties": {} }),
+        },
+    ]
 }
 
 fn build_system_prompt(context: &SchematicContext) -> String {
     let mut system = String::from(
-        "You are Signal, an AI design assistant integrated into Signex EDA (Electronic Design Automation). \
+        "You are Signal, an AI design assistant integrated into Signex EDA. \
          You help hardware engineers with schematic design, component selection, ERC troubleshooting, \
-         and circuit analysis. You are knowledgeable about electronics, PCB design, and KiCad file formats.\n\n\
+         and circuit analysis.\n\n\
          Guidelines:\n\
-         - Be concise and technical. Hardware engineers don't need hand-holding.\n\
-         - When suggesting components, include specific part numbers and values.\n\
-         - When explaining circuits, use standard EE terminology.\n\
-         - Reference designators (R1, C1, U1) when discussing specific components.\n\
-         - If asked about ERC violations, explain the root cause and suggest fixes.\n\
-         - Format responses with markdown for readability.\n\n"
+         - Be concise and technical.\n\
+         - Use specific part numbers and values when suggesting components.\n\
+         - Use standard EE terminology and reference designators (R1, C1, U1).\n\
+         - Format responses with markdown.\n\
+         - When asked to create or modify circuits, use the available tools.\n\n"
     );
 
-    system.push_str("Current schematic context:\n");
+    // Design brief (persistent context)
+    if let Some(brief) = &context.design_brief {
+        if !brief.is_empty() {
+            system.push_str(&format!("Design intent: {}\n\n", brief));
+        }
+    }
+
+    system.push_str("Current schematic:\n");
     system.push_str(&format!("- Title: {}\n", if context.title.is_empty() { "Untitled" } else { &context.title }));
-    system.push_str(&format!("- Paper: {}\n", context.paper_size));
-    system.push_str(&format!("- Components: {}, Wires: {}, Nets: {}\n",
-        context.component_count, context.wire_count, context.net_count));
+    system.push_str(&format!("- Paper: {}, Components: {}, Wires: {}, Nets: {}\n",
+        context.paper_size, context.component_count, context.wire_count, context.net_count));
 
     if context.erc_errors > 0 || context.erc_warnings > 0 {
-        system.push_str(&format!("- ERC: {} errors, {} warnings\n",
-            context.erc_errors, context.erc_warnings));
+        system.push_str(&format!("- ERC: {} errors, {} warnings\n", context.erc_errors, context.erc_warnings));
     }
 
     if !context.selected_components.is_empty() {
-        system.push_str("\nSelected components:\n");
+        system.push_str("\nSelected:\n");
         for comp in &context.selected_components {
-            system.push_str(&format!("- {} = {} ({})\n",
-                comp.reference, comp.value, comp.footprint));
+            system.push_str(&format!("- {} = {} ({})\n", comp.reference, comp.value, comp.footprint));
+        }
+    }
+
+    // Rich detailed context (net connectivity, component list, ERC details)
+    if let Some(detail) = &context.detailed_context {
+        if !detail.is_empty() {
+            system.push_str("\n");
+            system.push_str(detail);
         }
     }
 
     system
 }
 
-/// Set the Claude API key
+fn get_api_key() -> Result<String, String> {
+    let guard = API_KEY.lock().unwrap_or_else(|e| e.into_inner());
+    guard.clone().ok_or_else(|| "API key not configured. Set it in Signal panel.".to_string())
+}
+
+fn build_request(
+    messages: &[ChatMessage],
+    context: &SchematicContext,
+    model: Option<&str>,
+    stream: bool,
+    enable_tools: bool,
+    image_base64: Option<&str>,
+) -> ClaudeRequest {
+    let system = build_system_prompt(context);
+
+    let claude_messages: Vec<ClaudeApiMessage> = messages
+        .iter()
+        .enumerate()
+        .map(|(i, m)| {
+            // If this is the last user message and we have an image, send as multi-content
+            if i == messages.len() - 1 && m.role == "user" && image_base64.is_some() {
+                ClaudeApiMessage {
+                    role: m.role.clone(),
+                    content: serde_json::json!([
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": image_base64.unwrap()
+                            }
+                        },
+                        { "type": "text", "text": m.content }
+                    ]),
+                }
+            } else {
+                ClaudeApiMessage {
+                    role: m.role.clone(),
+                    content: serde_json::Value::String(m.content.clone()),
+                }
+            }
+        })
+        .collect();
+
+    ClaudeRequest {
+        model: model.unwrap_or(DEFAULT_MODEL).to_string(),
+        max_tokens: 4096,
+        system,
+        messages: claude_messages,
+        stream: if stream { Some(true) } else { None },
+        tools: if enable_tools { Some(get_tool_definitions()) } else { None },
+    }
+}
+
+// --- Commands ---
+
 #[tauri::command]
 pub fn set_api_key(key: String) -> Result<(), String> {
     let mut api_key = API_KEY.lock().unwrap_or_else(|e| e.into_inner());
@@ -119,40 +302,26 @@ pub fn set_api_key(key: String) -> Result<(), String> {
     Ok(())
 }
 
-/// Check if API key is configured
 #[tauri::command]
 pub fn has_api_key() -> bool {
     let api_key = API_KEY.lock().unwrap_or_else(|e| e.into_inner());
     api_key.is_some()
 }
 
-/// Send a message to Claude and get a response
+/// Non-streaming chat (kept for backwards compat and simple queries)
 #[tauri::command]
 pub async fn signal_chat(
     messages: Vec<ChatMessage>,
     context: SchematicContext,
+    model: Option<String>,
+    image_base64: Option<String>,
 ) -> Result<SignalResponse, String> {
-    let api_key = {
-        let guard = API_KEY.lock().unwrap_or_else(|e| e.into_inner());
-        guard.clone().ok_or_else(|| "API key not configured. Set it in Preferences > Signal AI.".to_string())?
-    };
-
-    let system = build_system_prompt(&context);
-
-    let claude_messages: Vec<ClaudeMessage> = messages
-        .iter()
-        .map(|m| ClaudeMessage {
-            role: m.role.clone(),
-            content: m.content.clone(),
-        })
-        .collect();
-
-    let request = ClaudeRequest {
-        model: "claude-sonnet-4-20250514".to_string(),
-        max_tokens: 4096,
-        system,
-        messages: claude_messages,
-    };
+    let api_key = get_api_key()?;
+    let request = build_request(
+        &messages, &context,
+        model.as_deref(), false, true,
+        image_base64.as_deref(),
+    );
 
     let client = reqwest::Client::new();
     let response = client
@@ -171,58 +340,213 @@ pub async fn signal_chat(
         return Err(format!("Claude API error ({}): {}", status, body));
     }
 
-    let claude_response: ClaudeResponse = response
-        .json()
-        .await
+    let claude_response: ClaudeResponse = response.json().await
         .map_err(|e| format!("Failed to parse response: {}", e))?;
 
-    let message = claude_response
-        .content
-        .iter()
-        .filter_map(|c| c.text.as_ref())
-        .cloned()
-        .collect::<Vec<_>>()
-        .join("\n");
+    let mut message = String::new();
+    let mut tool_calls = Vec::new();
+
+    for c in &claude_response.content {
+        match c.content_type.as_str() {
+            "text" => {
+                if let Some(text) = &c.text {
+                    message.push_str(text);
+                }
+            }
+            "tool_use" => {
+                if let (Some(id), Some(name), Some(input)) = (&c.id, &c.name, &c.input) {
+                    tool_calls.push(ToolCall {
+                        id: id.clone(),
+                        name: name.clone(),
+                        input: input.clone(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
 
     Ok(SignalResponse {
         message,
         usage: claude_response.usage,
+        tool_calls: if tool_calls.is_empty() { None } else { Some(tool_calls) },
+        stop_reason: claude_response.stop_reason,
     })
 }
 
-/// Quick analysis: send schematic context and get design review
+/// Streaming chat — emits events as tokens arrive
+#[tauri::command]
+pub async fn signal_chat_stream(
+    app: tauri::AppHandle,
+    message_id: String,
+    messages: Vec<ChatMessage>,
+    context: SchematicContext,
+    model: Option<String>,
+    image_base64: Option<String>,
+) -> Result<(), String> {
+    let api_key = get_api_key()?;
+    let request = build_request(
+        &messages, &context,
+        model.as_deref(), true, true,
+        image_base64.as_deref(),
+    );
+
+    // Spawn the streaming task
+    tokio::spawn(async move {
+        let client = reqwest::Client::new();
+        let response = match client
+            .post("https://api.anthropic.com/v1/messages")
+            .header("x-api-key", &api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .json(&request)
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                let _ = app.emit("signal:stream-error", StreamError {
+                    message_id, error: format!("Network error: {}", e),
+                });
+                return;
+            }
+        };
+
+        if !response.status().is_success() {
+            let body = response.text().await.unwrap_or_default();
+            let _ = app.emit("signal:stream-error", StreamError {
+                message_id, error: format!("API error: {}", body),
+            });
+            return;
+        }
+
+        // Read SSE stream
+        let mut buffer = String::new();
+        let mut usage = ClaudeUsage { input_tokens: 0, output_tokens: 0 };
+        let mut tool_calls: Vec<ToolCall> = Vec::new();
+        let mut stop_reason = String::from("end_turn");
+        let mut current_tool_id = String::new();
+        let mut current_tool_name = String::new();
+        let mut current_tool_input = String::new();
+
+        let bytes = response.bytes().await.unwrap_or_default();
+        let text = String::from_utf8_lossy(&bytes);
+
+        for line in text.lines() {
+            if line.starts_with("data: ") {
+                let data = &line[6..];
+                if data == "[DONE]" { break; }
+
+                if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
+                    let event_type = event.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+                    match event_type {
+                        "content_block_delta" => {
+                            if let Some(delta) = event.get("delta") {
+                                let delta_type = delta.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                                if delta_type == "text_delta" {
+                                    if let Some(text) = delta.get("text").and_then(|t| t.as_str()) {
+                                        buffer.push_str(text);
+                                        let _ = app.emit("signal:stream-delta", StreamDelta {
+                                            text: text.to_string(),
+                                            message_id: message_id.clone(),
+                                        });
+                                    }
+                                } else if delta_type == "input_json_delta" {
+                                    if let Some(partial) = delta.get("partial_json").and_then(|t| t.as_str()) {
+                                        current_tool_input.push_str(partial);
+                                    }
+                                }
+                            }
+                        }
+                        "content_block_start" => {
+                            if let Some(cb) = event.get("content_block") {
+                                let cb_type = cb.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                                if cb_type == "tool_use" {
+                                    current_tool_id = cb.get("id").and_then(|t| t.as_str()).unwrap_or("").to_string();
+                                    current_tool_name = cb.get("name").and_then(|t| t.as_str()).unwrap_or("").to_string();
+                                    current_tool_input.clear();
+                                }
+                            }
+                        }
+                        "content_block_stop" => {
+                            if !current_tool_name.is_empty() {
+                                let input = serde_json::from_str(&current_tool_input).unwrap_or(serde_json::json!({}));
+                                tool_calls.push(ToolCall {
+                                    id: current_tool_id.clone(),
+                                    name: current_tool_name.clone(),
+                                    input,
+                                });
+                                current_tool_name.clear();
+                                current_tool_id.clear();
+                                current_tool_input.clear();
+                            }
+                        }
+                        "message_delta" => {
+                            if let Some(u) = event.get("usage") {
+                                if let Some(out) = u.get("output_tokens").and_then(|t| t.as_u64()) {
+                                    usage.output_tokens = out as u32;
+                                }
+                            }
+                            if let Some(sr) = event.get("delta").and_then(|d| d.get("stop_reason")).and_then(|s| s.as_str()) {
+                                stop_reason = sr.to_string();
+                            }
+                        }
+                        "message_start" => {
+                            if let Some(msg) = event.get("message") {
+                                if let Some(u) = msg.get("usage") {
+                                    if let Some(inp) = u.get("input_tokens").and_then(|t| t.as_u64()) {
+                                        usage.input_tokens = inp as u32;
+                                    }
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        let _ = app.emit("signal:stream-done", StreamDone {
+            message_id,
+            usage,
+            tool_calls,
+            stop_reason,
+        });
+    });
+
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn signal_review(
     context: SchematicContext,
+    model: Option<String>,
 ) -> Result<SignalResponse, String> {
     let review_message = ChatMessage {
         role: "user".to_string(),
-        content: "Review this schematic design. Check for common issues like:\n\
+        content: "Review this schematic design. Check for:\n\
             - Missing bypass capacitors\n\
             - Incorrect pull-up/pull-down values\n\
             - Power rail issues\n\
             - Signal integrity concerns\n\
-            - Component selection suggestions\n\
             Provide a brief, actionable review.".to_string(),
     };
-
-    signal_chat(vec![review_message], context).await
+    signal_chat(vec![review_message], context, model, None).await
 }
 
-/// Quick fix: suggest fix for a specific ERC violation
 #[tauri::command]
 pub async fn signal_fix_erc(
     violation_message: String,
     context: SchematicContext,
+    model: Option<String>,
 ) -> Result<SignalResponse, String> {
     let fix_message = ChatMessage {
         role: "user".to_string(),
         content: format!(
-            "I have this ERC violation: \"{}\"\n\nExplain what's wrong and suggest a specific fix. \
-             Be concise — just the cause and the fix.",
+            "ERC violation: \"{}\"\n\nExplain the cause and suggest a specific fix. Be concise.",
             violation_message
         ),
     };
-
-    signal_chat(vec![fix_message], context).await
+    signal_chat(vec![fix_message], context, model, None).await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ pub fn run() {
             signal::set_api_key,
             signal::has_api_key,
             signal::signal_chat,
+            signal::signal_chat_stream,
             signal::signal_review,
             signal::signal_fix_erc,
         ])

--- a/src/components/SignalInlineSuggestion.tsx
+++ b/src/components/SignalInlineSuggestion.tsx
@@ -1,0 +1,137 @@
+import { useState, useEffect, useRef } from "react";
+import { Zap, Loader2, X } from "lucide-react";
+import { invoke } from "@tauri-apps/api/core";
+import { useSchematicStore } from "@/stores/schematic";
+import { useEditorStore } from "@/stores/editor";
+import { useSignalStore } from "@/stores/signal";
+import { buildRichContext } from "@/lib/signalContext";
+
+interface Props {
+  targetUuid: string;
+  targetType: "symbol" | "wire" | "label" | "net";
+  targetInfo: string; // e.g., "R1 = 10k" or "Net: SDA"
+  position: { x: number; y: number }; // Screen position for popover
+  onClose: () => void;
+}
+
+export function SignalInlineSuggestion({ targetUuid, targetType, targetInfo, position, onClose }: Props) {
+  const [suggestion, setSuggestion] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  const apiKeySet = useSignalStore((s) => s.apiKeySet);
+
+  useEffect(() => {
+    if (!apiKeySet) return;
+
+    const fetchSuggestion = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const data = useSchematicStore.getState().data;
+        const selectedIds = useSchematicStore.getState().selectedIds;
+        const ercMarkers = useEditorStore.getState().ercMarkers;
+        const model = useSignalStore.getState().model;
+
+        if (!data) throw new Error("No schematic loaded");
+
+        const detailedContext = buildRichContext(data, selectedIds, ercMarkers);
+
+        const prompt = targetType === "symbol"
+          ? `Quick analysis of component ${targetInfo}. Any concerns about value, footprint, or connections? One paragraph max.`
+          : targetType === "label" || targetType === "net"
+          ? `Quick analysis of net/label "${targetInfo}". Any signal integrity or connectivity concerns? One paragraph max.`
+          : `Quick analysis of ${targetType} "${targetInfo}". Any concerns? One paragraph max.`;
+
+        const context = {
+          component_count: data.symbols.filter((s) => !s.is_power).length,
+          wire_count: data.wires.length,
+          net_count: data.labels.length,
+          selected_components: [],
+          erc_errors: ercMarkers.filter((m) => m.severity === "error").length,
+          erc_warnings: ercMarkers.filter((m) => m.severity === "warning").length,
+          paper_size: data.paper_size,
+          title: data.title_block?.title || "",
+          detailed_context: detailedContext,
+          design_brief: useSignalStore.getState().designBrief || null,
+        };
+
+        const response = await invoke<{ message: string; usage: { input_tokens: number; output_tokens: number } }>(
+          "signal_chat",
+          {
+            messages: [{ role: "user", content: prompt }],
+            context,
+            model,
+            imageBase64: null,
+          }
+        );
+
+        setSuggestion(response.message);
+        useSignalStore.getState().addTokens(response.usage.input_tokens, response.usage.output_tokens);
+        useSignalStore.getState().addCost(response.usage.input_tokens, response.usage.output_tokens);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSuggestion();
+  }, [targetUuid, targetType, targetInfo, apiKeySet]);
+
+  // Click outside to close
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [onClose]);
+
+  if (!apiKeySet) return null;
+
+  return (
+    <div
+      ref={popoverRef}
+      className="fixed z-[100] bg-[#1e1e2e] border border-[#45475a] rounded-lg shadow-2xl p-3 max-w-[300px] text-xs"
+      style={{ left: position.x, top: position.y }}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-1.5 text-accent">
+          <Zap size={12} />
+          <span className="text-[10px] font-semibold uppercase tracking-wider">Signal</span>
+        </div>
+        <button onClick={onClose} className="p-0.5 rounded hover:bg-[#313244] text-[#6c7086]">
+          <X size={12} />
+        </button>
+      </div>
+
+      <div className="text-[10px] text-[#a6adc8] mb-2 font-mono truncate">
+        {targetInfo}
+      </div>
+
+      {loading && (
+        <div className="flex items-center gap-2 text-accent/60 py-2">
+          <Loader2 size={12} className="animate-spin" />
+          <span className="text-[10px]">Analyzing...</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="text-[10px] text-red-400 py-1">
+          {error}
+        </div>
+      )}
+
+      {suggestion && (
+        <div className="text-[11px] text-[#cdd6f4] leading-relaxed whitespace-pre-wrap">
+          {suggestion}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/pdfExport.ts
+++ b/src/lib/pdfExport.ts
@@ -160,7 +160,7 @@ function drawTextProp(
   }
 }
 
-function renderSchematicToCanvas(
+export function renderSchematicToCanvas(
   data: SchematicData, canvas: HTMLCanvasElement,
   opts: { showGrid: boolean; colorMode: "color" | "monochrome" },
 ) {

--- a/src/lib/signalContext.ts
+++ b/src/lib/signalContext.ts
@@ -1,0 +1,124 @@
+import type { SchematicData } from "@/types";
+import type { ErcMarker } from "@/stores/editor";
+import { resolveNets } from "./netResolver";
+import { renderSchematicToCanvas } from "./pdfExport";
+
+const MAX_COMPONENTS = 50;
+const MAX_NETS = 30;
+const MAX_CHARS = 8000;
+
+/**
+ * Build a rich text context string with component list, net connectivity, and ERC details.
+ * This gets sent to Claude as part of the system prompt for better analysis.
+ */
+export function buildRichContext(
+  data: SchematicData,
+  selectedIds: Set<string>,
+  ercMarkers: ErcMarker[],
+): string {
+  const parts: string[] = [];
+
+  // Component list
+  const components = data.symbols.filter((s) => !s.is_power);
+  if (components.length > 0) {
+    parts.push("Components:");
+    const sorted = [...components].sort((a, b) => a.reference.localeCompare(b.reference, undefined, { numeric: true }));
+    const shown = sorted.slice(0, MAX_COMPONENTS);
+    for (const c of shown) {
+      const sel = selectedIds.has(c.uuid) ? " [SELECTED]" : "";
+      parts.push(`  ${c.reference} = ${c.value} (${c.footprint || "no footprint"})${sel}`);
+    }
+    if (components.length > MAX_COMPONENTS) {
+      parts.push(`  ... and ${components.length - MAX_COMPONENTS} more`);
+    }
+  }
+
+  // Net connectivity
+  try {
+    const nets = resolveNets(data);
+    if (nets.length > 0) {
+      parts.push("\nNets:");
+      const named = nets.filter((n) => n.name);
+      const shown = named.slice(0, MAX_NETS);
+      for (const net of shown) {
+        const pins = net.pins.map((p) => `${p.symbolRef}:${p.pinName || p.pinNumber}`).join(", ");
+        parts.push(`  ${net.name}: ${pins} (${net.pins.length} pins, ${net.wireUuids.length} wires)`);
+      }
+      const unnamed = nets.filter((n) => !n.name);
+      if (unnamed.length > 0) {
+        parts.push(`  + ${unnamed.length} unnamed nets`);
+      }
+    }
+  } catch {
+    // Net resolution may fail on incomplete schematics
+  }
+
+  // Net classes
+  if (data.net_classes && data.net_classes.length > 0) {
+    parts.push("\nNet Classes:");
+    for (const nc of data.net_classes) {
+      parts.push(`  ${nc.name}: ${nc.nets.join(", ")}`);
+    }
+  }
+
+  // ERC violations
+  if (ercMarkers.length > 0) {
+    parts.push("\nERC Violations:");
+    for (const m of ercMarkers.slice(0, 20)) {
+      parts.push(`  [${m.severity}] ${m.message}`);
+    }
+    if (ercMarkers.length > 20) {
+      parts.push(`  ... and ${ercMarkers.length - 20} more`);
+    }
+  }
+
+  // Truncate to max chars
+  let result = parts.join("\n");
+  if (result.length > MAX_CHARS) {
+    result = result.slice(0, MAX_CHARS) + "\n... (context truncated)";
+  }
+  return result;
+}
+
+/**
+ * Capture the current schematic as a base64 PNG for visual context.
+ * Returns the raw base64 string (no data URL prefix).
+ */
+export function captureSchematicScreenshot(data: SchematicData): string | null {
+  try {
+    const canvas = document.createElement("canvas");
+    // Use a reasonable resolution for Claude vision
+    const width = 1200;
+    const height = 800;
+    canvas.width = width;
+    canvas.height = height;
+    renderSchematicToCanvas(data, canvas, { showGrid: false, colorMode: "color" });
+    const dataUrl = canvas.toDataURL("image/png");
+    // Strip the data URL prefix to get raw base64
+    return dataUrl.replace(/^data:image\/png;base64,/, "");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Estimate token count from text (rough: ~4 chars per token).
+ */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Estimate cost in USD for a given token count and model.
+ */
+export function estimateCost(
+  inputTokens: number,
+  outputTokens: number,
+  model: string,
+): number {
+  if (model.includes("opus")) {
+    return (inputTokens * 15 + outputTokens * 75) / 1_000_000;
+  }
+  // Sonnet pricing
+  return (inputTokens * 3 + outputTokens * 15) / 1_000_000;
+}

--- a/src/lib/signalTemplates.ts
+++ b/src/lib/signalTemplates.ts
@@ -1,0 +1,56 @@
+/**
+ * Circuit template prompts for Signal AI.
+ * When selected, these are sent as user messages with instructions
+ * for Claude to use tool calls to build the circuit.
+ */
+
+export interface CircuitTemplate {
+  name: string;
+  description: string;
+  prompt: string;
+}
+
+export const CIRCUIT_TEMPLATES: CircuitTemplate[] = [
+  {
+    name: "LDO Regulator",
+    description: "Linear voltage regulator with input/output caps",
+    prompt: "Create an LDO voltage regulator circuit. Use the add_component, add_wire, and add_net_label tools to build it. Include:\n- LDO regulator IC (e.g., AMS1117-3.3)\n- Input capacitor (10uF electrolytic)\n- Output capacitor (10uF + 100nF ceramic)\n- Input and output net labels (VIN, 3V3)\n- Ground connections\nPlace components in a clean left-to-right layout starting at x=100, y=100 with ~20mm spacing.",
+  },
+  {
+    name: "Decoupling Caps",
+    description: "Standard bypass capacitor arrangement",
+    prompt: "Add standard decoupling capacitors near the selected component (or at x=150, y=100 if nothing selected). Use add_component to place:\n- 100nF ceramic cap close to the IC\n- 10uF bulk cap nearby\nAdd GND net labels on the bottom pins. Place them vertically with ~5mm spacing.",
+  },
+  {
+    name: "Pull-up Resistors",
+    description: "I2C or GPIO pull-up network",
+    prompt: "Create a pull-up resistor network for I2C. Use add_component and add_net_label tools:\n- Two 4.7k pull-up resistors (R_PU_SDA, R_PU_SCL)\n- Net labels: SDA, SCL, 3V3\nPlace at x=120, y=80. Arrange vertically with the resistors connected to 3V3 on top and signal lines below.",
+  },
+  {
+    name: "Op-Amp Buffer",
+    description: "Unity-gain voltage follower",
+    prompt: "Create an op-amp unity-gain buffer circuit. Use tools to place:\n- Op-amp IC (e.g., LM358)\n- Input and output connections\n- Power supply bypass cap (100nF)\n- VCC and GND net labels\nConnect output to inverting input for unity gain. Place at x=130, y=100.",
+  },
+  {
+    name: "RC Filter",
+    description: "Low-pass RC filter",
+    prompt: "Create a simple RC low-pass filter. Use tools:\n- One resistor (10k)\n- One capacitor (100nF)\n- Input and output net labels\n- GND connection\nCutoff frequency ~160Hz. Place at x=110, y=100 in series configuration.",
+  },
+  {
+    name: "Power Header",
+    description: "Power input connector with protection",
+    prompt: "Create a power input section. Use tools to add:\n- 2-pin header connector for power input\n- Schottky diode for reverse polarity protection\n- Bulk capacitor (100uF)\n- Ceramic capacitor (100nF)\n- VIN and GND net labels\nPlace at x=80, y=100.",
+  },
+];
+
+/**
+ * BOM optimization prompt
+ */
+export const BOM_OPTIMIZE_PROMPT = "Analyze the current schematic's Bill of Materials. Look at all components and suggest:\n\n1. **Consolidation**: Are there similar values that could be standardized? (e.g., using all 10k resistors instead of 9.1k and 10k)\n2. **Missing components**: Are there bypass caps or pull-ups that should be added?\n3. **Value corrections**: Any obviously wrong values for common circuits?\n4. **Package standardization**: Could packages be standardized (e.g., all 0402 or all 0603)?\n\nUse the set_component_value tool to apply any recommended changes. Be conservative — only change values that are clearly improvements.";
+
+/**
+ * Component suggestion prompt
+ */
+export function buildComponentSuggestionPrompt(circuitContext: string): string {
+  return `Based on the current schematic context, suggest 3-5 components that would commonly be needed next. Consider:\n- Standard support components (bypass caps, pull-ups, ESD protection)\n- Missing connections or incomplete circuits\n- Common companion components\n\nFor each suggestion, specify: component type, value, and why it's needed.\n\nCurrent circuit:\n${circuitContext}`;
+}

--- a/src/lib/signalTools.ts
+++ b/src/lib/signalTools.ts
@@ -1,0 +1,112 @@
+import { useSchematicStore } from "@/stores/schematic";
+import { runErc } from "./erc";
+import type { SchPoint } from "@/types";
+
+interface ToolResult {
+  success: boolean;
+  message: string;
+}
+
+/**
+ * Execute a Signal AI tool call against the schematic store.
+ * Returns a result string to send back to Claude as tool_result.
+ */
+export function executeToolCall(
+  name: string,
+  input: Record<string, unknown>,
+): ToolResult {
+  const store = useSchematicStore.getState();
+  const data = store.data;
+  if (!data) return { success: false, message: "No schematic loaded" };
+
+  switch (name) {
+    case "add_component": {
+      const prefix = String(input.reference_prefix || "U");
+      const value = String(input.value || "");
+      const x = Number(input.x || 100);
+      const y = Number(input.y || 100);
+
+      // Find next available reference number
+      const existing = data.symbols
+        .filter((s) => s.reference.startsWith(prefix) && /^\d/.test(s.reference.slice(prefix.length)))
+        .map((s) => parseInt(s.reference.slice(prefix.length), 10))
+        .filter((n) => !isNaN(n));
+      let nextNum = 1;
+      while (existing.includes(nextNum)) nextNum++;
+      const reference = `${prefix}${nextNum}`;
+
+      // Add a minimal symbol (no lib_id — will show as a box)
+      store.pushUndo();
+      const newData = structuredClone(data);
+      newData.symbols.push({
+        uuid: crypto.randomUUID(),
+        lib_id: "",
+        reference,
+        value,
+        footprint: "",
+        position: { x, y },
+        rotation: 0,
+        mirror_x: false,
+        mirror_y: false,
+        unit: 1,
+        is_power: false,
+        ref_text: { position: { x: x + 1, y: y - 2 }, rotation: 0, font_size: 1.27, justify_h: "left", justify_v: "center", hidden: false },
+        val_text: { position: { x: x + 1, y: y + 2 }, rotation: 0, font_size: 1.27, justify_h: "left", justify_v: "center", hidden: false },
+        fields_autoplaced: true,
+        dnp: false,
+        in_bom: true,
+        on_board: true,
+        exclude_from_sim: false,
+        locked: false,
+        fields: {},
+      });
+      useSchematicStore.setState({ data: newData, dirty: true });
+
+      return { success: true, message: `Added ${reference} = ${value} at (${x}, ${y})` };
+    }
+
+    case "add_wire": {
+      const start: SchPoint = { x: Number(input.start_x || 0), y: Number(input.start_y || 0) };
+      const end: SchPoint = { x: Number(input.end_x || 0), y: Number(input.end_y || 0) };
+      store.pushUndo();
+      const newData = structuredClone(data);
+      newData.wires.push({ uuid: crypto.randomUUID(), start, end });
+      useSchematicStore.setState({ data: newData, dirty: true });
+      return { success: true, message: `Added wire from (${start.x}, ${start.y}) to (${end.x}, ${end.y})` };
+    }
+
+    case "set_component_value": {
+      const ref = String(input.reference || "");
+      const newValue = String(input.value || "");
+      const sym = data.symbols.find((s) => s.reference === ref);
+      if (!sym) return { success: false, message: `Component ${ref} not found` };
+      store.updateSymbolProp(sym.uuid, "value", newValue);
+      return { success: true, message: `Set ${ref} value to ${newValue}` };
+    }
+
+    case "add_net_label": {
+      const text = String(input.text || "");
+      const x = Number(input.x || 0);
+      const y = Number(input.y || 0);
+      store.placeNetLabel({ x, y }, text);
+      return { success: true, message: `Added net label "${text}" at (${x}, ${y})` };
+    }
+
+    case "run_erc": {
+      const result = runErc(data);
+      const errors = result.violations.filter((v) => v.severity === "error");
+      const warnings = result.violations.filter((v) => v.severity === "warning");
+      let msg = `ERC: ${errors.length} errors, ${warnings.length} warnings\n`;
+      for (const v of result.violations.slice(0, 15)) {
+        msg += `- [${v.severity}] ${v.message}\n`;
+      }
+      if (result.violations.length > 15) {
+        msg += `... and ${result.violations.length - 15} more\n`;
+      }
+      return { success: true, message: msg };
+    }
+
+    default:
+      return { success: false, message: `Unknown tool: ${name}` };
+  }
+}

--- a/src/panels/SignalPanel.tsx
+++ b/src/panels/SignalPanel.tsx
@@ -1,9 +1,13 @@
 import { useState, useRef, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { Zap, Send, Trash2, Key, AlertCircle, Cpu, FileSearch, Loader2 } from "lucide-react";
+import {
+  Zap, Send, Trash2, Key, AlertCircle, Cpu, FileSearch, Loader2,
+  Download, Camera, ChevronDown, ChevronRight,
+} from "lucide-react";
 import { useSignalStore } from "@/stores/signal";
 import { useSchematicStore } from "@/stores/schematic";
 import { useEditorStore } from "@/stores/editor";
+import { buildRichContext, captureSchematicScreenshot, estimateCost } from "@/lib/signalContext";
 import { cn } from "@/lib/utils";
 import type { SignalMessage } from "@/stores/signal";
 
@@ -11,23 +15,23 @@ function buildContext() {
   const data = useSchematicStore.getState().data;
   const selectedIds = useSchematicStore.getState().selectedIds;
   const ercMarkers = useEditorStore.getState().ercMarkers;
+  const designBrief = useSignalStore.getState().designBrief;
 
   if (!data) {
     return {
       component_count: 0, wire_count: 0, net_count: 0,
-      selected_components: [], erc_errors: 0, erc_warnings: 0,
-      paper_size: "A4", title: "",
+      selected_components: [] as { reference: string; value: string; footprint: string; lib_id: string }[],
+      erc_errors: 0, erc_warnings: 0, paper_size: "A4", title: "",
+      detailed_context: null as string | null,
+      design_brief: designBrief || null,
     };
   }
 
   const selectedComponents = data.symbols
     .filter((s) => selectedIds.has(s.uuid) && !s.is_power)
-    .map((s) => ({
-      reference: s.reference,
-      value: s.value,
-      footprint: s.footprint,
-      lib_id: s.lib_id,
-    }));
+    .map((s) => ({ reference: s.reference, value: s.value, footprint: s.footprint, lib_id: s.lib_id }));
+
+  const detailedContext = buildRichContext(data, selectedIds, ercMarkers);
 
   return {
     component_count: data.symbols.filter((s) => !s.is_power).length,
@@ -38,6 +42,8 @@ function buildContext() {
     erc_warnings: ercMarkers.filter((m) => m.severity === "warning").length,
     paper_size: data.paper_size,
     title: data.title_block?.title || "",
+    detailed_context: detailedContext,
+    design_brief: designBrief || null,
   };
 }
 
@@ -46,24 +52,23 @@ export function SignalPanel() {
   const apiKeySet = useSignalStore((s) => s.apiKeySet);
   const isLoading = useSignalStore((s) => s.isLoading);
   const totalTokens = useSignalStore((s) => s.totalTokens);
+  const sessionCost = useSignalStore((s) => s.sessionCost);
+  const model = useSignalStore((s) => s.model);
+  const designBrief = useSignalStore((s) => s.designBrief);
   const [input, setInput] = useState("");
   const [showKeyInput, setShowKeyInput] = useState(false);
   const [apiKey, setApiKey] = useState("");
+  const [showBrief, setShowBrief] = useState(false);
+  const [includeScreenshot, setIncludeScreenshot] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Check API key on mount
   useEffect(() => {
-    invoke<boolean>("has_api_key").then((has) => {
-      useSignalStore.getState().setApiKeySet(has);
-    });
+    invoke<boolean>("has_api_key").then((has) => useSignalStore.getState().setApiKeySet(has));
   }, []);
 
-  // Auto-scroll to bottom
   useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
+    if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
   }, [messages]);
 
   const saveApiKey = async () => {
@@ -72,48 +77,50 @@ export function SignalPanel() {
       useSignalStore.getState().setApiKeySet(true);
       setShowKeyInput(false);
       setApiKey("");
-    } catch (e) {
-      console.error("Failed to set API key:", e);
-    }
+    } catch (e) { console.error("Failed to set API key:", e); }
   };
 
   const sendMessage = async () => {
     const text = input.trim();
     if (!text || isLoading) return;
-
     setInput("");
     const store = useSignalStore.getState();
 
-    // Add user message
     store.addMessage({ role: "user", content: text });
 
-    // Add loading placeholder
-    const loadingId = crypto.randomUUID();
-    store.addMessage({ role: "assistant", content: "", loading: true, id: loadingId } as SignalMessage);
+    const msgId = crypto.randomUUID();
+    store.addMessage({ role: "assistant", content: "", loading: true, id: msgId } as SignalMessage);
     store.setLoading(true);
+
+    // Start stream listener before sending
+    await store.startStreamListener(msgId);
 
     try {
       const chatMessages = [...store.messages.filter((m) => !m.loading), { role: "user", content: text }]
         .map((m) => ({ role: m.role, content: m.content }));
 
       const context = buildContext();
-      const response = await invoke<{ message: string; usage: { input_tokens: number; output_tokens: number } }>(
-        "signal_chat", { messages: chatMessages, context }
-      );
 
-      store.updateMessage(loadingId, {
-        content: response.message,
-        loading: false,
-        usage: response.usage,
+      // Capture screenshot if enabled
+      let imageBase64: string | null = null;
+      if (includeScreenshot) {
+        const data = useSchematicStore.getState().data;
+        if (data) imageBase64 = captureSchematicScreenshot(data);
+      }
+
+      await invoke("signal_chat_stream", {
+        messageId: msgId,
+        messages: chatMessages,
+        context,
+        model: store.model,
+        imageBase64,
       });
-      store.addTokens(response.usage.input_tokens, response.usage.output_tokens);
     } catch (e) {
-      store.updateMessage(loadingId, {
+      store.updateMessage(msgId, {
         content: `Error: ${e instanceof Error ? e.message : String(e)}`,
         loading: false,
         role: "system",
       });
-    } finally {
       store.setLoading(false);
     }
   };
@@ -121,34 +128,38 @@ export function SignalPanel() {
   const runDesignReview = async () => {
     const store = useSignalStore.getState();
     store.addMessage({ role: "user", content: "Review my schematic design" });
-
-    const loadingId = crypto.randomUUID();
-    store.addMessage({ role: "assistant", content: "", loading: true, id: loadingId } as SignalMessage);
+    const msgId = crypto.randomUUID();
+    store.addMessage({ role: "assistant", content: "", loading: true, id: msgId } as SignalMessage);
     store.setLoading(true);
+    await store.startStreamListener(msgId);
 
     try {
       const context = buildContext();
-      const response = await invoke<{ message: string; usage: { input_tokens: number; output_tokens: number } }>(
-        "signal_review", { context }
-      );
-      store.updateMessage(loadingId, {
-        content: response.message,
-        loading: false,
-        usage: response.usage,
+      const chatMessages = [{ role: "user", content: "Review this schematic design. Check for missing bypass capacitors, incorrect pull-up/pull-down values, power rail issues, and signal integrity concerns. Provide a brief, actionable review." }];
+      await invoke("signal_chat_stream", {
+        messageId: msgId, messages: chatMessages, context,
+        model: store.model, imageBase64: null,
       });
-      store.addTokens(response.usage.input_tokens, response.usage.output_tokens);
     } catch (e) {
-      store.updateMessage(loadingId, {
-        content: `Error: ${e instanceof Error ? e.message : String(e)}`,
-        loading: false,
-        role: "system",
-      });
-    } finally {
+      store.updateMessage(msgId, { content: `Error: ${e}`, loading: false, role: "system" });
       store.setLoading(false);
     }
   };
 
-  // No API key state
+  const exportChat = () => {
+    const lines = messages.map((m) => {
+      const role = m.role === "user" ? "**You**" : m.role === "assistant" ? "**Signal**" : "**Error**";
+      return `### ${role}\n\n${m.content}\n`;
+    });
+    const md = `# Signal AI Chat\n\n_Exported ${new Date().toLocaleString()}_\n\n---\n\n${lines.join("\n---\n\n")}\n\n---\n_Tokens: ${totalTokens} | Cost: $${sessionCost.toFixed(4)}_\n`;
+    const blob = new Blob([md], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url; a.download = "signal-chat.md"; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  // No API key
   if (!apiKeySet && !showKeyInput) {
     return (
       <div className="flex flex-col h-full items-center justify-center gap-4 p-6 text-xs">
@@ -165,60 +176,95 @@ export function SignalPanel() {
     );
   }
 
-  // API key input state
   if (showKeyInput) {
     return (
       <div className="flex flex-col h-full items-center justify-center gap-3 p-6 text-xs">
         <Key size={20} className="text-accent/60" />
         <span className="text-text-secondary font-semibold">Anthropic API Key</span>
-        <input
-          type="password"
-          value={apiKey}
+        <input type="password" value={apiKey}
           onChange={(e) => setApiKey(e.target.value)}
           onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Enter") saveApiKey(); }}
           placeholder="sk-ant-..."
-          className="w-full max-w-[280px] bg-bg-surface border border-border-subtle rounded px-3 py-2 text-[11px] font-mono text-text-primary outline-none focus:border-accent"
-        />
+          className="w-full max-w-[280px] bg-bg-surface border border-border-subtle rounded px-3 py-2 text-[11px] font-mono text-text-primary outline-none focus:border-accent" />
         <div className="flex gap-2">
-          <button onClick={() => setShowKeyInput(false)}
-            className="px-3 py-1.5 rounded text-[11px] bg-bg-hover text-text-muted hover:text-text-secondary transition-colors">
-            Cancel
-          </button>
+          <button onClick={() => setShowKeyInput(false)} className="px-3 py-1.5 rounded text-[11px] bg-bg-hover text-text-muted">Cancel</button>
           <button onClick={saveApiKey} disabled={!apiKey.startsWith("sk-")}
-            className="px-3 py-1.5 rounded text-[11px] bg-accent/20 text-accent hover:bg-accent/30 transition-colors disabled:opacity-40">
-            Save
-          </button>
+            className="px-3 py-1.5 rounded text-[11px] bg-accent/20 text-accent hover:bg-accent/30 disabled:opacity-40">Save</button>
         </div>
         <span className="text-text-muted/30 text-[10px] text-center max-w-[250px]">
-          Key is stored in memory only. It's never saved to disk or sent anywhere except the Anthropic API.
+          Key is stored in memory only. Never saved to disk.
         </span>
       </div>
     );
   }
 
+  const estCost = estimateCost(
+    Math.ceil((input.length + 2000) / 4), // rough input estimate
+    500, // assume ~500 output tokens
+    model
+  );
+
   return (
     <div className="flex flex-col h-full text-xs">
       {/* Toolbar */}
-      <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border-subtle shrink-0">
+      <div className="flex items-center gap-1 px-3 py-1.5 border-b border-border-subtle shrink-0">
         <Zap size={12} className="text-accent" />
         <span className="text-[10px] font-semibold text-accent uppercase tracking-wider">Signal</span>
         <div className="flex-1" />
+
+        {/* Model selector */}
+        <select value={model} onChange={(e) => useSignalStore.getState().setModel(e.target.value)}
+          className="bg-transparent border border-border-subtle rounded px-1.5 py-0.5 text-[9px] text-text-muted outline-none focus:border-accent">
+          <option value="claude-sonnet-4-20250514">Sonnet 4</option>
+          <option value="claude-opus-4-20250514">Opus 4</option>
+        </select>
+
+        <button onClick={() => setIncludeScreenshot(!includeScreenshot)} title={includeScreenshot ? "Screenshot ON" : "Screenshot OFF"}
+          className={cn("p-1 rounded transition-colors", includeScreenshot ? "text-accent bg-accent/10" : "text-text-muted/50 hover:text-text-secondary")}>
+          <Camera size={13} />
+        </button>
         <button onClick={runDesignReview} disabled={isLoading} title="Design Review"
           className="p-1 rounded text-text-muted/50 hover:text-accent hover:bg-accent/10 transition-colors disabled:opacity-30">
           <FileSearch size={13} />
         </button>
-        <button onClick={() => useSignalStore.getState().clearHistory()} title="Clear History"
+        <button onClick={exportChat} title="Export Chat" disabled={messages.length === 0}
+          className="p-1 rounded text-text-muted/50 hover:text-text-secondary transition-colors disabled:opacity-30">
+          <Download size={13} />
+        </button>
+        <button onClick={() => useSignalStore.getState().clearHistory()} title="Clear"
           className="p-1 rounded text-text-muted/50 hover:text-error hover:bg-error/10 transition-colors">
           <Trash2 size={13} />
         </button>
-        <button onClick={() => setShowKeyInput(true)} title="Change API Key"
+        <button onClick={() => setShowKeyInput(true)} title="API Key"
           className="p-1 rounded text-text-muted/50 hover:text-text-secondary transition-colors">
           <Key size={13} />
         </button>
-        {totalTokens > 0 && (
-          <span className="text-[9px] text-text-muted/30 font-mono tabular-nums">
-            {(totalTokens / 1000).toFixed(1)}k
+
+        {/* Cost display */}
+        {sessionCost > 0 && (
+          <span className="text-[9px] text-text-muted/30 font-mono tabular-nums" title={`${totalTokens} tokens`}>
+            ${sessionCost.toFixed(3)}
           </span>
+        )}
+      </div>
+
+      {/* Design Brief (collapsible) */}
+      <div className="border-b border-border-subtle">
+        <button onClick={() => setShowBrief(!showBrief)}
+          className="w-full flex items-center gap-1 px-3 py-1 text-[10px] text-text-muted/50 hover:text-text-muted transition-colors">
+          {showBrief ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
+          Design Brief {designBrief && <span className="text-accent/50">*</span>}
+        </button>
+        {showBrief && (
+          <div className="px-3 pb-2">
+            <textarea
+              value={designBrief}
+              onChange={(e) => useSignalStore.getState().setDesignBrief(e.target.value)}
+              onKeyDown={(e) => e.stopPropagation()}
+              placeholder="Describe your design intent... (e.g., USB-C PD board with STM32, 5V/3A output)"
+              className="w-full h-16 bg-bg-surface border border-border-subtle rounded px-2 py-1.5 text-[10px] text-text-primary placeholder:text-text-muted/30 outline-none focus:border-accent/50 resize-none"
+            />
+          </div>
         )}
       </div>
 
@@ -228,8 +274,8 @@ export function SignalPanel() {
           <div className="flex flex-col items-center justify-center h-full gap-3 text-text-muted/30">
             <Zap size={20} />
             <span className="text-[11px]">Ask Signal about your design</span>
-            <div className="flex flex-wrap gap-1.5 justify-center max-w-[250px]">
-              {["Review my design", "Suggest bypass caps", "Fix ERC errors", "Component alternatives"].map((q) => (
+            <div className="flex flex-wrap gap-1.5 justify-center max-w-[280px]">
+              {["Review my design", "Suggest bypass caps", "Fix ERC errors", "Component alternatives", "Create LDO circuit", "Optimize BOM"].map((q) => (
                 <button key={q} onClick={() => { setInput(q); inputRef.current?.focus(); }}
                   className="px-2 py-1 rounded bg-bg-surface border border-border-subtle text-[10px] text-text-muted hover:text-accent hover:border-accent/30 transition-colors">
                   {q}
@@ -238,33 +284,22 @@ export function SignalPanel() {
             </div>
           </div>
         )}
-
-        {messages.map((msg) => (
-          <MessageBubble key={msg.id} message={msg} />
-        ))}
+        {messages.map((msg) => <MessageBubble key={msg.id} message={msg} />)}
       </div>
 
       {/* Input */}
       <div className="border-t border-border-subtle p-2 shrink-0">
         <div className="flex gap-2">
-          <input
-            ref={inputRef}
-            type="text"
-            value={input}
+          <input ref={inputRef} type="text" value={input}
             onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => {
-              e.stopPropagation();
-              if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); }
-            }}
-            placeholder="Ask Signal about your design..."
+            onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); } }}
+            placeholder="Ask Signal..."
             className="flex-1 bg-bg-surface border border-border-subtle rounded px-3 py-1.5 text-[11px] text-text-primary placeholder:text-text-muted/40 outline-none focus:border-accent/50"
-            disabled={isLoading}
-          />
+            disabled={isLoading} />
           <button onClick={sendMessage} disabled={isLoading || !input.trim()}
-            className={cn(
-              "px-3 py-1.5 rounded text-[11px] transition-colors flex items-center gap-1",
-              isLoading ? "bg-accent/10 text-accent/40" : "bg-accent/20 text-accent hover:bg-accent/30"
-            )}>
+            title={input.trim() ? `~$${estCost.toFixed(4)}` : ""}
+            className={cn("px-3 py-1.5 rounded text-[11px] transition-colors flex items-center gap-1",
+              isLoading ? "bg-accent/10 text-accent/40" : "bg-accent/20 text-accent hover:bg-accent/30")}>
             {isLoading ? <Loader2 size={12} className="animate-spin" /> : <Send size={12} />}
           </button>
         </div>
@@ -277,7 +312,7 @@ function MessageBubble({ message }: { message: SignalMessage }) {
   const isUser = message.role === "user";
   const isSystem = message.role === "system";
 
-  if (message.loading) {
+  if (message.loading && !message.content) {
     return (
       <div className="flex items-center gap-2 text-accent/60">
         <Loader2 size={14} className="animate-spin" />
@@ -290,41 +325,37 @@ function MessageBubble({ message }: { message: SignalMessage }) {
     <div className={cn("flex flex-col gap-1", isUser ? "items-end" : "items-start")}>
       <div className={cn(
         "rounded-lg px-3 py-2 max-w-[90%] text-[11px] leading-relaxed",
-        isUser
-          ? "bg-accent/15 text-text-primary"
-          : isSystem
-            ? "bg-error/10 text-error border border-error/20"
-            : "bg-bg-surface border border-border-subtle text-text-secondary"
+        isUser ? "bg-accent/15 text-text-primary"
+          : isSystem ? "bg-error/10 text-error border border-error/20"
+          : "bg-bg-surface border border-border-subtle text-text-secondary"
       )}>
-        {isSystem && (
-          <div className="flex items-center gap-1 mb-1 text-[10px] text-error/70">
-            <AlertCircle size={10} /> Error
+        {isSystem && <div className="flex items-center gap-1 mb-1 text-[10px] text-error/70"><AlertCircle size={10} /> Error</div>}
+        {!isUser && !isSystem && <div className="flex items-center gap-1 mb-1 text-[10px] text-accent/50"><Cpu size={10} /> Signal</div>}
+        <div className="whitespace-pre-wrap break-words">{renderMarkdown(message.content)}</div>
+        {message.loading && <Loader2 size={10} className="animate-spin text-accent/40 mt-1" />}
+        {message.toolCalls && message.toolCalls.length > 0 && (
+          <div className="mt-2 space-y-1">
+            {message.toolCalls.map((tc) => (
+              <div key={tc.id} className="flex items-center gap-1.5 text-[9px] text-accent/60 bg-accent/5 rounded px-2 py-0.5">
+                <Zap size={8} /> {tc.name}({JSON.stringify(tc.input).slice(0, 60)}...)
+              </div>
+            ))}
           </div>
         )}
-        {!isUser && !isSystem && (
-          <div className="flex items-center gap-1 mb-1 text-[10px] text-accent/50">
-            <Cpu size={10} /> Signal
-          </div>
-        )}
-        <div className="whitespace-pre-wrap break-words">
-          {renderMarkdown(message.content)}
-        </div>
       </div>
       {message.usage && (
         <span className="text-[9px] text-text-muted/20 font-mono px-1">
-          {message.usage.input_tokens + message.usage.output_tokens} tokens
+          {message.usage.input_tokens + message.usage.output_tokens} tok
         </span>
       )}
     </div>
   );
 }
 
-/**
- * Minimal markdown rendering — bold, inline code, code blocks, lists
- */
+// --- Markdown renderer ---
+
 function renderMarkdown(text: string): React.ReactNode {
   if (!text) return null;
-
   const parts: React.ReactNode[] = [];
   const lines = text.split("\n");
   let inCodeBlock = false;
@@ -333,67 +364,36 @@ function renderMarkdown(text: string): React.ReactNode {
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-
     if (line.startsWith("```")) {
       if (inCodeBlock) {
-        parts.push(
-          <pre key={`code-${codeKey++}`} className="bg-bg-primary rounded p-2 my-1 text-[10px] font-mono overflow-x-auto border border-border-subtle">
-            {codeContent}
-          </pre>
-        );
+        parts.push(<pre key={`code-${codeKey++}`} className="bg-bg-primary rounded p-2 my-1 text-[10px] font-mono overflow-x-auto border border-border-subtle">{codeContent}</pre>);
         codeContent = "";
         inCodeBlock = false;
-      } else {
-        inCodeBlock = true;
-      }
+      } else { inCodeBlock = true; }
       continue;
     }
-
-    if (inCodeBlock) {
-      codeContent += (codeContent ? "\n" : "") + line;
-      continue;
-    }
-
-    // Headers
-    if (line.startsWith("### ")) {
-      parts.push(<div key={i} className="font-semibold text-text-primary mt-2 mb-0.5">{line.slice(4)}</div>);
-    } else if (line.startsWith("## ")) {
-      parts.push(<div key={i} className="font-bold text-text-primary mt-2 mb-0.5">{line.slice(3)}</div>);
-    } else if (line.startsWith("# ")) {
-      parts.push(<div key={i} className="font-bold text-text-primary text-xs mt-2 mb-1">{line.slice(2)}</div>);
-    } else if (line.startsWith("- ") || line.startsWith("* ")) {
-      parts.push(<div key={i} className="pl-3">{"\u2022 "}{formatInline(line.slice(2))}</div>);
-    } else if (/^\d+\.\s/.test(line)) {
-      const match = line.match(/^(\d+\.)\s(.*)$/);
-      if (match) parts.push(<div key={i} className="pl-3">{match[1]} {formatInline(match[2])}</div>);
-    } else if (line.trim() === "") {
-      parts.push(<div key={i} className="h-1" />);
-    } else {
-      parts.push(<div key={i}>{formatInline(line)}</div>);
-    }
+    if (inCodeBlock) { codeContent += (codeContent ? "\n" : "") + line; continue; }
+    if (line.startsWith("### ")) { parts.push(<div key={i} className="font-semibold text-text-primary mt-2 mb-0.5">{line.slice(4)}</div>); }
+    else if (line.startsWith("## ")) { parts.push(<div key={i} className="font-bold text-text-primary mt-2 mb-0.5">{line.slice(3)}</div>); }
+    else if (line.startsWith("# ")) { parts.push(<div key={i} className="font-bold text-text-primary text-xs mt-2 mb-1">{line.slice(2)}</div>); }
+    else if (line.startsWith("- ") || line.startsWith("* ")) { parts.push(<div key={i} className="pl-3">{"\u2022 "}{formatInline(line.slice(2))}</div>); }
+    else if (/^\d+\.\s/.test(line)) { const m = line.match(/^(\d+\.)\s(.*)$/); if (m) parts.push(<div key={i} className="pl-3">{m[1]} {formatInline(m[2])}</div>); }
+    else if (line.trim() === "") { parts.push(<div key={i} className="h-1" />); }
+    else { parts.push(<div key={i}>{formatInline(line)}</div>); }
   }
-
   return <>{parts}</>;
 }
 
 function formatInline(text: string): React.ReactNode {
-  // Bold, inline code
   const parts: React.ReactNode[] = [];
   let remaining = text;
   let key = 0;
-
   while (remaining.length > 0) {
-    // Inline code
     const codeMatch = remaining.match(/^(.*?)`([^`]+)`(.*)$/);
     if (codeMatch) {
       if (codeMatch[1]) parts.push(formatBold(codeMatch[1], key++));
-      parts.push(
-        <code key={`ic-${key++}`} className="bg-bg-primary px-1 py-0.5 rounded text-accent font-mono text-[10px]">
-          {codeMatch[2]}
-        </code>
-      );
-      remaining = codeMatch[3];
-      continue;
+      parts.push(<code key={`ic-${key++}`} className="bg-bg-primary px-1 py-0.5 rounded text-accent font-mono text-[10px]">{codeMatch[2]}</code>);
+      remaining = codeMatch[3]; continue;
     }
     parts.push(formatBold(remaining, key++));
     break;
@@ -403,16 +403,13 @@ function formatInline(text: string): React.ReactNode {
 
 function formatBold(text: string, key: number): React.ReactNode {
   const parts: React.ReactNode[] = [];
-  const boldRegex = /\*\*(.+?)\*\*/g;
-  let lastIndex = 0;
-  let match;
-
-  while ((match = boldRegex.exec(text)) !== null) {
-    if (match.index > lastIndex) parts.push(text.slice(lastIndex, match.index));
+  const re = /\*\*(.+?)\*\*/g;
+  let last = 0, match;
+  while ((match = re.exec(text)) !== null) {
+    if (match.index > last) parts.push(text.slice(last, match.index));
     parts.push(<strong key={`b-${key}-${match.index}`}>{match[1]}</strong>);
-    lastIndex = match.index + match[0].length;
+    last = match.index + match[0].length;
   }
-  if (lastIndex < text.length) parts.push(text.slice(lastIndex));
-  if (parts.length === 0) return text;
-  return <>{parts}</>;
+  if (last < text.length) parts.push(text.slice(last));
+  return parts.length === 0 ? text : <>{parts}</>;
 }

--- a/src/stores/signal.ts
+++ b/src/stores/signal.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 export interface SignalMessage {
   id: string;
@@ -8,6 +9,7 @@ export interface SignalMessage {
   timestamp: number;
   usage?: { input_tokens: number; output_tokens: number };
   loading?: boolean;
+  toolCalls?: { id: string; name: string; input: Record<string, unknown> }[];
 }
 
 interface SignalState {
@@ -15,57 +17,134 @@ interface SignalState {
   apiKeySet: boolean;
   isLoading: boolean;
   totalTokens: number;
+  sessionCost: number;
+  model: string;
+  designBrief: string;
 
-  addMessage: (msg: Omit<SignalMessage, "id" | "timestamp">) => void;
+  // Actions
+  addMessage: (msg: Omit<SignalMessage, "id" | "timestamp"> & { id?: string }) => void;
   updateMessage: (id: string, updates: Partial<SignalMessage>) => void;
   removeMessage: (id: string) => void;
   clearHistory: () => void;
   setApiKeySet: (v: boolean) => void;
   setLoading: (v: boolean) => void;
   addTokens: (input: number, output: number) => void;
+  addCost: (input: number, output: number) => void;
+  setModel: (model: string) => void;
+  setDesignBrief: (brief: string) => void;
+
+  // Streaming
+  startStreamListener: (messageId: string) => Promise<void>;
+  _unlisteners: UnlistenFn[];
 }
 
 export const useSignalStore = create<SignalState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       messages: [],
       apiKeySet: false,
       isLoading: false,
       totalTokens: 0,
+      sessionCost: 0,
+      model: "claude-sonnet-4-20250514",
+      designBrief: "",
+      _unlisteners: [],
 
       addMessage: (msg) =>
         set((s) => ({
           messages: [
             ...s.messages,
-            { ...msg, id: crypto.randomUUID(), timestamp: Date.now() },
+            { ...msg, id: msg.id || crypto.randomUUID(), timestamp: Date.now() } as SignalMessage,
           ],
         })),
 
       updateMessage: (id, updates) =>
         set((s) => ({
-          messages: s.messages.map((m) =>
-            m.id === id ? { ...m, ...updates } : m
-          ),
+          messages: s.messages.map((m) => (m.id === id ? { ...m, ...updates } : m)),
         })),
 
       removeMessage: (id) =>
         set((s) => ({ messages: s.messages.filter((m) => m.id !== id) })),
 
-      clearHistory: () => set({ messages: [], totalTokens: 0 }),
+      clearHistory: () => set({ messages: [], totalTokens: 0, sessionCost: 0 }),
 
       setApiKeySet: (v) => set({ apiKeySet: v }),
-
       setLoading: (v) => set({ isLoading: v }),
+      setModel: (model) => set({ model }),
+      setDesignBrief: (brief) => set({ designBrief: brief }),
 
       addTokens: (input, output) =>
         set((s) => ({ totalTokens: s.totalTokens + input + output })),
+
+      addCost: (input, output) => {
+        const model = get().model;
+        const isOpus = model.includes("opus");
+        const cost = isOpus
+          ? (input * 15 + output * 75) / 1_000_000
+          : (input * 3 + output * 15) / 1_000_000;
+        set((s) => ({ sessionCost: s.sessionCost + cost }));
+      },
+
+      startStreamListener: async (messageId) => {
+        const unlisteners: UnlistenFn[] = [];
+
+        // Listen for text deltas
+        const u1 = await listen<{ text: string; message_id: string }>("signal:stream-delta", (event) => {
+          if (event.payload.message_id === messageId) {
+            const store = useSignalStore.getState();
+            const msg = store.messages.find((m) => m.id === messageId);
+            if (msg) {
+              store.updateMessage(messageId, { content: (msg.content || "") + event.payload.text });
+            }
+          }
+        });
+        unlisteners.push(u1);
+
+        // Listen for stream completion
+        const u2 = await listen<{ message_id: string; usage: { input_tokens: number; output_tokens: number }; tool_calls: { id: string; name: string; input: Record<string, unknown> }[]; stop_reason: string }>("signal:stream-done", (event) => {
+          if (event.payload.message_id === messageId) {
+            const store = useSignalStore.getState();
+            store.updateMessage(messageId, {
+              loading: false,
+              usage: event.payload.usage,
+              toolCalls: event.payload.tool_calls.length > 0 ? event.payload.tool_calls : undefined,
+            });
+            store.addTokens(event.payload.usage.input_tokens, event.payload.usage.output_tokens);
+            store.addCost(event.payload.usage.input_tokens, event.payload.usage.output_tokens);
+            store.setLoading(false);
+            // Cleanup listeners
+            for (const u of unlisteners) u();
+          }
+        });
+        unlisteners.push(u2);
+
+        // Listen for errors
+        const u3 = await listen<{ message_id: string; error: string }>("signal:stream-error", (event) => {
+          if (event.payload.message_id === messageId) {
+            const store = useSignalStore.getState();
+            store.updateMessage(messageId, {
+              content: `Error: ${event.payload.error}`,
+              loading: false,
+              role: "system",
+            });
+            store.setLoading(false);
+            for (const u of unlisteners) u();
+          }
+        });
+        unlisteners.push(u3);
+
+        set((s) => ({ _unlisteners: [...s._unlisteners, ...unlisteners] }));
+      },
     }),
     {
       name: "signex-signal",
       partialize: (state) => ({
-        messages: state.messages.filter((m) => !m.loading),
+        messages: state.messages.filter((m) => !m.loading).slice(-100), // Keep last 100 messages
         apiKeySet: state.apiKeySet,
         totalTokens: state.totalTokens,
+        sessionCost: state.sessionCost,
+        model: state.model,
+        designBrief: state.designBrief,
       }),
     }
   )


### PR DESCRIPTION
…text, templates

Streaming:
- signal_chat_stream command with SSE parsing and Tauri event emission
- Frontend stream listener with incremental message updates
- Live token-by-token display in chat panel

Rich context:
- buildRichContext: sends full component list, net connectivity (via resolveNets), ERC violation details, net class assignments — capped at ~2000 tokens
- Design Brief: persistent text field prepended to system prompt

Visual context:
- captureSchematicScreenshot: renders to offscreen canvas, returns base64 PNG
- Multi-content message support in API client (text + image blocks)
- Screenshot toggle button in Signal toolbar

Tool use:
- 5 tool definitions: add_component, add_wire, set_component_value, add_net_label, run_erc
- Tool call parsing from Claude response (streaming and non-streaming)
- signalTools.ts: dispatcher that executes tool calls against schematic store
- Tool call indicators shown inline in chat messages

Model selection:
- Sonnet 4 / Opus 4 dropdown in toolbar
- Model passed to all API commands
- Cost estimation based on model pricing

UX:
- Export chat as markdown (Download button)
- Session cost tracking ($X.XXX display)
- Cost estimation tooltip on Send button
- 6 circuit templates (LDO, Decoupling, Pull-ups, Op-Amp, RC Filter, Power Header)
- BOM optimization prompt
- Component suggestion prompt builder
- Inline suggestion popover (SignalInlineSuggestion component)
- Ctrl+Shift+A opens Signal panel

New files:
- src/lib/signalContext.ts — rich context builder + screenshot capture + cost estimation
- src/lib/signalTools.ts — tool call execution dispatcher
- src/lib/signalTemplates.ts — circuit templates and prompt builders
- src/components/SignalInlineSuggestion.tsx — copilot-style hover suggestions