### PR TITLE
Update docs for theme system and completed phases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Target: schematic capture, PCB layout, 3D viewer, SI simulation, AI copilot (Sig
 - **Parser:** Pure Rust S-expression parser for KiCad format (.kicad_sch, .kicad_sym)
 - **3D:** Three.js (future)
 - **AI:** Claude API via Rust reqwest client — branded "Signal"
-- **State:** Zustand (4 stores: layout, project, editor, schematic)
+- **State:** Zustand (9 stores: layout, project, editor, schematic, pcb, libraryEditor, outputJobs, signal, theme)
 
 ## Project Structure
 ```
@@ -39,7 +39,7 @@ src/                    React frontend
 - `npx tsc --noEmit` — TypeScript check
 
 ## Conventions
-- Dark theme (Catppuccin Mocha-inspired palette)
+- 6 built-in themes (Catppuccin Mocha default, VS Code Dark, GitHub Dark, Altium Dark, Solarized Light, Nord)
 - 13px base font size (dense EDA UI)
 - All panels collapsible, layout persisted to localStorage
 - Altium-compatible keyboard shortcuts (see docs/altium-schematic-reference.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,17 +75,20 @@ npm run tauri dev    # Start dev mode
 
 ## Architecture Overview
 
-| File | Purpose | Lines |
-|------|---------|-------|
-| `src/stores/schematic.ts` | Main state store — all editing operations | ~1300 |
-| `src/canvas/SchematicRenderer.tsx` | Canvas2D rendering + mouse/keyboard handlers | ~1900 |
-| `src/canvas/hitTest.ts` | Hit detection and box selection | ~300 |
-| `src/lib/netResolver.ts` | Net connectivity (union-find) | ~200 |
-| `src/lib/erc.ts` | Electrical rules check (11 checks) | ~250 |
-| `src/lib/ercMatrix.ts` | Pin-to-pin connection matrix (12x12) | ~200 |
-| `src/panels/PropertiesPanel.tsx` | Altium-style properties for all types | ~900 |
-| `src-tauri/src/engine/parser.rs` | KiCad S-expression parser | ~900 |
-| `src-tauri/src/engine/writer.rs` | KiCad S-expression writer | ~300 |
+| File | Purpose |
+|------|---------|
+| `src/stores/schematic.ts` | Main schematic state store — all editing operations |
+| `src/canvas/SchematicRenderer.tsx` | Schematic Canvas2D rendering + mouse/keyboard handlers |
+| `src/canvas/schematicDrawHelpers.ts` | Schematic draw helpers (shapes, symbols, labels) |
+| `src/canvas/PcbRenderer.tsx` | PCB Canvas2D rendering |
+| `src/canvas/hitTest*.ts` | Hit detection (point, area, connectivity, flood fill) |
+| `src/lib/themes.ts` | 6 built-in themes with full canvas color definitions |
+| `src/stores/theme.ts` | Theme state store with persistence |
+| `src/lib/pcbRouter.ts` | PCB interactive routing engine |
+| `src/lib/pcbDrc.ts` | PCB DRC engine (15 check types) |
+| `src-tauri/src/engine/parser.rs` | KiCad schematic S-expression parser |
+| `src-tauri/src/engine/pcb_parser.rs` | KiCad PCB S-expression parser |
+| `src-tauri/src/engine/writer.rs` | KiCad S-expression writer |
 
 ### Key Patterns
 
@@ -121,13 +124,13 @@ Check the [Issues](https://github.com/alplabai/signex/issues) tab for open tasks
 
 | Area | Difficulty | Description |
 |------|-----------|-------------|
-| ERC | Easy | Add more violation types to `src/lib/erc.ts` |
+| Themes | Easy | Add new color themes to `src/lib/themes.ts` |
 | Properties | Easy | Improve property editing for specific object types |
-| Drawing | Medium | Add ellipse, bezier, polygon placement tools |
-| Export | Medium | PDF export, improved netlist format |
-| Panels | Medium | Enhance Filter/List/Navigator panels |
-| PCB | Hard | Start Phase 6 — PCB layout editor |
-| AI | Hard | Start Phase 5 — Claude API integration |
+| Panels | Medium | Enhance Navigator, Inspector, Variants panels |
+| Export | Medium | Improve Gerber/ODB++ output fidelity |
+| 3D | Medium | STEP/VRML model import for PCB 3D viewer |
+| Simulation | Hard | SPICE netlist generation and waveform viewer |
+| Collaboration | Hard | Comment threads, design diff, real-time editing |
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 Signex is an open-source desktop EDA tool built for hardware engineers who want Altium Designer-class UX without the Altium price tag. It reads and writes KiCad files natively, so you can use existing KiCad libraries and schematics while enjoying a modern, fast editing experience.
 
-> **Status:** Alpha. Schematic capture is fully functional with ~85% Altium feature parity. Signal AI copilot is integrated. PCB layout and simulation are next.
+> **Status:** Alpha. Schematic capture and PCB layout are fully functional with Altium-class feature parity. Signal AI copilot and 6 built-in themes are integrated. Simulation is next.
 
 ## Why Signex?
 
@@ -33,6 +33,7 @@ Signex is an open-source desktop EDA tool built for hardware engineers who want 
 - **KiCad file compatibility** (.kicad_sch, .kicad_sym read/write, KiCad 8/9/10)
 - **Native desktop app** via Tauri v2 (Rust backend, React frontend) -- fast startup, low memory
 - **Signal AI copilot** -- Claude-powered design assistant with streaming, tool use, and visual context
+- **6 built-in themes** -- Catppuccin Mocha, VS Code Dark, GitHub Dark, Altium Dark, Solarized Light, Nord
 - **Built by hardware engineers** for hardware engineers
 
 ## Features
@@ -163,6 +164,16 @@ Signex is an open-source desktop EDA tool built for hardware engineers who want 
 </details>
 
 <details>
+<summary><strong>Theme System</strong></summary>
+
+- 6 built-in themes: Catppuccin Mocha, VS Code Dark, GitHub Dark, Altium Dark, Solarized Light, Nord
+- Full canvas theming: background, grid, wire, junction, component body, text colors
+- Fill type support: background fill, outline fill, and no fill for correct symbol rendering
+- Theme persisted across sessions via Zustand store
+- Theme editor panel for customization
+</details>
+
+<details>
 <summary><strong>Panels (Altium-style)</strong></summary>
 
 - **Properties** -- context-aware editing for schematic and PCB objects
@@ -195,8 +206,10 @@ Signex is an open-source desktop EDA tool built for hardware engineers who want 
 | **Phase 4+: Altium Parity** | Done | 40+ features: selection filter, drawing tools, net classes, diff pairs, harnesses, constraints, design variants, parameter manager, multi-channel, BOM formats |
 | **Phase 5: Signal AI** | Done | Claude API streaming, tool use, visual context, circuit templates, design review |
 | **Phase 6: PCB Layout** | Done | KiCad PCB parser, routing (walkaround/push/diff pair), 15-type DRC, copper pour, Gerber/ODB++/STEP export, 3D viewer, cross-probing |
+| **Theme System** | Done | 6 built-in themes, canvas theming, fill type support, theme editor |
 | **Phase 7: Simulation** | Planned | SPICE integration, signal integrity, power analysis |
-| **Phase 8: Ecosystem** | Planned | Plugin system, community libraries, cloud storage |
+| **Phase 8: Collaboration** | Planned | Comment threads, design diff, Git integration, real-time multi-user |
+| **Phase 9: Ecosystem** | Planned | Plugin system, community libraries, cloud storage |
 
 See [docs/feature-roadmap.md](docs/feature-roadmap.md) for the detailed roadmap.
 
@@ -273,7 +286,7 @@ npm run tauri dev
 | Frontend | React 19 + TypeScript + Vite 7 |
 | Styling | Tailwind CSS 4 |
 | Canvas | Canvas2D (schematic + PCB), WebGL2 framework ready, Three.js (3D viewer) |
-| State | Zustand (8 stores: layout, project, editor, schematic, libraryEditor, outputJobs, signal, pcb) |
+| State | Zustand (9 stores: layout, project, editor, schematic, pcb, libraryEditor, outputJobs, signal, theme) |
 | Parser | Pure Rust S-expression parser |
 | AI | Claude API via Rust reqwest (streaming SSE, tool use, vision) |
 
@@ -287,8 +300,8 @@ src/
   canvas/             SchematicRenderer, PcbRenderer, Pcb3DViewer, PcbWebGLRenderer, hitTest
   components/         MenuBar, ToolbarStrip, PcbToolbar, StatusBar, dialogs (18 files)
   panels/             Properties, PcbProperties, Components, Messages, Signal, Filter, List, Navigator, OutputJobs, LayerStack, DRC, Inspector, Variants, Snippets, CrossSection (16 files)
-  stores/             Zustand: layout, project, editor, schematic, pcb, libraryEditor, outputJobs, signal
-  lib/                Schematic (ERC, net resolver, geometry, PDF, BOM) + PCB (router, DRC, ratsnest, copper pour, Gerber, ODB++, STEP, cross-probe) + Signal AI
+  stores/             Zustand: layout, project, editor, schematic, pcb, libraryEditor, outputJobs, signal, theme
+  lib/                Schematic (ERC, net resolver, geometry, PDF, BOM) + PCB (router, DRC, ratsnest, copper pour, Gerber, ODB++, STEP, cross-probe) + Signal AI + themes
   __tests__/          Vitest test suite
 docs/                 Roadmap, master plan, Altium reference
 ```

--- a/docs/feature-roadmap.md
+++ b/docs/feature-roadmap.md
@@ -80,8 +80,6 @@
 
 ---
 
-## Upcoming
-
 ### Phase 5: Signal AI
 - [x] Claude API integration via Rust reqwest with streaming SSE
 - [x] Chat panel with markdown rendering and model selection (Sonnet 4 / Opus 4)
@@ -98,6 +96,15 @@
 - [x] Session cost tracking with per-model pricing
 - [x] Export chat as markdown
 - [x] Ctrl+Shift+A shortcut
+
+---
+
+### Theme System
+- [x] 6 built-in themes: Catppuccin Mocha, VS Code Dark, GitHub Dark, Altium Dark, Solarized Light, Nord
+- [x] Full canvas theming (background, grid, wire, junction, component body, text)
+- [x] Fill type support (background, outline, none) for correct symbol rendering
+- [x] Theme persistence across sessions
+- [x] Theme editor panel for customization
 
 ---
 
@@ -163,8 +170,9 @@
 ### Phase 8: Collaboration
 - [ ] Comment threads on schematic/PCB
 - [ ] Schematic/PCB diff/comparison
-- [ ] Git integration
-- [ ] Real-time multi-user editing
+- [ ] Git integration for version control
+- [ ] Real-time multi-user editing (CRDT)
+- [ ] Design review workflow (comments, approvals)
 
 ### Phase 9: Ecosystem
 - [ ] Plugin system (Rust + WASM)

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -100,42 +100,42 @@ full-featured schematic capture, PCB layout, 3D visualization, and SI simulation
 
 ---
 
-## Phase 2: Core Schematic Editing
+## Phase 2: Core Schematic Editing (DONE)
 
 **Goal:** Reach Altium parity for daily schematic capture work.
 
 ### Wiring & Connectivity
-- [ ] Wire routing modes: 90°, 45°, any angle (Shift+Space to cycle)
-- [ ] Backspace to remove last wire vertex during placement
-- [ ] Rubber-banding (wires stretch when dragging connected components)
-- [ ] Wire segment editing (drag vertex, drag segment)
-- [ ] Bus placement (P,B) with Data[0..7] naming syntax
-- [ ] Bus entry placement
-- [ ] Net label placement (P,L) with auto-increment
-- [ ] Power port placement with style selector (VCC, GND, Arrow, Bar, etc.)
-- [ ] No-connect marker (P,X)
-- [ ] Port placement for multi-sheet connectivity
+- [x] Wire routing modes: 90°, 45°, any angle (Shift+Space to cycle)
+- [x] Backspace to remove last wire vertex during placement
+- [x] Rubber-banding (wires stretch when dragging connected components)
+- [x] Wire segment editing (drag vertex, drag segment)
+- [x] Bus placement (P,B) with Data[0..7] naming syntax
+- [x] Bus entry placement
+- [x] Net label placement (P,L) with auto-increment
+- [x] Power port placement with style selector (VCC, GND, Arrow, Bar, etc.)
+- [x] No-connect marker (P,X)
+- [x] Port placement for multi-sheet connectivity
 
 ### Editing Operations
-- [ ] Copy/Paste (Ctrl+C/V) with paste anchor point
-- [ ] Smart Paste (Shift+Ctrl+V) — arrays, transform types
-- [ ] Ctrl+Arrow nudge selection by grid
-- [ ] In-place text editing (F2 or click-pause-click)
-- [ ] Tab during placement to edit properties before placing
-- [ ] Auto-increment designators (R1, R2, R3...)
-- [ ] Find Similar Objects (Shift+F)
-- [ ] Alignment tools (Shift+Ctrl+L/R/T/B)
-- [ ] Distribute evenly (Shift+Ctrl+H/D)
-- [ ] Bring to front / Send to back
-- [ ] Multi-part component support (unit selector)
-- [ ] Ctrl+Q toggle mm/mil units
+- [x] Copy/Paste (Ctrl+C/V) with paste anchor point
+- [x] Smart Paste (Shift+Ctrl+V) — arrays, transform types
+- [x] Ctrl+Arrow nudge selection by grid
+- [x] In-place text editing (F2 or click-pause-click)
+- [x] Tab during placement to edit properties before placing
+- [x] Auto-increment designators (R1, R2, R3...)
+- [x] Find Similar Objects (Shift+F)
+- [x] Alignment tools (Shift+Ctrl+L/R/T/B)
+- [x] Distribute evenly (Shift+Ctrl+H/D)
+- [x] Bring to front / Send to back
+- [x] Multi-part component support (unit selector)
+- [x] Ctrl+Q toggle mm/mil units
 
 ### Multi-Sheet
-- [ ] Sheet symbol placement
-- [ ] Sheet entry / port connectivity
-- [ ] Ctrl+Double-Click jump between entry/port
-- [ ] Hierarchical net scope modes (Global, Flat, Hierarchical, Strict)
-- [ ] Create sheet from sheet symbol
+- [x] Sheet symbol placement
+- [x] Sheet entry / port connectivity
+- [x] Ctrl+Double-Click jump between entry/port
+- [x] Hierarchical net scope modes (Global, Flat, Hierarchical, Strict)
+- [x] Create sheet from sheet symbol
 
 ---
 
@@ -156,55 +156,55 @@ full-featured schematic capture, PCB layout, 3D visualization, and SI simulation
 - [x] Net with no label warning
 - [x] Unannotated component detection
 - [x] Multiple conflicting net names on same net
-- [ ] No ERC directives to suppress individual violations
-- [ ] AutoFocus: dim unrelated wiring when inspecting violation
+- [x] No ERC directives to suppress individual violations
+- [x] AutoFocus: dim unrelated wiring when inspecting violation
 
 ### Annotation
 - [x] Auto-annotate schematic (processing order: top-to-bottom, left-to-right)
 - [x] Reset designators
 - [x] Reset duplicates only
-- [ ] Per-sheet annotation control
-- [ ] Lock/unlock individual designators
-- [ ] Back-annotation from PCB
+- [x] Per-sheet annotation control
+- [x] Lock/unlock individual designators
+- [x] Back-annotation from PCB
 
 ### Cross-Reference
 - [x] Alt+Click to highlight entire net across all sheets
 - [x] Net color override (F5)
-- [ ] Port cross-references showing sheet/grid location
-- [ ] Component cross-references
+- [x] Port cross-references showing sheet/grid location
+- [x] Component cross-references
 
 ---
 
-## Phase 4: Library & Output
+## Phase 4: Library & Output (DONE)
 
 **Goal:** Full library management and professional output generation.
 
 ### Library Management
-- [ ] Library manager panel
+- [x] Library manager panel
 - [x] Create/edit schematic symbols (.snxsym)
-- [ ] Footprint assignment and management
-- [ ] Library search with parametric filtering
-- [ ] Component comparison (side-by-side diff)
+- [x] Footprint assignment and management
+- [x] Library search with parametric filtering
+- [x] Component comparison (side-by-side diff)
 - [ ] Part Choices with supplier data integration
 
 ### Drawing Objects
-- [ ] Text string / Text frame / Note
-- [ ] Line, Arc, Bezier, Rectangle, Polygon
-- [ ] Image placement
+- [x] Text string / Text frame / Note
+- [x] Line, Arc, Bezier, Rectangle, Polygon
+- [x] Image placement
 - [ ] Dimension annotations
 
 ### Output Generation
-- [ ] BOM generation (configurable columns, grouping)
-- [ ] Netlist export (KiCad, Altium, generic)
-- [ ] PDF schematic export
-- [ ] Print support with page setup
+- [x] BOM generation (configurable columns, grouping)
+- [x] Netlist export (KiCad S-expression, generic XML)
+- [x] PDF schematic export (single/multi-sheet, DPI, color/mono)
+- [x] Print support with page setup
 - [x] Output Jobs configuration
 
 ### Properties Panel Enhancements
-- [ ] Batch editing of multiple selected objects
-- [ ] Document properties when nothing selected (grid, page, template)
-- [ ] Full parameter editing
-- [ ] Model assignment (footprint, simulation)
+- [x] Batch editing of multiple selected objects
+- [x] Document properties when nothing selected (grid, page, template)
+- [x] Full parameter editing
+- [x] Model assignment (footprint, simulation)
 
 ---
 
@@ -292,27 +292,30 @@ full-featured schematic capture, PCB layout, 3D visualization, and SI simulation
 
 ---
 
-## Phase 8: Signal (AI Integration)
+## Phase 8: Signal AI (DONE)
 
 **Goal:** AI-powered design assistance that understands electronics.
 
 ### Signal Chat
-- [ ] Claude API integration via Rust reqwest
-- [ ] Chat panel with markdown rendering
-- [ ] Context-aware: Signal sees current schematic, selection, ERC results
+- [x] Claude API integration via Rust reqwest with streaming SSE
+- [x] Chat panel with markdown rendering and model selection (Sonnet 4 / Opus 4)
+- [x] Context-aware: Signal sees current schematic, selection, ERC results
+- [x] Visual context: schematic screenshot sent to Claude vision
 
 ### Signal Tools
-- [ ] Component suggestion based on circuit context
-- [ ] ERC fix suggestions with one-click apply
+- [x] Component suggestion based on circuit context
+- [x] ERC fix suggestions with one-click apply
 - [ ] Auto-routing assistance
-- [ ] Design review analysis (best practices, common mistakes)
+- [x] Design review analysis (best practices, common mistakes)
 - [ ] Datasheet Q&A (parse PDF datasheets, answer pin questions)
-- [ ] BOM optimization (suggest alternatives, check availability)
+- [x] BOM optimization (suggest alternatives, check availability)
 
 ### Signal Automation
-- [ ] Natural language to schematic operations ("add a 10k pullup on SDA")
-- [ ] Circuit template generation ("create an LDO circuit for 3.3V 500mA")
-- [ ] Design intent documentation (auto-generate design notes)
+- [x] Natural language to schematic operations (tool use: add_component, add_wire, set_value, add_label, run_erc)
+- [x] Circuit template generation (6 templates: LDO, Decoupling, Pull-ups, Op-Amp, RC Filter, Power Header)
+- [x] Design intent documentation (Design Brief feature)
+- [x] Session cost tracking with per-model pricing
+- [x] Export chat as markdown
 
 ---
 


### PR DESCRIPTION
## Summary
- README: Updated status line (PCB done, not next), added theme system feature section, added collaboration phase to roadmap, fixed store count to 9
- CLAUDE.md: Updated store count, added theme names
- CONTRIBUTING.md: Updated "What to Work On" table (removed done phases, added current areas), updated architecture table with PCB and theme files
- docs/feature-roadmap.md: Added theme system section, removed stale "Upcoming" header from completed phases, added collaboration phase details
- docs/master-plan.md: Checked off all completed items in Phase 2/3/4, updated Signal AI phase with actual features delivered