### PR TITLE
Panel improvements: cross-probe, sorting, search, compare, library management

### DIFF
--- a/src/canvas/SchematicRenderer.tsx
+++ b/src/canvas/SchematicRenderer.tsx
@@ -1697,6 +1697,21 @@ export function SchematicRenderer() {
     return () => cancelAnimationFrame(animRef.current);
   }, [render]);
 
+  // Cross-probe zoom: when a panel requests zoom-to-object
+  const zoomToRequest = useSchematicStore((s) => s.zoomToRequest);
+  useEffect(() => {
+    if (!zoomToRequest || !containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const zoom = zoomToRequest.zoom ?? 6;
+    camRef.current = {
+      zoom,
+      x: rect.width / 2 - zoomToRequest.x * zoom,
+      y: rect.height / 2 - zoomToRequest.y * zoom,
+    };
+    useSchematicStore.getState().clearZoomRequest();
+    render();
+  }, [zoomToRequest, render]);
+
   // ResizeObserver — mount once, call latest render via ref to avoid recreation
   const renderRef = useRef(render);
   renderRef.current = render;

--- a/src/lib/crossProbe.ts
+++ b/src/lib/crossProbe.ts
@@ -12,6 +12,7 @@
 import { useSchematicStore } from "@/stores/schematic";
 import { usePcbStore } from "@/stores/pcb";
 import { useEditorStore } from "@/stores/editor";
+import { getObjectBounds, rectCenter } from "@/lib/objectBounds";
 
 export type CrossProbeDirection = "sch-to-pcb" | "pcb-to-sch";
 
@@ -156,4 +157,35 @@ export function toggleCrossSelect(): boolean {
 
 export function isCrossSelectEnabled(): boolean {
   return crossSelectEnabled;
+}
+
+/** Zoom the schematic canvas to center on a specific object. */
+export function zoomToObject(uuid: string) {
+  const store = useSchematicStore.getState();
+  if (!store.data) return;
+  const bounds = getObjectBounds(uuid, store.data);
+  if (!bounds) return;
+  const center = rectCenter(bounds);
+  const extent = Math.max(bounds.width, bounds.height, 20);
+  store.requestZoomTo({ x: center.x, y: center.y, zoom: 800 / extent });
+}
+
+/** Zoom to fit multiple objects. */
+export function zoomToObjects(uuids: string[]) {
+  const store = useSchematicStore.getState();
+  if (!store.data || uuids.length === 0) return;
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (const uuid of uuids) {
+    const b = getObjectBounds(uuid, store.data);
+    if (!b) continue;
+    minX = Math.min(minX, b.x);
+    minY = Math.min(minY, b.y);
+    maxX = Math.max(maxX, b.x + b.width);
+    maxY = Math.max(maxY, b.y + b.height);
+  }
+  if (minX === Infinity) return;
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+  const extent = Math.max(maxX - minX, maxY - minY, 20);
+  store.requestZoomTo({ x: cx, y: cy, zoom: 800 / extent });
 }

--- a/src/lib/objectBounds.ts
+++ b/src/lib/objectBounds.ts
@@ -1,0 +1,75 @@
+import type { SchematicData } from "@/types";
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Return bounding rect for a schematic object by UUID */
+export function getObjectBounds(uuid: string, data: SchematicData): Rect | null {
+  const sym = data.symbols.find(s => s.uuid === uuid);
+  if (sym) {
+    const w = sym.is_power ? 5 : 20;
+    const h = sym.is_power ? 10 : 15;
+    return { x: sym.position.x - w / 2, y: sym.position.y - h / 2, width: w, height: h };
+  }
+
+  const wire = data.wires.find(w => w.uuid === uuid);
+  if (wire) {
+    const minX = Math.min(wire.start.x, wire.end.x);
+    const minY = Math.min(wire.start.y, wire.end.y);
+    return { x: minX, y: minY, width: Math.abs(wire.end.x - wire.start.x) || 2, height: Math.abs(wire.end.y - wire.start.y) || 2 };
+  }
+
+  const label = data.labels.find(l => l.uuid === uuid);
+  if (label) {
+    const w = label.text.length * 1.5 + 4;
+    return { x: label.position.x - 1, y: label.position.y - 2, width: w, height: 4 };
+  }
+
+  const junction = data.junctions.find(j => j.uuid === uuid);
+  if (junction) return { x: junction.position.x - 1, y: junction.position.y - 1, width: 2, height: 2 };
+
+  const nc = data.no_connects.find(n => n.uuid === uuid);
+  if (nc) return { x: nc.position.x - 1, y: nc.position.y - 1, width: 2, height: 2 };
+
+  const bus = data.buses.find(b => b.uuid === uuid);
+  if (bus) {
+    const minX = Math.min(bus.start.x, bus.end.x);
+    const minY = Math.min(bus.start.y, bus.end.y);
+    return { x: minX, y: minY, width: Math.abs(bus.end.x - bus.start.x) || 2, height: Math.abs(bus.end.y - bus.start.y) || 2 };
+  }
+
+  const be = data.bus_entries.find(b => b.uuid === uuid);
+  if (be) return { x: be.position.x - 1, y: be.position.y - 1, width: 4, height: 4 };
+
+  const tn = data.text_notes.find(t => t.uuid === uuid);
+  if (tn) {
+    const w = (tn.text?.length ?? 5) * 1.5 + 4;
+    return { x: tn.position.x, y: tn.position.y - 2, width: w, height: 4 };
+  }
+
+  const cs = data.child_sheets.find(c => c.uuid === uuid);
+  if (cs) return { x: cs.position.x, y: cs.position.y, width: cs.size?.[0] ?? 30, height: cs.size?.[1] ?? 20 };
+
+  const rect = data.rectangles.find(r => r.uuid === uuid);
+  if (rect) {
+    const minX = Math.min(rect.start.x, rect.end.x);
+    const minY = Math.min(rect.start.y, rect.end.y);
+    return { x: minX, y: minY, width: Math.abs(rect.end.x - rect.start.x) || 2, height: Math.abs(rect.end.y - rect.start.y) || 2 };
+  }
+
+  const drawing = data.drawings.find(d => d.uuid === uuid);
+  if (drawing) {
+    const pos = (drawing as any).position || (drawing as any).start || (drawing as any).center || { x: 0, y: 0 };
+    return { x: pos.x - 5, y: pos.y - 5, width: 10, height: 10 };
+  }
+
+  return null;
+}
+
+export function rectCenter(r: Rect): { x: number; y: number } {
+  return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+}

--- a/src/lib/panelRegistry.ts
+++ b/src/lib/panelRegistry.ts
@@ -14,9 +14,10 @@ import { LayerStackPanel } from "@/panels/LayerStackPanel";
 import { SnippetsPanel } from "@/panels/SnippetsPanel";
 import { VariantPanel } from "@/panels/VariantPanel";
 import { BoardCrossSectionPanel } from "@/panels/BoardCrossSectionPanel";
+import { LibraryPanel } from "@/panels/LibraryPanel";
 
 export type PanelId =
-  | "projects" | "components" | "navigator"
+  | "projects" | "components" | "navigator" | "libraryMgmt"
   | "properties" | "filter" | "list"
   | "messages" | "output-jobs" | "signal"
   | "inspector" | "drc" | "layerStack" | "snippets" | "variants" | "boardCrossSection";
@@ -35,6 +36,7 @@ export const PANEL_DEFS: PanelDef[] = [
   { id: "projects", title: "Projects", defaultDock: "left", context: "both" },
   { id: "components", title: "Components", defaultDock: "left", context: "both" },
   { id: "navigator", title: "Navigator", defaultDock: "left", context: "both" },
+  { id: "libraryMgmt", title: "Libraries", defaultDock: "left", context: "both" },
   { id: "properties", title: "Properties", defaultDock: "right", context: "both" },
   { id: "messages", title: "Messages", defaultDock: "bottom", context: "both" },
   { id: "signal", title: "Signal", defaultDock: "bottom", context: "both" },
@@ -62,6 +64,7 @@ export const PANEL_COMPONENTS: Record<PanelId, React.FC> = {
   projects: ProjectPanel,
   components: ComponentPanel,
   navigator: NavigatorPanel,
+  libraryMgmt: LibraryPanel,
   properties: PropertiesPanel,
   filter: FilterPanel,
   list: ListPanel,

--- a/src/panels/InspectorPanel.tsx
+++ b/src/panels/InspectorPanel.tsx
@@ -1,9 +1,9 @@
+import { useState, useCallback } from "react";
 import { useSchematicStore } from "@/stores/schematic";
+import { zoomToObject } from "@/lib/crossProbe";
+import { Copy, Check, Crosshair } from "lucide-react";
+import type { SchSymbol } from "@/types";
 
-/**
- * Inspector Panel — detailed object inspection (Altium-style).
- * Shows all properties of the selected object in a read-only table format.
- */
 export function InspectorPanel() {
   const data = useSchematicStore((s) => s.data);
   const selectedIds = useSchematicStore((s) => s.selectedIds);
@@ -11,14 +11,21 @@ export function InspectorPanel() {
   if (!data) return <div className="p-4 text-xs text-text-muted/50">No schematic loaded</div>;
   if (selectedIds.size === 0) return <div className="p-4 text-xs text-text-muted/50">Select an object to inspect</div>;
 
-  const uuid = [...selectedIds][0];
+  const uuids = [...selectedIds];
 
-  // Find object
+  // Compare mode for 2+ objects
+  if (uuids.length >= 2 && uuids.length <= 4) {
+    const objects = uuids.map(uuid => resolveObject(uuid, data)).filter(Boolean) as ResolvedObject[];
+    if (objects.length >= 2) return <CompareTable objects={objects} />;
+  }
+
+  const uuid = uuids[0];
+
   const sym = data.symbols.find((s) => s.uuid === uuid);
   if (sym) return <SymbolInspector sym={sym} />;
 
   const wire = data.wires.find((w) => w.uuid === uuid);
-  if (wire) return <ObjectTable title="Wire" fields={{
+  if (wire) return <ObjectTable title="Wire" uuid={wire.uuid} fields={{
     UUID: wire.uuid,
     "Start X": wire.start.x.toFixed(3),
     "Start Y": wire.start.y.toFixed(3),
@@ -28,7 +35,7 @@ export function InspectorPanel() {
   }} />;
 
   const label = data.labels.find((l) => l.uuid === uuid);
-  if (label) return <ObjectTable title={`Label: ${label.text}`} fields={{
+  if (label) return <ObjectTable title={`Label: ${label.text}`} uuid={label.uuid} fields={{
     UUID: label.uuid,
     Text: label.text,
     Type: label.label_type,
@@ -41,14 +48,14 @@ export function InspectorPanel() {
   }} />;
 
   const junction = data.junctions.find((j) => j.uuid === uuid);
-  if (junction) return <ObjectTable title="Junction" fields={{
+  if (junction) return <ObjectTable title="Junction" uuid={junction.uuid} fields={{
     UUID: junction.uuid,
     X: junction.position.x.toFixed(3),
     Y: junction.position.y.toFixed(3),
   }} />;
 
   const nc = data.no_connects.find((n) => n.uuid === uuid);
-  if (nc) return <ObjectTable title="No Connect" fields={{
+  if (nc) return <ObjectTable title="No Connect" uuid={nc.uuid} fields={{
     UUID: nc.uuid,
     X: nc.position.x.toFixed(3),
     Y: nc.position.y.toFixed(3),
@@ -57,7 +64,77 @@ export function InspectorPanel() {
   return <div className="p-4 text-xs text-text-muted/50">Unknown object type</div>;
 }
 
-function SymbolInspector({ sym }: { sym: import("@/types").SchSymbol }) {
+interface ResolvedObject {
+  uuid: string;
+  type: string;
+  name: string;
+  fields: Record<string, string>;
+}
+
+function resolveObject(uuid: string, data: import("@/types").SchematicData): ResolvedObject | null {
+  const sym = data.symbols.find(s => s.uuid === uuid);
+  if (sym) return {
+    uuid, type: "Component", name: sym.reference,
+    fields: { Reference: sym.reference, Value: sym.value, Footprint: sym.footprint || "--", X: sym.position.x.toFixed(3), Y: sym.position.y.toFixed(3), Rotation: `${sym.rotation}\u00b0` },
+  };
+
+  const label = data.labels.find(l => l.uuid === uuid);
+  if (label) return {
+    uuid, type: "Label", name: label.text,
+    fields: { Text: label.text, Type: label.label_type, X: label.position.x.toFixed(3), Y: label.position.y.toFixed(3), Rotation: `${label.rotation}\u00b0` },
+  };
+
+  const wire = data.wires.find(w => w.uuid === uuid);
+  if (wire) return {
+    uuid, type: "Wire", name: "Wire",
+    fields: { "Start X": wire.start.x.toFixed(3), "Start Y": wire.start.y.toFixed(3), "End X": wire.end.x.toFixed(3), "End Y": wire.end.y.toFixed(3) },
+  };
+
+  return null;
+}
+
+function CompareTable({ objects }: { objects: ResolvedObject[] }) {
+  const allKeys = new Set<string>();
+  for (const obj of objects) for (const k of Object.keys(obj.fields)) allKeys.add(k);
+
+  return (
+    <div className="text-xs">
+      <div className="px-3 py-2 border-b border-border-subtle">
+        <span className="text-[11px] font-semibold text-text-secondary">Compare ({objects.length} objects)</span>
+      </div>
+      <div className="overflow-y-auto">
+        {/* Header row */}
+        <div className="flex items-center px-3 py-0.5 border-b border-border-subtle bg-bg-secondary/40 text-[9px] font-semibold text-text-muted/60">
+          <span className="w-20 shrink-0">Property</span>
+          {objects.map((obj, i) => (
+            <span key={i} className="flex-1 truncate font-mono">{obj.name}</span>
+          ))}
+        </div>
+        {/* Type row */}
+        <div className="flex items-center px-3 py-0.5 border-b border-border-subtle/20">
+          <span className="w-20 shrink-0 text-[10px] text-text-muted/60">Type</span>
+          {objects.map((obj, i) => (
+            <span key={i} className="flex-1 text-[10px] font-mono text-text-primary">{obj.type}</span>
+          ))}
+        </div>
+        {[...allKeys].map(key => {
+          const values = objects.map(o => o.fields[key] ?? "--");
+          const allSame = values.every(v => v === values[0]);
+          return (
+            <div key={key} className="flex items-center px-3 py-0.5 border-b border-border-subtle/20 hover:bg-bg-hover/30">
+              <span className="w-20 shrink-0 text-[10px] text-text-muted/60">{key}</span>
+              {values.map((val, i) => (
+                <span key={i} className={`flex-1 text-[10px] font-mono truncate ${allSame ? "text-text-primary" : "text-warning"}`}>{val}</span>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function SymbolInspector({ sym }: { sym: SchSymbol }) {
   const fields: Record<string, string> = {
     UUID: sym.uuid,
     Reference: sym.reference,
@@ -74,29 +151,52 @@ function SymbolInspector({ sym }: { sym: import("@/types").SchSymbol }) {
     DNP: sym.dnp ? "Yes" : "No",
     "In BOM": sym.in_bom ? "Yes" : "No",
     "On Board": sym.on_board ? "Yes" : "No",
-    "Exclude Sim": sym.exclude_from_sim ? "Yes" : "No",
     Locked: sym.locked ? "Yes" : "No",
   };
 
-  // Add custom fields
   for (const [k, v] of Object.entries(sym.fields)) {
     fields[`Field: ${k}`] = v;
   }
 
-  return <ObjectTable title={`Component: ${sym.reference}`} fields={fields} />;
+  return <ObjectTable title={`Component: ${sym.reference}`} uuid={sym.uuid} fields={fields} />;
 }
 
-function ObjectTable({ title, fields }: { title: string; fields: Record<string, string> }) {
+function ObjectTable({ title, uuid, fields }: { title: string; uuid: string; fields: Record<string, string> }) {
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const copyValue = useCallback((key: string, value: string) => {
+    navigator.clipboard.writeText(value);
+    setCopied(key);
+    setTimeout(() => setCopied(null), 1000);
+  }, []);
+
   return (
     <div className="text-xs">
-      <div className="px-3 py-2 border-b border-border-subtle">
-        <span className="text-[11px] font-semibold text-text-secondary">{title}</span>
+      <div className="px-3 py-2 border-b border-border-subtle flex items-center gap-2">
+        <span className="text-[11px] font-semibold text-text-secondary flex-1">{title}</span>
+        <button
+          onClick={() => zoomToObject(uuid)}
+          className="p-0.5 rounded hover:bg-bg-hover text-text-muted/50 hover:text-accent"
+          title="Zoom to object"
+        >
+          <Crosshair size={12} />
+        </button>
       </div>
       <div className="overflow-y-auto">
         {Object.entries(fields).map(([key, value]) => (
-          <div key={key} className="flex items-center px-3 py-0.5 border-b border-border-subtle/20 hover:bg-bg-hover/30">
+          <div
+            key={key}
+            className="flex items-center px-3 py-0.5 border-b border-border-subtle/20 hover:bg-bg-hover/30 group cursor-pointer"
+            onClick={() => copyValue(key, value)}
+          >
             <span className="w-24 shrink-0 text-[10px] text-text-muted/60">{key}</span>
             <span className="flex-1 text-[10px] font-mono text-text-primary truncate select-all">{value}</span>
+            <span className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0 ml-1">
+              {copied === key
+                ? <Check size={10} className="text-success" />
+                : <Copy size={10} className="text-text-muted/40" />
+              }
+            </span>
           </div>
         ))}
       </div>

--- a/src/panels/LibraryPanel.tsx
+++ b/src/panels/LibraryPanel.tsx
@@ -1,0 +1,146 @@
+import { useState, useEffect, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Library, RefreshCw, ToggleLeft, ToggleRight, Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface LibInfo {
+  name: string;
+  path: string;
+  symbolCount: number | null;
+}
+
+const DISABLED_KEY = "signex-disabled-libs";
+
+function getDisabledLibs(): Set<string> {
+  try {
+    return new Set(JSON.parse(localStorage.getItem(DISABLED_KEY) || "[]"));
+  } catch {
+    return new Set();
+  }
+}
+
+function setDisabledLibs(s: Set<string>) {
+  localStorage.setItem(DISABLED_KEY, JSON.stringify([...s]));
+}
+
+export function LibraryPanel() {
+  const [libs, setLibs] = useState<LibInfo[]>([]);
+  const [disabled, setDisabled] = useState<Set<string>>(getDisabledLibs);
+  const [loading, setLoading] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const loadLibraries = useCallback(async () => {
+    setLoading(true);
+    try {
+      const names: string[] = await invoke("list_libraries");
+      const infos: LibInfo[] = names.map(name => ({ name, path: "", symbolCount: null }));
+      setLibs(infos);
+
+      // Fetch symbol counts in background
+      for (const info of infos) {
+        try {
+          const symbols: any[] = await invoke("list_library_symbols", { libraryName: info.name });
+          setLibs(prev => prev.map(l => l.name === info.name ? { ...l, symbolCount: symbols.length } : l));
+        } catch { /* library might fail to parse */ }
+      }
+    } catch {
+      setLibs([]);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { loadLibraries(); }, [loadLibraries]);
+
+  const toggleLib = useCallback((name: string) => {
+    setDisabled(prev => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      setDisabledLibs(next);
+      return next;
+    });
+  }, []);
+
+  const q = search.toLowerCase();
+  const filtered = q ? libs.filter(l => l.name.toLowerCase().includes(q)) : libs;
+  const enabledCount = libs.filter(l => !disabled.has(l.name)).length;
+  const totalSymbols = libs.reduce((sum, l) => sum + (l.symbolCount ?? 0), 0);
+
+  return (
+    <div className="text-xs flex flex-col h-full select-none">
+      {/* Header */}
+      <div className="px-2 py-1.5 border-b border-border-subtle bg-bg-surface/80 shrink-0 flex items-center gap-2">
+        <Library size={12} className="text-accent shrink-0" />
+        <span className="text-[11px] font-semibold text-text-secondary">Libraries</span>
+        <span className="ml-auto text-[10px] text-text-muted/50">{enabledCount}/{libs.length}</span>
+        <button
+          onClick={loadLibraries}
+          className={cn("p-0.5 rounded hover:bg-bg-hover text-text-muted/50 hover:text-accent", loading && "animate-spin")}
+          title="Refresh"
+        >
+          <RefreshCw size={11} />
+        </button>
+      </div>
+
+      {/* Search */}
+      <div className="px-2 py-1 border-b border-border-subtle/50 flex items-center gap-1.5">
+        <Search size={10} className="text-text-muted/40 shrink-0" />
+        <input
+          type="text"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Filter libraries..."
+          className="flex-1 bg-transparent text-[10px] text-text-primary placeholder:text-text-muted/30 outline-none"
+        />
+      </div>
+
+      {/* Library list */}
+      <div className="flex-1 overflow-y-auto">
+        {loading && libs.length === 0 ? (
+          <div className="p-4 text-[10px] text-text-muted/40 text-center">Loading libraries...</div>
+        ) : filtered.length === 0 ? (
+          <div className="p-4 text-[10px] text-text-muted/40 text-center">
+            {libs.length === 0 ? "No libraries found" : "No matches"}
+          </div>
+        ) : (
+          filtered.map(lib => {
+            const isDisabled = disabled.has(lib.name);
+            return (
+              <div
+                key={lib.name}
+                className={cn(
+                  "flex items-center gap-2 px-2 py-1 border-b border-border-subtle/20 hover:bg-bg-hover/50 transition-colors",
+                  isDisabled && "opacity-40",
+                )}
+              >
+                <button
+                  onClick={() => toggleLib(lib.name)}
+                  className="shrink-0 text-text-muted/60 hover:text-accent"
+                  title={isDisabled ? "Enable" : "Disable"}
+                >
+                  {isDisabled
+                    ? <ToggleLeft size={14} className="text-text-muted/40" />
+                    : <ToggleRight size={14} className="text-accent" />
+                  }
+                </button>
+                <div className="flex-1 min-w-0">
+                  <div className="text-[10px] text-text-primary truncate">{lib.name}</div>
+                </div>
+                <span className="text-[9px] text-text-muted/50 tabular-nums shrink-0">
+                  {lib.symbolCount !== null ? `${lib.symbolCount} sym` : "\u2026"}
+                </span>
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {/* Stats footer */}
+      <div className="px-3 py-1 border-t border-border-subtle text-[10px] text-text-muted/50 shrink-0 flex gap-3">
+        <span>{libs.length} libraries</span>
+        <span>{totalSymbols} symbols</span>
+        <span>{enabledCount} enabled</span>
+      </div>
+    </div>
+  );
+}

--- a/src/panels/ListPanel.tsx
+++ b/src/panels/ListPanel.tsx
@@ -1,8 +1,8 @@
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useState } from "react";
 import { useSchematicStore } from "@/stores/schematic";
 import { useEditorStore } from "@/stores/editor";
+import { zoomToObject } from "@/lib/crossProbe";
 import { cn } from "@/lib/utils";
-import type { SchPoint } from "@/types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -16,42 +16,39 @@ function mmToDisplay(mm: number, unit: "mm" | "mil" | "inch"): string {
 
 function rotationLabel(deg: number): string {
   const n = ((deg % 360) + 360) % 360;
-  return `${n} Degrees`;
+  return `${n}\u00b0`;
 }
 
-// Unified row shape for every object kind
 interface ListRow {
   uuid: string;
   kind: string;
+  name: string;
   x: number;
   y: number;
   orientation: number;
-  color: string; // hex color string
+  color: string;
 }
 
 const KIND_COLORS: Record<string, string> = {
-  Component:     "#89b4fa", // blue
-  "Power Port":  "#f38ba8", // red
-  Wire:          "#a6e3a1", // green
-  Junction:      "#f9e2af", // yellow
-  "Net Label":   "#cba6f7", // mauve
-  "Global Label":"#94e2d5", // teal
-  "Hier Label":  "#fab387", // peach
-  Bus:           "#74c7ec", // sapphire
+  Component:     "#89b4fa",
+  "Power Port":  "#f38ba8",
+  Wire:          "#a6e3a1",
+  Junction:      "#f9e2af",
+  "Net Label":   "#cba6f7",
+  "Global Label":"#94e2d5",
+  "Hier Label":  "#fab387",
+  Bus:           "#74c7ec",
   "Bus Entry":   "#74c7ec",
-  "No Connect":  "#9399b2", // overlay1
-  "Text Note":   "#bac2de", // subtext1
-  "Sheet":       "#f5c2e7", // pink
+  "No Connect":  "#9399b2",
+  "Text Note":   "#bac2de",
+  "Sheet":       "#f5c2e7",
   Rectangle:     "#9399b2",
   Drawing:       "#9399b2",
 };
 
-function positionOf(obj: { position?: SchPoint; start?: SchPoint; center?: SchPoint }): SchPoint {
-  if (obj.position) return obj.position;
-  if ((obj as any).start) return (obj as any).start;
-  if ((obj as any).center) return (obj as any).center;
-  return { x: 0, y: 0 };
-}
+const ALL_KINDS = Object.keys(KIND_COLORS);
+
+type SortKey = "kind" | "name" | "x" | "y" | "orientation";
 
 // ---------------------------------------------------------------------------
 // Component
@@ -62,196 +59,122 @@ export function ListPanel() {
   const selectedIds = useSchematicStore((s) => s.selectedIds);
   const units = useEditorStore((s) => s.statusBar.units);
 
-  // Build a flat list of all objects
+  const [kindFilter, setKindFilter] = useState("All");
+  const [sortCol, setSortCol] = useState<SortKey | null>(null);
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
+
+  // Build flat list of all objects
   const allRows: ListRow[] = useMemo(() => {
     if (!data) return [];
     const rows: ListRow[] = [];
 
-    // Components (non-power symbols)
     for (const sym of data.symbols) {
-      if (sym.is_power) {
-        rows.push({
-          uuid: sym.uuid,
-          kind: "Power Port",
-          x: sym.position.x,
-          y: sym.position.y,
-          orientation: sym.rotation,
-          color: KIND_COLORS["Power Port"],
-        });
-      } else {
-        rows.push({
-          uuid: sym.uuid,
-          kind: "Component",
-          x: sym.position.x,
-          y: sym.position.y,
-          orientation: sym.rotation,
-          color: KIND_COLORS["Component"],
-        });
-      }
-    }
-
-    // Wires
-    for (const w of data.wires) {
+      const isPower = sym.is_power;
       rows.push({
-        uuid: w.uuid,
-        kind: "Wire",
-        x: w.start.x,
-        y: w.start.y,
-        orientation: 0,
-        color: KIND_COLORS["Wire"],
+        uuid: sym.uuid,
+        kind: isPower ? "Power Port" : "Component",
+        name: isPower ? sym.value : sym.reference,
+        x: sym.position.x, y: sym.position.y,
+        orientation: sym.rotation,
+        color: KIND_COLORS[isPower ? "Power Port" : "Component"],
       });
     }
 
-    // Junctions
-    for (const j of data.junctions) {
-      rows.push({
-        uuid: j.uuid,
-        kind: "Junction",
-        x: j.position.x,
-        y: j.position.y,
-        orientation: 0,
-        color: KIND_COLORS["Junction"],
-      });
-    }
+    for (const w of data.wires) rows.push({ uuid: w.uuid, kind: "Wire", name: "--", x: w.start.x, y: w.start.y, orientation: 0, color: KIND_COLORS.Wire });
+    for (const j of data.junctions) rows.push({ uuid: j.uuid, kind: "Junction", name: "--", x: j.position.x, y: j.position.y, orientation: 0, color: KIND_COLORS.Junction });
 
-    // Labels
     for (const l of data.labels) {
-      const kindMap: Record<string, string> = {
-        Net: "Net Label",
-        Global: "Global Label",
-        Hierarchical: "Hier Label",
-        Power: "Power Port",
-      };
-      rows.push({
-        uuid: l.uuid,
-        kind: kindMap[l.label_type] ?? "Net Label",
-        x: l.position.x,
-        y: l.position.y,
-        orientation: l.rotation,
-        color: KIND_COLORS[kindMap[l.label_type] ?? "Net Label"],
-      });
+      const km: Record<string, string> = { Net: "Net Label", Global: "Global Label", Hierarchical: "Hier Label", Power: "Power Port" };
+      const kind = km[l.label_type] ?? "Net Label";
+      rows.push({ uuid: l.uuid, kind, name: l.text, x: l.position.x, y: l.position.y, orientation: l.rotation, color: KIND_COLORS[kind] });
     }
 
-    // Buses
-    for (const b of data.buses) {
-      rows.push({
-        uuid: b.uuid,
-        kind: "Bus",
-        x: b.start.x,
-        y: b.start.y,
-        orientation: 0,
-        color: KIND_COLORS["Bus"],
-      });
-    }
+    for (const b of data.buses) rows.push({ uuid: b.uuid, kind: "Bus", name: "--", x: b.start.x, y: b.start.y, orientation: 0, color: KIND_COLORS.Bus });
+    for (const be of data.bus_entries) rows.push({ uuid: be.uuid, kind: "Bus Entry", name: "--", x: be.position.x, y: be.position.y, orientation: 0, color: KIND_COLORS["Bus Entry"] });
+    for (const nc of data.no_connects) rows.push({ uuid: nc.uuid, kind: "No Connect", name: "--", x: nc.position.x, y: nc.position.y, orientation: 0, color: KIND_COLORS["No Connect"] });
 
-    // Bus entries
-    for (const be of data.bus_entries) {
-      rows.push({
-        uuid: be.uuid,
-        kind: "Bus Entry",
-        x: be.position.x,
-        y: be.position.y,
-        orientation: 0,
-        color: KIND_COLORS["Bus Entry"],
-      });
-    }
+    for (const t of data.text_notes) rows.push({ uuid: t.uuid, kind: "Text Note", name: t.text?.slice(0, 30) || "--", x: t.position.x, y: t.position.y, orientation: t.rotation, color: KIND_COLORS["Text Note"] });
+    for (const cs of data.child_sheets) rows.push({ uuid: cs.uuid, kind: "Sheet", name: cs.name || cs.filename, x: cs.position.x, y: cs.position.y, orientation: 0, color: KIND_COLORS.Sheet });
+    for (const r of data.rectangles) rows.push({ uuid: r.uuid, kind: "Rectangle", name: "--", x: r.start.x, y: r.start.y, orientation: 0, color: KIND_COLORS.Rectangle });
 
-    // No connects
-    for (const nc of data.no_connects) {
-      rows.push({
-        uuid: nc.uuid,
-        kind: "No Connect",
-        x: nc.position.x,
-        y: nc.position.y,
-        orientation: 0,
-        color: KIND_COLORS["No Connect"],
-      });
-    }
-
-    // Text notes
-    for (const t of data.text_notes) {
-      rows.push({
-        uuid: t.uuid,
-        kind: "Text Note",
-        x: t.position.x,
-        y: t.position.y,
-        orientation: t.rotation,
-        color: KIND_COLORS["Text Note"],
-      });
-    }
-
-    // Child sheets
-    for (const cs of data.child_sheets) {
-      rows.push({
-        uuid: cs.uuid,
-        kind: "Sheet",
-        x: cs.position.x,
-        y: cs.position.y,
-        orientation: 0,
-        color: KIND_COLORS["Sheet"],
-      });
-    }
-
-    // Rectangles
-    for (const r of data.rectangles) {
-      rows.push({
-        uuid: r.uuid,
-        kind: "Rectangle",
-        x: r.start.x,
-        y: r.start.y,
-        orientation: 0,
-        color: KIND_COLORS["Rectangle"],
-      });
-    }
-
-    // Drawings
     for (const d of data.drawings) {
-      const pos = positionOf(d as any);
-      rows.push({
-        uuid: d.uuid,
-        kind: "Drawing",
-        x: pos.x,
-        y: pos.y,
-        orientation: 0,
-        color: KIND_COLORS["Drawing"],
-      });
+      const pos = (d as any).position || (d as any).start || (d as any).center || { x: 0, y: 0 };
+      rows.push({ uuid: d.uuid, kind: "Drawing", name: "--", x: pos.x, y: pos.y, orientation: 0, color: KIND_COLORS.Drawing });
     }
 
     return rows;
   }, [data]);
 
-  // If objects are selected, show only those; otherwise show all
+  // Filter by kind
+  const filteredRows = useMemo(() => {
+    if (kindFilter === "All") return allRows;
+    return allRows.filter(r => r.kind === kindFilter);
+  }, [allRows, kindFilter]);
+
+  // Show only selected if any, otherwise all filtered
   const displayRows = useMemo(() => {
-    if (selectedIds.size === 0) return allRows;
-    return allRows.filter((r) => selectedIds.has(r.uuid));
-  }, [allRows, selectedIds]);
+    if (selectedIds.size === 0) return filteredRows;
+    return filteredRows.filter(r => selectedIds.has(r.uuid));
+  }, [filteredRows, selectedIds]);
 
-  const totalCount = allRows.length;
-  const selectedCount = selectedIds.size;
+  // Sort
+  const sortedRows = useMemo(() => {
+    if (!sortCol) return displayRows;
+    return [...displayRows].sort((a, b) => {
+      const av = a[sortCol], bv = b[sortCol];
+      if (typeof av === "number" && typeof bv === "number") return sortDir === "asc" ? av - bv : bv - av;
+      return sortDir === "asc"
+        ? String(av).localeCompare(String(bv), undefined, { numeric: true })
+        : String(bv).localeCompare(String(av), undefined, { numeric: true });
+    });
+  }, [displayRows, sortCol, sortDir]);
 
-  const handleRowClick = useCallback(
-    (uuid: string, e: React.MouseEvent) => {
-      if (e.ctrlKey || e.metaKey) {
-        useSchematicStore.getState().toggleSelect(uuid);
-      } else {
-        useSchematicStore.getState().select(uuid);
+  const handleSort = useCallback((col: SortKey) => {
+    setSortCol(prev => {
+      if (prev === col) {
+        setSortDir(d => d === "asc" ? "desc" : "asc");
+        return col;
       }
-    },
-    [],
-  );
+      setSortDir("asc");
+      return col;
+    });
+  }, []);
 
-  if (!data) {
-    return (
-      <div className="p-4 text-xs text-text-muted/50">No document loaded</div>
-    );
-  }
+  const handleRowClick = useCallback((uuid: string, e: React.MouseEvent) => {
+    if (e.ctrlKey || e.metaKey) {
+      useSchematicStore.getState().toggleSelect(uuid);
+    } else {
+      useSchematicStore.getState().select(uuid);
+    }
+  }, []);
+
+  const handleRowDoubleClick = useCallback((uuid: string) => {
+    useSchematicStore.getState().select(uuid);
+    zoomToObject(uuid);
+  }, []);
+
+  const sortIndicator = (col: SortKey) => {
+    if (sortCol !== col) return null;
+    return <span className="ml-0.5 text-accent">{sortDir === "asc" ? "\u25b2" : "\u25bc"}</span>;
+  };
+
+  if (!data) return <div className="p-4 text-xs text-text-muted/50">No document loaded</div>;
 
   return (
     <div className="text-xs flex flex-col h-full select-none">
-      {/* Header bar */}
-      <div className="px-3 py-1.5 border-b border-border-subtle bg-bg-surface/80 text-[10px] text-text-muted/70 shrink-0 leading-tight">
-        Edit selected objects from all project documents include all types of
-        objects
+      {/* Header with filter */}
+      <div className="px-2 py-1 border-b border-border-subtle bg-bg-surface/80 shrink-0 flex items-center gap-2">
+        <select
+          value={kindFilter}
+          onChange={e => setKindFilter(e.target.value)}
+          className="bg-bg-secondary border border-border-subtle rounded px-1.5 py-0.5 text-[10px] text-text-secondary outline-none"
+        >
+          <option value="All">All Types</option>
+          {ALL_KINDS.map(k => <option key={k} value={k}>{k}</option>)}
+        </select>
+        <span className="text-[10px] text-text-muted/50 ml-auto">
+          {sortedRows.length} / {allRows.length}
+        </span>
       </div>
 
       {/* Table */}
@@ -259,67 +182,50 @@ export function ListPanel() {
         <table className="w-full border-collapse">
           <thead className="sticky top-0 z-10 bg-bg-surface">
             <tr className="border-b border-border-subtle text-left">
-              <th className="px-2 py-1 text-[9px] uppercase tracking-wider text-text-muted/50 font-medium">
-                Object Kind
+              <th onClick={() => handleSort("kind")} className="px-2 py-1 text-[9px] uppercase tracking-wider text-text-muted/50 font-medium cursor-pointer hover:text-accent">
+                Kind{sortIndicator("kind")}
               </th>
-              <th className="px-2 py-1 text-[9px] uppercase tracking-wider text-text-muted/50 font-medium text-right w-[72px]">
-                X1
+              <th onClick={() => handleSort("name")} className="px-2 py-1 text-[9px] uppercase tracking-wider text-text-muted/50 font-medium cursor-pointer hover:text-accent">
+                Name{sortIndicator("name")}
               </th>
-              <th className="px-2 py-1 text-[9px] uppercase tracking-wider text-text-muted/50 font-medium text-right w-[72px]">
-                Y1
+              <th onClick={() => handleSort("x")} className="px-2 py-1 text-[9px] uppercase tracking-wider text-text-muted/50 font-medium text-right w-[68px] cursor-pointer hover:text-accent">
+                X{sortIndicator("x")}
               </th>
-              <th className="px-2 py-1 text-[9px] uppercase tracking-wider text-text-muted/50 font-medium w-[90px]">
-                Orientation
+              <th onClick={() => handleSort("y")} className="px-2 py-1 text-[9px] uppercase tracking-wider text-text-muted/50 font-medium text-right w-[68px] cursor-pointer hover:text-accent">
+                Y{sortIndicator("y")}
               </th>
-              <th className="px-2 py-1 text-[9px] uppercase tracking-wider text-text-muted/50 font-medium w-[48px]">
-                Color
+              <th onClick={() => handleSort("orientation")} className="px-2 py-1 text-[9px] uppercase tracking-wider text-text-muted/50 font-medium w-[48px] cursor-pointer hover:text-accent">
+                Rot{sortIndicator("orientation")}
               </th>
+              <th className="px-2 py-1 w-[24px]" />
             </tr>
           </thead>
           <tbody>
-            {displayRows.map((row) => {
+            {sortedRows.map(row => {
               const isSelected = selectedIds.has(row.uuid);
               return (
                 <tr
                   key={row.uuid}
-                  onClick={(e) => handleRowClick(row.uuid, e)}
+                  onClick={e => handleRowClick(row.uuid, e)}
+                  onDoubleClick={() => handleRowDoubleClick(row.uuid)}
                   className={cn(
                     "border-b border-border-subtle/20 cursor-pointer transition-colors",
-                    isSelected
-                      ? "bg-accent/15 hover:bg-accent/20"
-                      : "hover:bg-bg-hover/50",
+                    isSelected ? "bg-accent/15 hover:bg-accent/20" : "hover:bg-bg-hover/50",
                   )}
                 >
-                  <td className="px-2 py-0.5 text-[10px] text-text-secondary">
-                    {row.kind}
-                  </td>
-                  <td className="px-2 py-0.5 font-mono text-[10px] text-text-muted/70 tabular-nums text-right">
-                    {mmToDisplay(row.x, units)}
-                  </td>
-                  <td className="px-2 py-0.5 font-mono text-[10px] text-text-muted/70 tabular-nums text-right">
-                    {mmToDisplay(row.y, units)}
-                  </td>
-                  <td className="px-2 py-0.5 text-[10px] text-text-muted/70">
-                    {rotationLabel(row.orientation)}
-                  </td>
-                  <td className="px-2 py-0.5">
-                    <div
-                      className="w-3 h-3 rounded-sm border border-white/10"
-                      style={{ backgroundColor: row.color }}
-                    />
+                  <td className="px-2 py-0.5 text-[10px] text-text-secondary">{row.kind}</td>
+                  <td className="px-2 py-0.5 text-[10px] font-mono text-text-primary truncate max-w-[120px]">{row.name}</td>
+                  <td className="px-2 py-0.5 font-mono text-[10px] text-text-muted/70 tabular-nums text-right">{mmToDisplay(row.x, units)}</td>
+                  <td className="px-2 py-0.5 font-mono text-[10px] text-text-muted/70 tabular-nums text-right">{mmToDisplay(row.y, units)}</td>
+                  <td className="px-2 py-0.5 text-[10px] text-text-muted/70">{rotationLabel(row.orientation)}</td>
+                  <td className="px-1 py-0.5">
+                    <div className="w-2.5 h-2.5 rounded-sm border border-white/10" style={{ backgroundColor: row.color }} />
                   </td>
                 </tr>
               );
             })}
-            {displayRows.length === 0 && (
-              <tr>
-                <td
-                  colSpan={5}
-                  className="px-2 py-6 text-center text-text-muted/40 text-[10px]"
-                >
-                  No objects in document
-                </td>
-              </tr>
+            {sortedRows.length === 0 && (
+              <tr><td colSpan={6} className="px-2 py-6 text-center text-text-muted/40 text-[10px]">No objects</td></tr>
             )}
           </tbody>
         </table>
@@ -327,8 +233,7 @@ export function ListPanel() {
 
       {/* Status bar */}
       <div className="px-3 py-1 border-t border-border-subtle text-[10px] text-text-muted/50 shrink-0">
-        {totalCount} Object{totalCount !== 1 ? "s" : ""} ({selectedCount}{" "}
-        Selected)
+        {allRows.length} Objects ({selectedIds.size} Selected){kindFilter !== "All" ? ` \u2014 Filter: ${kindFilter}` : ""}
       </div>
     </div>
   );

--- a/src/panels/NavigatorPanel.tsx
+++ b/src/panels/NavigatorPanel.tsx
@@ -1,6 +1,7 @@
 import { useSchematicStore } from "@/stores/schematic";
 import { useProjectStore } from "@/stores/project";
-import { ChevronDown, ChevronRight, FileText } from "lucide-react";
+import { zoomToObject, zoomToObjects } from "@/lib/crossProbe";
+import { ChevronDown, ChevronRight, FileText, Search } from "lucide-react";
 import { useState, useMemo, useCallback } from "react";
 import { cn } from "@/lib/utils";
 
@@ -211,19 +212,19 @@ function DocumentsSection() {
 
 // --- Instance (Components) section ---
 
-function InstanceSection() {
+function InstanceSection({ filter = "" }: { filter?: string }) {
   const [open, setOpen] = useState(true);
   const data = useSchematicStore((s) => s.data);
   const selectedIds = useSchematicStore((s) => s.selectedIds);
   const select = useSchematicStore((s) => s.select);
 
-  const components = useMemo(
-    () =>
-      (data?.symbols ?? [])
-        .filter((s) => !s.is_power)
-        .sort((a, b) => a.reference.localeCompare(b.reference, undefined, { numeric: true })),
-    [data?.symbols]
-  );
+  const components = useMemo(() => {
+    const q = filter.toLowerCase();
+    return (data?.symbols ?? [])
+      .filter((s) => !s.is_power)
+      .filter((s) => !q || s.reference.toLowerCase().includes(q) || s.value.toLowerCase().includes(q))
+      .sort((a, b) => a.reference.localeCompare(b.reference, undefined, { numeric: true }));
+  }, [data?.symbols, filter]);
 
   return (
     <div>
@@ -253,7 +254,7 @@ function InstanceSection() {
                 <TableRow
                   key={sym.uuid}
                   selected={selectedIds.has(sym.uuid)}
-                  onClick={() => select(sym.uuid)}
+                  onClick={() => { select(sym.uuid); zoomToObject(sym.uuid); }}
                   expandable
                   cells={[
                     { text: sym.reference, flex: "w-[68px] shrink-0", mono: true },
@@ -272,7 +273,7 @@ function InstanceSection() {
 
 // --- Net / Bus section ---
 
-function NetBusSection() {
+function NetBusSection({ filter = "" }: { filter?: string }) {
   const [open, setOpen] = useState(true);
   const data = useSchematicStore((s) => s.data);
   const selectedIds = useSchematicStore((s) => s.selectedIds);
@@ -280,8 +281,8 @@ function NetBusSection() {
 
   const nets = useMemo(() => {
     if (!data) return [];
+    const q = filter.toLowerCase();
 
-    // Collect unique net names from labels, dedup, and determine scope
     const netMap = new Map<string, { uuids: string[]; text: string; labelType: string }>();
     for (const label of data.labels) {
       if (label.label_type === "Net" || label.label_type === "Global" || label.label_type === "Power") {
@@ -298,10 +299,10 @@ function NetBusSection() {
       }
     }
 
-    return Array.from(netMap.values()).sort((a, b) =>
-      a.text.localeCompare(b.text, undefined, { numeric: true })
-    );
-  }, [data?.labels]);
+    return Array.from(netMap.values())
+      .filter(n => !q || n.text.toLowerCase().includes(q))
+      .sort((a, b) => a.text.localeCompare(b.text, undefined, { numeric: true }));
+  }, [data?.labels, filter]);
 
   const getScopeLabel = (labelType: string) => {
     switch (labelType) {
@@ -317,8 +318,8 @@ function NetBusSection() {
 
   const handleNetClick = useCallback(
     (net: { uuids: string[] }) => {
-      // Select all labels belonging to this net to highlight the net
       selectMultiple(net.uuids);
+      if (net.uuids.length > 0) zoomToObjects(net.uuids);
     },
     [selectMultiple]
   );
@@ -371,7 +372,7 @@ function NetBusSection() {
 
 // --- Ports section ---
 
-function PortsSection() {
+function PortsSection({ filter = "" }: { filter?: string }) {
   const [open, setOpen] = useState(true);
   const data = useSchematicStore((s) => s.data);
   const selectedIds = useSchematicStore((s) => s.selectedIds);
@@ -379,33 +380,26 @@ function PortsSection() {
 
   const ports = useMemo(() => {
     if (!data) return [];
+    const q = filter.toLowerCase();
 
     const items: { uuid: string; name: string; portType: string }[] = [];
 
-    // Hierarchical labels act as ports (sheet interface)
     for (const label of data.labels) {
       if (label.label_type === "Hierarchical") {
-        items.push({
-          uuid: label.uuid,
-          name: label.text,
-          portType: "Hierarchical",
-        });
+        items.push({ uuid: label.uuid, name: label.text, portType: "Hierarchical" });
       }
     }
 
-    // Sheet pins are also ports
     for (const sheet of data.child_sheets) {
       for (const pin of sheet.pins) {
-        items.push({
-          uuid: pin.uuid,
-          name: pin.name,
-          portType: pin.direction || "Bidirectional",
-        });
+        items.push({ uuid: pin.uuid, name: pin.name, portType: pin.direction || "Bidirectional" });
       }
     }
 
-    return items.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
-  }, [data?.labels, data?.child_sheets]);
+    return items
+      .filter(p => !q || p.name.toLowerCase().includes(q))
+      .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
+  }, [data?.labels, data?.child_sheets, filter]);
 
   return (
     <div>
@@ -435,7 +429,7 @@ function PortsSection() {
                 <TableRow
                   key={port.uuid}
                   selected={selectedIds.has(port.uuid)}
-                  onClick={() => select(port.uuid)}
+                  onClick={() => { select(port.uuid); zoomToObject(port.uuid); }}
                   icon={<PortIcon direction={port.portType} className="text-text-muted/50" />}
                   cells={[
                     { text: String(idx + 1), flex: "w-[28px] shrink-0", mono: true },
@@ -456,6 +450,7 @@ function PortsSection() {
 
 export function NavigatorPanel() {
   const data = useSchematicStore((s) => s.data);
+  const [search, setSearch] = useState("");
 
   if (!data) {
     return (
@@ -467,11 +462,24 @@ export function NavigatorPanel() {
 
   return (
     <div className="text-xs overflow-y-auto h-full flex flex-col">
+      {/* Search bar */}
+      <div className="px-2 py-1 border-b border-border-subtle bg-bg-surface/80 shrink-0 flex items-center gap-1.5">
+        <Search size={10} className="text-text-muted/40 shrink-0" />
+        <input
+          type="text"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Search..."
+          className="flex-1 bg-transparent text-[10px] text-text-primary placeholder:text-text-muted/30 outline-none"
+        />
+        {search && (
+          <button onClick={() => setSearch("")} className="text-text-muted/40 hover:text-text-primary text-[10px]">&times;</button>
+        )}
+      </div>
       <DocumentsSection />
-      <InstanceSection />
-      <NetBusSection />
-      <PortsSection />
-      {/* Fill remaining space */}
+      <InstanceSection filter={search} />
+      <NetBusSection filter={search} />
+      <PortsSection filter={search} />
       <div className="flex-1" />
     </div>
   );

--- a/src/stores/schematic.ts
+++ b/src/stores/schematic.ts
@@ -197,6 +197,11 @@ interface SchematicState {
   mirrorPlacementY: () => void;
   placeSymbolAt: (pos: SchPoint) => void;
   cancelPlacement: () => void;
+
+  // Cross-probe zoom
+  zoomToRequest: { x: number; y: number; zoom?: number } | null;
+  requestZoomTo: (target: { x: number; y: number; zoom?: number }) => void;
+  clearZoomRequest: () => void;
 }
 
 function generateUuid(): string {
@@ -1764,6 +1769,11 @@ export const useSchematicStore = create<SchematicState>()((set, get) => ({
   cancelPlacement: () => {
     set({ placingSymbol: null, editMode: "select" });
   },
+
+  // Cross-probe zoom
+  zoomToRequest: null,
+  requestZoomTo: (target) => set({ zoomToRequest: target }),
+  clearZoomRequest: () => set({ zoomToRequest: null }),
 
   // Find Similar: select all objects matching the selected object's type/lib_id
   findSimilar: () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export type PanelId =
   | "projects"
   | "components"
   | "navigator"
+  | "libraryMgmt"
   | "properties"
   | "filter"
   | "list"


### PR DESCRIPTION
## Summary
- **Cross-probe infrastructure**: Any panel can now zoom the canvas to an object via `zoomToObject(uuid)`. Added `zoomToRequest` state in schematic store, `objectBounds.ts` utility, and a `useEffect` consumer in SchematicRenderer.
- **SCH List panel**: Sortable columns (click header), object type filter dropdown, new Name column (reference/text), double-click row to zoom to object on canvas.
- **Navigator panel**: Search bar filters all sections (instances, nets, ports). Click any item to select + zoom to it on canvas.
- **Inspector panel**: Multi-object compare mode (2-4 selected objects show side-by-side with diff highlighting). Click any property value to copy to clipboard. Zoom-to-object button in header.
- **Library Management panel**: New panel listing all loaded KiCad libraries with enable/disable toggles, symbol counts, search filter, and stats footer.

## Files changed
- `src/stores/schematic.ts` — Added `zoomToRequest`, `requestZoomTo`, `clearZoomRequest`
- `src/lib/objectBounds.ts` — NEW: bounding rect utility for all schematic object types
- `src/lib/crossProbe.ts` — Added `zoomToObject()`, `zoomToObjects()`
- `src/canvas/SchematicRenderer.tsx` — Added zoom request consumer effect
- `src/panels/ListPanel.tsx` — Rewritten with sorting, filtering, name column, double-click zoom
- `src/panels/NavigatorPanel.tsx` — Added search, click-to-zoom
- `src/panels/InspectorPanel.tsx` — Added compare mode, copy-to-clipboard, zoom button
- `src/panels/LibraryPanel.tsx` — NEW: Library Management panel
- `src/lib/panelRegistry.ts` — Registered new panel
- `src/types/index.ts` — Added `libraryMgmt` to PanelId

## Test plan
- [ ] Open schematic, double-click row in SCH List — canvas zooms to object
- [ ] Click column headers in SCH List — rows sort correctly
- [ ] Use type filter dropdown — list filters by object kind
- [ ] Type in Navigator search — instances/nets/ports filter
- [ ] Click instance in Navigator — canvas zooms to component
- [ ] Select 2 components — Inspector shows compare table with diff highlighting
- [ ] Click property value in Inspector — value copied to clipboard
- [ ] Open Libraries panel — all KiCad libraries listed with symbol counts
- [ ] Toggle library enable/disable — persists across reload