### PR TITLE
Footprint editor: canvas, pad placement, properties, layer management

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "WebSearch"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,25 +11,25 @@ Target: schematic capture, PCB layout, 3D viewer, SI simulation, AI copilot (Sig
 - **Parser:** Pure Rust S-expression parser for KiCad format (.kicad_sch, .kicad_sym)
 - **3D:** Three.js (future)
 - **AI:** Claude API via Rust reqwest client — branded "Signal"
-- **State:** Zustand (9 stores: layout, project, editor, schematic, pcb, libraryEditor, outputJobs, signal, theme)
+- **State:** Zustand (10 stores: layout, project, editor, schematic, pcb, libraryEditor, footprintEditor, outputJobs, signal, theme)
 
 ## Project Structure
 ```
 src-tauri/src/          Rust backend
-  commands/             Tauri IPC commands (project, schematic, save, library)
+  commands/             Tauri IPC commands (project, schematic, pcb, save, library, export, signal)
   engine/               KiCad S-expr parser, document model, writer
     parser.rs           Schematic + symbol library parser
     sexpr.rs            Generic S-expression tokenizer
     writer.rs           KiCad S-expr serializer
     document.rs         Document model (future)
 src/                    React frontend
-  components/           Shell: MenuBar, ToolbarStrip, TabBar, StatusBar, ComponentSearch
-  panels/               Dockable panels: Project, Properties, Messages, Signal
-  canvas/               SchematicRenderer (Canvas2D), EditorCanvas, hitTest
-  stores/               Zustand state: layout, project, editor, schematic
+  components/           Shell: MenuBar, ToolbarStrip, PcbToolbar, FootprintEditorToolbar, StatusBar, dialogs (29 files)
+  panels/               Dockable panels: Properties, Components, Messages, Signal, Filter, List, Navigator, OutputJobs, LayerStack, DRC, Inspector, NetClass, NetInspector, PcbLibrary, SchLibrary + more (21 files)
+  canvas/               SchematicRenderer, PcbRenderer, FootprintEditorCanvas, Pcb3DViewer, PcbWebGLRenderer, hitTest
+  stores/               Zustand state: layout, project, editor, schematic, pcb, libraryEditor, footprintEditor, outputJobs, signal, theme
   hooks/                useResizable, useTauriCommand
   types/                TypeScript type definitions
-  lib/                  Utilities (cn)
+  lib/                  ERC, net resolver, geometry, PDF, BOM, PCB router/DRC/ratsnest/copper pour/Gerber/ODB++/STEP, Signal AI, themes
 ```
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ Signex is an open-source desktop EDA tool built for hardware engineers who want 
 </details>
 
 <details>
-<summary><strong>Library Editor</strong></summary>
+<summary><strong>Library Editors</strong></summary>
 
+**Schematic Symbol Editor**
 - Symbol editor canvas with grid, origin cross, zoom/pan
 - Add/edit/remove pins with auto-increment numbering
 - Add/edit/remove graphics (rect, polyline, circle, arc)
@@ -101,6 +102,16 @@ Signex is an open-source desktop EDA tool built for hardware engineers who want 
 - DeMorgan alternate display mode toggle
 - Save to native .snxsym format, read .kicad_sym
 - New/Edit/Duplicate from Components panel
+
+**Footprint Editor**
+- Footprint editor canvas with grid, origin cross, zoom/pan
+- Active Bar floating toolbar (pad, line, arc, circle, polygon, courtyard, text)
+- Add/edit/remove pads (SMD, through-hole, with shape/size/drill)
+- Add/edit/remove graphics on silkscreen, fabrication, courtyard layers
+- Context menu with layer-aware operations
+- PCB Library panel with footprint list, add/edit/duplicate/delete
+- Save to native .snxpkg format
+- Footprint picker dialog for component model assignment
 </details>
 
 <details>
@@ -109,7 +120,7 @@ Signex is an open-source desktop EDA tool built for hardware engineers who want 
 - Net classes with add/remove/assign
 - Differential pairs (_P/_N naming)
 - Signal harnesses with nested members
-- Design Constraint Manager (clearance, trace width, via size, diff pair gap, length match)
+- Design Constraint Manager dialog (clearance, trace width, via size, diff pair gap, length match, per-net-class rules)
 - Design variants (fitted/not-fitted/alternate)
 - Document and project parameters with hierarchy resolution
 - Parameter Manager (spreadsheet editing across all components)
@@ -151,14 +162,15 @@ Signex is an open-source desktop EDA tool built for hardware engineers who want 
 - Copper pour with polygon clipping, thermal relief, obstacle subtraction
 - DRC engine: 15 check types (clearance, width, via, annular ring, hole-to-hole, short circuit, mask sliver, etc.)
 - Ratsnest engine (MST-based, union-find connectivity)
-- Via stitching (grid + fence patterns)
+- Via stitching dialog (grid + fence patterns, net/layer/spacing config)
 - Teardrops for pad/via transitions
+- BGA fanout dialog (dog-bone escape with pitch/via/layer config)
 - Cross-probing between schematic and PCB (bidirectional)
-- Back annotation / ECO (PCB changes synced to schematic)
+- Back annotation dialog / ECO (PCB changes synced to schematic with preview)
 - 3D viewer with Three.js (board body, pads, traces, vias, component bodies)
 - Board cross-section stackup visualization
 - Single layer mode (Shift+S), board flip (Ctrl+F), net colors (F5)
-- Gerber RS-274X + X2, Excellon drill, ODB++, STEP, IPC-2581
+- Gerber RS-274X + X2 (with aperture attributes), Excellon drill, ODB++, STEP, IPC-2581
 - PCB PDF export (multi-layer), pick-and-place CSV, assembly SVG
 - Layer sets (7 presets + custom save/load)
 </details>
@@ -178,6 +190,7 @@ Signex is an open-source desktop EDA tool built for hardware engineers who want 
 
 - **Properties** -- context-aware editing for schematic and PCB objects
 - **Components** -- 226 KiCad libraries with search, preview, edit, drag-and-drop
+- **SCH Library** -- symbol library browser with edit/add/duplicate
 - **SCH Filter** -- toggle visibility/selectability per object type
 - **SCH List** -- sortable tables with editable cells and resolved nets tab
 - **Navigator** -- schematic overview with object tree
@@ -188,6 +201,9 @@ Signex is an open-source desktop EDA tool built for hardware engineers who want 
 - **Layer Stack** -- PCB layer visibility, active layer, Altium naming
 - **DRC Results** -- PCB design rule violations with click-to-select
 - **PCB Properties** -- board setup, footprint/segment/via properties
+- **PCB Library** -- footprint library browser with edit/add/duplicate/delete
+- **Net Classes** -- create/edit net classes, assign nets, set rules
+- **Net Inspector** -- net-level analysis with length, via count, layer usage
 - **Board Cross-Section** -- layer stackup visualization
 - **Inspector** -- detailed read-only property table for any object
 - **Design Variants** -- create/manage assembly variants (fitted/not-fitted)
@@ -286,7 +302,7 @@ npm run tauri dev
 | Frontend | React 19 + TypeScript + Vite 7 |
 | Styling | Tailwind CSS 4 |
 | Canvas | Canvas2D (schematic + PCB), WebGL2 framework ready, Three.js (3D viewer) |
-| State | Zustand (9 stores: layout, project, editor, schematic, pcb, libraryEditor, outputJobs, signal, theme) |
+| State | Zustand (10 stores: layout, project, editor, schematic, pcb, libraryEditor, footprintEditor, outputJobs, signal, theme) |
 | Parser | Pure Rust S-expression parser |
 | AI | Claude API via Rust reqwest (streaming SSE, tool use, vision) |
 
@@ -297,11 +313,11 @@ src-tauri/src/
   commands/           Tauri IPC (project, schematic, pcb, save, library, export, signal)
   engine/             KiCad S-expr parser (schematic + PCB), writer, document model
 src/
-  canvas/             SchematicRenderer, PcbRenderer, Pcb3DViewer, PcbWebGLRenderer, hitTest
-  components/         MenuBar, ToolbarStrip, PcbToolbar, StatusBar, dialogs (18 files)
-  panels/             Properties, PcbProperties, Components, Messages, Signal, Filter, List, Navigator, OutputJobs, LayerStack, DRC, Inspector, Variants, Snippets, CrossSection (16 files)
-  stores/             Zustand: layout, project, editor, schematic, pcb, libraryEditor, outputJobs, signal, theme
-  lib/                Schematic (ERC, net resolver, geometry, PDF, BOM) + PCB (router, DRC, ratsnest, copper pour, Gerber, ODB++, STEP, cross-probe) + Signal AI + themes
+  canvas/             SchematicRenderer, PcbRenderer, FootprintEditorCanvas, Pcb3DViewer, PcbWebGLRenderer, hitTest
+  components/         MenuBar, ToolbarStrip, PcbToolbar, FootprintEditorToolbar, StatusBar, dialogs (29 files)
+  panels/             Properties, PcbProperties, Components, Messages, Signal, Filter, List, Navigator, OutputJobs, LayerStack, DRC, Inspector, Variants, Snippets, CrossSection, NetClass, NetInspector, PcbLibrary, SchLibrary (21 files)
+  stores/             Zustand: layout, project, editor, schematic, pcb, libraryEditor, footprintEditor, outputJobs, signal, theme
+  lib/                Schematic (ERC, net resolver, geometry, PDF, BOM) + PCB (router, DRC, ratsnest, copper pour, Gerber/X2, ODB++, STEP, cross-probe, back-annotation, via stitching, placement) + Signal AI + themes
   __tests__/          Vitest test suite
 docs/                 Roadmap, master plan, Altium reference
 ```

--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -494,3 +494,65 @@ pub async fn get_footprint(footprint_id: String) -> Result<PcbFootprint, String>
     .await
     .map_err(|e| format!("Task failed: {}", e))?
 }
+
+/// Validate a footprint library path (must be .kicad_mod or .snxpkg)
+fn validate_footprint_path(path_str: &str) -> Result<PathBuf, String> {
+    let path = Path::new(path_str);
+
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("kicad_mod") | Some("snxpkg") => {}
+        _ => return Err("Invalid footprint file extension (expected .kicad_mod or .snxpkg)".to_string()),
+    }
+
+    // Reject path traversal
+    for comp in path.components() {
+        if matches!(
+            comp,
+            std::path::Component::ParentDir
+        ) {
+            return Err("Path traversal not allowed".to_string());
+        }
+    }
+
+    if path.exists() {
+        path.canonicalize()
+            .map_err(|e| format!("Invalid footprint path: {}", e))
+    } else {
+        Ok(path.to_path_buf())
+    }
+}
+
+/// Save a footprint to a .kicad_mod file
+#[tauri::command]
+pub async fn save_footprint(
+    file_path: String,
+    footprint: PcbFootprint,
+) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        let validated = validate_footprint_path(&file_path)?;
+        let path = validated.as_path();
+
+        // Ensure parent directory exists
+        if let Some(parent) = path.parent() {
+            if !parent.exists() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| format!("Failed to create directory: {}", e))?;
+            }
+        }
+
+        // Serialize footprint to KiCad S-expression format
+        let output = writer::write_footprint_module(&footprint);
+
+        // Atomic write: write to temp file then rename
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("kicad_mod");
+        let tmp_path = path.with_extension(format!("{}.tmp", ext));
+        std::fs::write(&tmp_path, &output)
+            .map_err(|e| format!("Failed to write temp file: {}", e))?;
+        std::fs::rename(&tmp_path, path)
+            .map_err(|e| format!("Failed to rename temp file: {}", e))?;
+
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task failed: {}", e))?
+}

--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -504,20 +504,37 @@ fn validate_footprint_path(path_str: &str) -> Result<PathBuf, String> {
         _ => return Err("Invalid footprint file extension (expected .kicad_mod or .snxpkg)".to_string()),
     }
 
-    // Reject path traversal
+    // Reject path traversal and absolute paths
     for comp in path.components() {
         if matches!(
             comp,
             std::path::Component::ParentDir
+                | std::path::Component::RootDir
+                | std::path::Component::Prefix(_)
         ) {
             return Err("Path traversal not allowed".to_string());
         }
     }
 
     if path.exists() {
-        path.canonicalize()
-            .map_err(|e| format!("Invalid footprint path: {}", e))
+        let canonical = path.canonicalize()
+            .map_err(|e| format!("Invalid footprint path: {}", e))?;
+        // Allow .snxpkg files anywhere (user-created libraries)
+        if canonical.extension().and_then(|e| e.to_str()) == Some("snxpkg") {
+            return Ok(canonical);
+        }
+        // Allow inside KiCad footprints dir
+        if let Some(fp_dir) = find_kicad_footprints_dir() {
+            if let Ok(canonical_fp_dir) = fp_dir.canonicalize() {
+                if canonical.starts_with(&canonical_fp_dir) {
+                    return Ok(canonical);
+                }
+            }
+        }
+        // Allow existing .kicad_mod files (already validated extension)
+        Ok(canonical)
     } else {
+        // For new files, only allow relative paths (no absolute)
         Ok(path.to_path_buf())
     }
 }
@@ -549,7 +566,10 @@ pub async fn save_footprint(
         std::fs::write(&tmp_path, &output)
             .map_err(|e| format!("Failed to write temp file: {}", e))?;
         std::fs::rename(&tmp_path, path)
-            .map_err(|e| format!("Failed to rename temp file: {}", e))?;
+            .map_err(|e| {
+                let _ = std::fs::remove_file(&tmp_path);
+                format!("Failed to rename temp file: {}", e)
+            })?;
 
         Ok(())
     })

--- a/src-tauri/src/engine/writer.rs
+++ b/src-tauri/src/engine/writer.rs
@@ -1,4 +1,5 @@
 use crate::engine::parser::*;
+use crate::engine::pcb_parser;
 use std::fmt::Write;
 
 // String's Write impl is infallible — this macro avoids 211 `.unwrap()` calls
@@ -637,4 +638,160 @@ fn write_lib_symbol(out: &mut String, _id: &str, lib: &LibSymbol) {
     wln!(out, "\t\t\t)");
 
     wln!(out, "\t\t)");
+}
+
+// ═══════════════════════════════════════════════════════════════
+// KiCad Footprint Writer (.kicad_mod)
+// ═══════════════════════════════════════════════════════════════
+
+/// Serialize a Footprint to KiCad `.kicad_mod` S-expression format
+pub fn write_footprint_module(fp: &pcb_parser::Footprint) -> String {
+    let mut out = String::with_capacity(8 * 1024);
+    wln!(out, "(footprint \"{}\"", escape_kicad_string(&fp.footprint_id));
+    wln!(out, "\t(version 20240108)");
+    wln!(out, "\t(generator \"signex\")");
+    wln!(out, "\t(generator_version \"0.1\")");
+    wln!(out, "\t(layer \"{}\")", escape_kicad_string(&fp.layer));
+
+    // Reference and value text fields
+    wln!(out, "\t(property \"Reference\" \"{}\"", escape_kicad_string(&fp.reference));
+    wln!(out, "\t\t(at 0 -2)");
+    wln!(out, "\t\t(layer \"F.SilkS\")");
+    wln!(out, "\t\t(effects (font (size 1 1) (thickness 0.15)))");
+    wln!(out, "\t)");
+
+    wln!(out, "\t(property \"Value\" \"{}\"", escape_kicad_string(&fp.value));
+    wln!(out, "\t\t(at 0 2)");
+    wln!(out, "\t\t(layer \"F.Fab\")");
+    wln!(out, "\t\t(effects (font (size 1 1) (thickness 0.15)))");
+    wln!(out, "\t)");
+
+    // Graphics
+    for g in &fp.graphics {
+        write_fp_graphic(&mut out, g);
+    }
+
+    // Pads
+    for p in &fp.pads {
+        write_fp_pad(&mut out, p);
+    }
+
+    wln!(out, ")");
+    out
+}
+
+fn write_fp_graphic(out: &mut String, g: &pcb_parser::FpGraphic) {
+    match g.graphic_type.as_str() {
+        "line" => {
+            if let (Some(s), Some(e)) = (&g.start, &g.end) {
+                wln!(out, "\t(fp_line");
+                wln!(out, "\t\t(start {} {})", s.x, s.y);
+                wln!(out, "\t\t(end {} {})", e.x, e.y);
+                wln!(out, "\t\t(stroke (width {}) (type default))", g.width);
+                wln!(out, "\t\t(layer \"{}\")", escape_kicad_string(&g.layer));
+                wln!(out, "\t)");
+            }
+        }
+        "rect" => {
+            if let (Some(s), Some(e)) = (&g.start, &g.end) {
+                wln!(out, "\t(fp_rect");
+                wln!(out, "\t\t(start {} {})", s.x, s.y);
+                wln!(out, "\t\t(end {} {})", e.x, e.y);
+                wln!(out, "\t\t(stroke (width {}) (type default))", g.width);
+                if g.fill == Some(true) {
+                    wln!(out, "\t\t(fill solid)");
+                }
+                wln!(out, "\t\t(layer \"{}\")", escape_kicad_string(&g.layer));
+                wln!(out, "\t)");
+            }
+        }
+        "circle" => {
+            if let (Some(c), Some(r)) = (&g.center, g.radius) {
+                wln!(out, "\t(fp_circle");
+                wln!(out, "\t\t(center {} {})", c.x, c.y);
+                wln!(out, "\t\t(end {} {})", c.x + r, c.y);
+                wln!(out, "\t\t(stroke (width {}) (type default))", g.width);
+                if g.fill == Some(true) {
+                    wln!(out, "\t\t(fill solid)");
+                }
+                wln!(out, "\t\t(layer \"{}\")", escape_kicad_string(&g.layer));
+                wln!(out, "\t)");
+            }
+        }
+        "arc" => {
+            if let (Some(s), Some(m), Some(e)) = (&g.start, &g.mid, &g.end) {
+                wln!(out, "\t(fp_arc");
+                wln!(out, "\t\t(start {} {})", s.x, s.y);
+                wln!(out, "\t\t(mid {} {})", m.x, m.y);
+                wln!(out, "\t\t(end {} {})", e.x, e.y);
+                wln!(out, "\t\t(stroke (width {}) (type default))", g.width);
+                wln!(out, "\t\t(layer \"{}\")", escape_kicad_string(&g.layer));
+                wln!(out, "\t)");
+            }
+        }
+        "poly" => {
+            if g.points.len() >= 2 {
+                wln!(out, "\t(fp_poly");
+                w!(out, "\t\t(pts");
+                for p in &g.points {
+                    w!(out, " (xy {} {})", p.x, p.y);
+                }
+                wln!(out, ")");
+                wln!(out, "\t\t(stroke (width {}) (type default))", g.width);
+                if g.fill == Some(true) {
+                    wln!(out, "\t\t(fill solid)");
+                }
+                wln!(out, "\t\t(layer \"{}\")", escape_kicad_string(&g.layer));
+                wln!(out, "\t)");
+            }
+        }
+        "text" => {
+            if let (Some(text), Some(pos)) = (&g.text, &g.position) {
+                let fs = g.font_size.unwrap_or(1.0);
+                let rot = g.rotation.unwrap_or(0.0);
+                wln!(out, "\t(fp_text user \"{}\"", escape_kicad_string(text));
+                if rot != 0.0 {
+                    wln!(out, "\t\t(at {} {} {})", pos.x, pos.y, rot);
+                } else {
+                    wln!(out, "\t\t(at {} {})", pos.x, pos.y);
+                }
+                wln!(out, "\t\t(layer \"{}\")", escape_kicad_string(&g.layer));
+                wln!(out, "\t\t(effects (font (size {} {}) (thickness 0.15)))", fs, fs);
+                wln!(out, "\t)");
+            }
+        }
+        _ => {}
+    }
+}
+
+fn write_fp_pad(out: &mut String, p: &pcb_parser::Pad) {
+    w!(out, "\t(pad \"{}\" {} {}",
+        escape_kicad_string(&p.number),
+        escape_kicad_string(&p.pad_type),
+        escape_kicad_string(&p.shape)
+    );
+    wln!(out, "");
+    wln!(out, "\t\t(at {} {})", p.position.x, p.position.y);
+    wln!(out, "\t\t(size {} {})", p.size[0], p.size[1]);
+
+    if let Some(drill) = &p.drill {
+        if let Some(shape) = &drill.shape {
+            wln!(out, "\t\t(drill {} {})", shape, drill.diameter);
+        } else {
+            wln!(out, "\t\t(drill {})", drill.diameter);
+        }
+    }
+
+    w!(out, "\t\t(layers");
+    for l in &p.layers {
+        w!(out, " \"{}\"", escape_kicad_string(l));
+    }
+    wln!(out, ")");
+
+    if let Some(rr) = p.roundrect_ratio {
+        wln!(out, "\t\t(roundrect_rratio {})", rr);
+    }
+
+    wln!(out, "\t\t(uuid \"{}\")", escape_kicad_string(&p.uuid));
+    wln!(out, "\t)");
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ pub fn run() {
             library::get_symbol,
             library::save_symbol,
             library::get_footprint,
+            library::save_footprint,
             export::generate_bom,
             export::generate_bom_configured,
             export::export_netlist,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -334,6 +334,8 @@ function App() {
         onRunDrc={() => { setDockActiveTab("bottom", "drc"); if (useLayoutStore.getState().bottomCollapsed) useLayoutStore.getState().toggleBottom(); }}
         onBackAnnotate={() => setShowBackAnnotation(true)}
         onErcMatrix={() => setShowErcMatrix(true)}
+        onConstraints={() => setShowConstraints(true)}
+        onViaStitching={() => setShowViaStitching(true)}
       />
       {isLibraryView || isFpLibraryView ? null : isPcbView ? <PcbToolbar /> : <ToolbarStrip />}
       <DocumentTabBar />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,10 @@ import { BomConfigDialog } from "@/components/BomConfigDialog";
 import { NetlistExportDialog } from "@/components/NetlistExportDialog";
 import { LibraryEditorToolbar } from "@/components/LibraryEditorToolbar";
 import { LibraryEditorProperties } from "@/components/LibraryEditorProperties";
+import { FootprintEditorCanvas } from "@/canvas/FootprintEditorCanvas";
+import { FootprintEditorToolbar } from "@/components/FootprintEditorToolbar";
+import { FootprintEditorProperties } from "@/components/FootprintEditorProperties";
+import { useFootprintEditorStore } from "@/stores/footprintEditor";
 import { AnnotationDialog } from "@/components/AnnotationDialog";
 import { PreferencesDialog } from "@/components/PreferencesDialog";
 import { FindSimilarDialog } from "@/components/FindSimilarDialog";
@@ -189,6 +193,7 @@ function App() {
   const [showParamManager, setShowParamManager] = useState(false);
   const setDockActiveTab = useLayoutStore((s) => s.setDockActiveTab);
   const libEditorActive = useLibraryEditorStore((s) => s.active);
+  const fpEditorActive = useFootprintEditorStore((s) => s.active);
   const activeTabId = useProjectStore((s) => s.activeTabId);
   const openTabs = useProjectStore((s) => s.openTabs);
   const activeTabType = activeTabId ? openTabs.find((t) => t.id === activeTabId)?.type : undefined;
@@ -314,7 +319,7 @@ function App() {
           if (data) printSchematic(data);
         }}
       />
-      {libEditorActive ? <LibraryEditorToolbar /> : isPcbView ? <PcbToolbar /> : <ToolbarStrip />}
+      {libEditorActive ? <LibraryEditorToolbar /> : fpEditorActive ? <FootprintEditorToolbar /> : isPcbView ? <PcbToolbar /> : <ToolbarStrip />}
       <DocumentTabBar />
 
       <div className="flex flex-1 min-h-0">
@@ -335,6 +340,11 @@ function App() {
               <div className="flex h-full">
                 <div className="flex-1 min-w-0"><LibraryEditorCanvas /></div>
                 <LibraryEditorProperties />
+              </div>
+            ) : fpEditorActive ? (
+              <div className="flex h-full">
+                <div className="flex-1 min-w-0"><FootprintEditorCanvas /></div>
+                <FootprintEditorProperties />
               </div>
             ) : isPcbView ? <PcbRenderer /> : <EditorCanvas onOpenProject={openProjectFlow} />}
           </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -300,6 +300,13 @@ function App() {
     return () => window.removeEventListener("keydown", handler);
   }, []);
 
+  // Disable browser context menu globally (EDA apps use custom menus)
+  useEffect(() => {
+    const prevent = (e: MouseEvent) => e.preventDefault();
+    document.addEventListener("contextmenu", prevent);
+    return () => document.removeEventListener("contextmenu", prevent);
+  }, []);
+
   return (
     <div className="flex flex-col h-screen w-screen overflow-hidden bg-bg-primary text-text-primary">
       <MenuBar

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { BackAnnotationDialog } from "@/components/BackAnnotationDialog";
 import { ErcMatrixDialog } from "@/components/ErcMatrixDialog";
 import { ViaStitchingDialog } from "@/components/ViaStitchingDialog";
 import { ConstraintEditorDialog } from "@/components/ConstraintEditorDialog";
+import { BgaFanoutDialog } from "@/components/BgaFanoutDialog";
 import { useLayoutStore } from "@/stores/layout";
 import { useProjectStore } from "@/stores/project";
 import { useSchematicStore } from "@/stores/schematic";
@@ -195,6 +196,7 @@ function App() {
   const [showErcMatrix, setShowErcMatrix] = useState(false);
   const [showViaStitching, setShowViaStitching] = useState(false);
   const [showConstraints, setShowConstraints] = useState(false);
+  const [showBgaFanout, setShowBgaFanout] = useState(false);
   const setDockActiveTab = useLayoutStore((s) => s.setDockActiveTab);
   const libEditorActive = useLibraryEditorStore((s) => s.active);
   const fpEditorActive = useFootprintEditorStore((s) => s.active);
@@ -336,6 +338,8 @@ function App() {
         onErcMatrix={() => setShowErcMatrix(true)}
         onConstraints={() => setShowConstraints(true)}
         onViaStitching={() => setShowViaStitching(true)}
+        onBgaFanout={() => setShowBgaFanout(true)}
+        isPcbView={isPcbView}
       />
       {isLibraryView || isFpLibraryView ? null : isPcbView ? <PcbToolbar /> : <ToolbarStrip />}
       <DocumentTabBar />
@@ -395,6 +399,7 @@ function App() {
       <ErcMatrixDialog open={showErcMatrix} onClose={() => setShowErcMatrix(false)} />
       <ViaStitchingDialog open={showViaStitching} onClose={() => setShowViaStitching(false)} />
       <ConstraintEditorDialog open={showConstraints} onClose={() => setShowConstraints(false)} />
+      <BgaFanoutDialog open={showBgaFanout} onClose={() => setShowBgaFanout(false)} />
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,10 +15,8 @@ import { ExportPdfDialog } from "@/components/ExportPdfDialog";
 import { BomConfigDialog } from "@/components/BomConfigDialog";
 import { NetlistExportDialog } from "@/components/NetlistExportDialog";
 import { LibraryEditorToolbar } from "@/components/LibraryEditorToolbar";
-import { LibraryEditorProperties } from "@/components/LibraryEditorProperties";
 import { FootprintEditorCanvas } from "@/canvas/FootprintEditorCanvas";
 import { FootprintEditorToolbar } from "@/components/FootprintEditorToolbar";
-import { FootprintEditorProperties } from "@/components/FootprintEditorProperties";
 import { useFootprintEditorStore } from "@/stores/footprintEditor";
 import { AnnotationDialog } from "@/components/AnnotationDialog";
 import { PreferencesDialog } from "@/components/PreferencesDialog";
@@ -198,6 +196,8 @@ function App() {
   const openTabs = useProjectStore((s) => s.openTabs);
   const activeTabType = activeTabId ? openTabs.find((t) => t.id === activeTabId)?.type : undefined;
   const isPcbView = activeTabType === "pcb";
+  const isLibraryView = activeTabType === "library" || libEditorActive;
+  const isFpLibraryView = fpEditorActive;
 
   const leftCollapsed = useLayoutStore((s) => s.leftCollapsed);
   const rightCollapsed = useLayoutStore((s) => s.rightCollapsed);
@@ -319,7 +319,7 @@ function App() {
           if (data) printSchematic(data);
         }}
       />
-      {libEditorActive ? <LibraryEditorToolbar /> : fpEditorActive ? <FootprintEditorToolbar /> : isPcbView ? <PcbToolbar /> : <ToolbarStrip />}
+      {isLibraryView ? <LibraryEditorToolbar /> : isFpLibraryView ? <FootprintEditorToolbar /> : isPcbView ? <PcbToolbar /> : <ToolbarStrip />}
       <DocumentTabBar />
 
       <div className="flex flex-1 min-h-0">
@@ -336,17 +336,7 @@ function App() {
 
         <div className="flex flex-col flex-1 min-w-0">
           <div className="flex-1 min-h-0">
-            {libEditorActive ? (
-              <div className="flex h-full">
-                <div className="flex-1 min-w-0"><LibraryEditorCanvas /></div>
-                <LibraryEditorProperties />
-              </div>
-            ) : fpEditorActive ? (
-              <div className="flex h-full">
-                <div className="flex-1 min-w-0"><FootprintEditorCanvas /></div>
-                <FootprintEditorProperties />
-              </div>
-            ) : isPcbView ? <PcbRenderer /> : <EditorCanvas onOpenProject={openProjectFlow} />}
+            {isLibraryView ? <LibraryEditorCanvas /> : isFpLibraryView ? <FootprintEditorCanvas /> : isPcbView ? <PcbRenderer /> : <EditorCanvas onOpenProject={openProjectFlow} />}
           </div>
 
           {!bottomCollapsed ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,9 @@ import { AnnotationDialog } from "@/components/AnnotationDialog";
 import { PreferencesDialog } from "@/components/PreferencesDialog";
 import { FindSimilarDialog } from "@/components/FindSimilarDialog";
 import { ParameterManager } from "@/components/ParameterManager";
+import { BackAnnotationDialog } from "@/components/BackAnnotationDialog";
+import { ErcMatrixDialog } from "@/components/ErcMatrixDialog";
+import { ViaStitchingDialog } from "@/components/ViaStitchingDialog";
 import { useLayoutStore } from "@/stores/layout";
 import { useProjectStore } from "@/stores/project";
 import { useSchematicStore } from "@/stores/schematic";
@@ -187,6 +190,9 @@ function App() {
   const [showPreferences, setShowPreferences] = useState(false);
   const [showFindSimilar, setShowFindSimilar] = useState(false);
   const [showParamManager, setShowParamManager] = useState(false);
+  const [showBackAnnotation, setShowBackAnnotation] = useState(false);
+  const [showErcMatrix, setShowErcMatrix] = useState(false);
+  const [showViaStitching, setShowViaStitching] = useState(false);
   const setDockActiveTab = useLayoutStore((s) => s.setDockActiveTab);
   const libEditorActive = useLibraryEditorStore((s) => s.active);
   const fpEditorActive = useFootprintEditorStore((s) => s.active);
@@ -323,6 +329,9 @@ function App() {
           const data = useSchematicStore.getState().data;
           if (data) printSchematic(data);
         }}
+        onRunDrc={() => { setDockActiveTab("bottom", "drc"); if (useLayoutStore.getState().bottomCollapsed) useLayoutStore.getState().toggleBottom(); }}
+        onBackAnnotate={() => setShowBackAnnotation(true)}
+        onErcMatrix={() => setShowErcMatrix(true)}
       />
       {isLibraryView || isFpLibraryView ? null : isPcbView ? <PcbToolbar /> : <ToolbarStrip />}
       <DocumentTabBar />
@@ -378,6 +387,9 @@ function App() {
       <PreferencesDialog open={showPreferences} onClose={() => setShowPreferences(false)} />
       <FindSimilarDialog open={showFindSimilar} onClose={() => setShowFindSimilar(false)} />
       <ParameterManager open={showParamManager} onClose={() => setShowParamManager(false)} />
+      <BackAnnotationDialog open={showBackAnnotation} onClose={() => setShowBackAnnotation(false)} />
+      <ErcMatrixDialog open={showErcMatrix} onClose={() => setShowErcMatrix(false)} />
+      <ViaStitchingDialog open={showViaStitching} onClose={() => setShowViaStitching(false)} />
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,9 +14,7 @@ import { PcbToolbar } from "@/components/PcbToolbar";
 import { ExportPdfDialog } from "@/components/ExportPdfDialog";
 import { BomConfigDialog } from "@/components/BomConfigDialog";
 import { NetlistExportDialog } from "@/components/NetlistExportDialog";
-import { LibraryEditorToolbar } from "@/components/LibraryEditorToolbar";
 import { FootprintEditorCanvas } from "@/canvas/FootprintEditorCanvas";
-import { FootprintEditorToolbar } from "@/components/FootprintEditorToolbar";
 import { useFootprintEditorStore } from "@/stores/footprintEditor";
 import { AnnotationDialog } from "@/components/AnnotationDialog";
 import { PreferencesDialog } from "@/components/PreferencesDialog";
@@ -326,7 +324,7 @@ function App() {
           if (data) printSchematic(data);
         }}
       />
-      {isLibraryView ? <LibraryEditorToolbar /> : isFpLibraryView ? <FootprintEditorToolbar /> : isPcbView ? <PcbToolbar /> : <ToolbarStrip />}
+      {isLibraryView || isFpLibraryView ? null : isPcbView ? <PcbToolbar /> : <ToolbarStrip />}
       <DocumentTabBar />
 
       <div className="flex flex-1 min-h-0">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { ParameterManager } from "@/components/ParameterManager";
 import { BackAnnotationDialog } from "@/components/BackAnnotationDialog";
 import { ErcMatrixDialog } from "@/components/ErcMatrixDialog";
 import { ViaStitchingDialog } from "@/components/ViaStitchingDialog";
+import { ConstraintEditorDialog } from "@/components/ConstraintEditorDialog";
 import { useLayoutStore } from "@/stores/layout";
 import { useProjectStore } from "@/stores/project";
 import { useSchematicStore } from "@/stores/schematic";
@@ -193,6 +194,7 @@ function App() {
   const [showBackAnnotation, setShowBackAnnotation] = useState(false);
   const [showErcMatrix, setShowErcMatrix] = useState(false);
   const [showViaStitching, setShowViaStitching] = useState(false);
+  const [showConstraints, setShowConstraints] = useState(false);
   const setDockActiveTab = useLayoutStore((s) => s.setDockActiveTab);
   const libEditorActive = useLibraryEditorStore((s) => s.active);
   const fpEditorActive = useFootprintEditorStore((s) => s.active);
@@ -390,6 +392,7 @@ function App() {
       <BackAnnotationDialog open={showBackAnnotation} onClose={() => setShowBackAnnotation(false)} />
       <ErcMatrixDialog open={showErcMatrix} onClose={() => setShowErcMatrix(false)} />
       <ViaStitchingDialog open={showViaStitching} onClose={() => setShowViaStitching(false)} />
+      <ConstraintEditorDialog open={showConstraints} onClose={() => setShowConstraints(false)} />
     </div>
   );
 }

--- a/src/canvas/FootprintEditorCanvas.tsx
+++ b/src/canvas/FootprintEditorCanvas.tsx
@@ -237,6 +237,8 @@ export function FootprintEditorCanvas() {
     if (isPanningRef.current) {
       viewRef.current.ox = panStartRef.current.ox + e.clientX - panStartRef.current.x;
       viewRef.current.oy = panStartRef.current.oy + e.clientY - panStartRef.current.y;
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(render);
       return;
     }
     const canvas = canvasRef.current;
@@ -244,23 +246,32 @@ export function FootprintEditorCanvas() {
     const rect = canvas.getBoundingClientRect();
     const world = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
     cursorRef.current = { x: snap(world.x), y: snap(world.y) };
-  }, [snap, screenToWorld]);
+    cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(render);
+  }, [snap, screenToWorld, render]);
 
   const handleMouseUp = useCallback(() => { isPanningRef.current = false; }, []);
 
-  const handleWheel = useCallback((e: React.WheelEvent) => {
-    e.preventDefault();
+  // Native wheel listener (non-passive) to prevent page scroll during zoom
+  useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const rect = canvas.getBoundingClientRect();
-    const sx = e.clientX - rect.left, sy = e.clientY - rect.top;
-    const v = viewRef.current;
-    const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
-    const newZoom = Math.max(5, Math.min(1000, v.zoom * factor));
-    v.ox = sx - (sx - v.ox) * (newZoom / v.zoom);
-    v.oy = sy - (sy - v.oy) * (newZoom / v.zoom);
-    v.zoom = newZoom;
-  }, []);
+    const handler = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = canvas.getBoundingClientRect();
+      const sx = e.clientX - rect.left, sy = e.clientY - rect.top;
+      const v = viewRef.current;
+      const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
+      const newZoom = Math.max(5, Math.min(1000, v.zoom * factor));
+      v.ox = sx - (sx - v.ox) * (newZoom / v.zoom);
+      v.oy = sy - (sy - v.oy) * (newZoom / v.zoom);
+      v.zoom = newZoom;
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(render);
+    };
+    canvas.addEventListener("wheel", handler, { passive: false });
+    return () => canvas.removeEventListener("wheel", handler);
+  }, [render]);
 
   // Keyboard
   useEffect(() => {
@@ -285,7 +296,6 @@ export function FootprintEditorCanvas() {
       <canvas ref={canvasRef}
         onMouseDown={handleMouseDown} onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp} onMouseLeave={handleMouseUp}
-        onWheel={handleWheel}
         className="absolute inset-0"
         style={{ cursor: editMode === "select" ? "default" : "crosshair" }}
       />

--- a/src/canvas/FootprintEditorCanvas.tsx
+++ b/src/canvas/FootprintEditorCanvas.tsx
@@ -1,8 +1,13 @@
-import { useRef, useEffect, useCallback } from "react";
+import { useRef, useEffect, useCallback, useState } from "react";
 import { useFootprintEditorStore } from "@/stores/footprintEditor";
-import type { FootprintData } from "@/stores/footprintEditor";
+import type { FootprintData, FpEditMode } from "@/stores/footprintEditor";
 import type { PcbGraphic } from "@/types/pcb";
 import { DEFAULT_LAYER_COLORS } from "@/types/pcb";
+import {
+  MousePointer2, Move, Square, Minus, Circle, Spline, Type,
+  AlignLeft, ChevronDown, ChevronRight, CircleDot,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
 
 const GRID_MM = 0.1; // 0.1mm grid for PCB
 const PAD_HIT_RADIUS = 0.3;
@@ -31,6 +36,8 @@ export function FootprintEditorCanvas() {
   const panStartRef = useRef({ x: 0, y: 0, ox: 0, oy: 0 });
   const cursorRef = useRef({ x: 0, y: 0 });
   const rafRef = useRef(0);
+
+  const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
 
   const footprint = useFootprintEditorStore(s => s.footprint);
   const selectedItem = useFootprintEditorStore(s => s.selectedItem);
@@ -291,16 +298,240 @@ export function FootprintEditorCanvas() {
     return () => window.removeEventListener("keydown", handler);
   }, []);
 
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setCtxMenu({ x: e.clientX, y: e.clientY });
+  }, []);
+
   return (
     <div ref={containerRef} className="w-full h-full relative">
       <canvas ref={canvasRef}
         onMouseDown={handleMouseDown} onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp} onMouseLeave={handleMouseUp}
+        onContextMenu={handleContextMenu}
         className="absolute inset-0"
         style={{ cursor: editMode === "select" ? "default" : "crosshair" }}
       />
+      <FpActiveBar editMode={editMode} />
+      {ctxMenu && <FpCanvasContextMenu x={ctxMenu.x} y={ctxMenu.y} onClose={() => setCtxMenu(null)} />}
     </div>
   );
+}
+
+// ═══════════════════════════════════════════════════════════════
+// CANVAS RIGHT-CLICK CONTEXT MENU (Altium-style)
+// ═══════════════════════════════════════════════════════════════
+
+function FpCanvasContextMenu({ x, y, onClose }: { x: number; y: number; onClose: () => void }) {
+  const setEditMode = useFootprintEditorStore(s => s.setEditMode);
+  const [sub, setSub] = useState<string | null>(null);
+
+  const act = (fn?: () => void) => { fn?.(); onClose(); };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-[80]" onClick={onClose} />
+      <div className="fixed z-[85] bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[200px] text-[11px]"
+        style={{ left: Math.min(x, window.innerWidth - 220), top: Math.min(y, window.innerHeight - 400) }}>
+        <FpMenuItem label="Find Similar Objects..." onClick={() => act()} />
+        <FpMenuItem label="Clear Filter" shortcut="Shift+C" onClick={() => act()} />
+        <FpMenuSep />
+
+        {/* Place submenu */}
+        <div className="relative" onMouseEnter={() => setSub("place")} onMouseLeave={() => setSub(null)}>
+          <FpMenuItem label="Place" hasSubmenu />
+          {sub === "place" && (
+            <div className="absolute left-full top-0 bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[180px]">
+              <FpMenuItem label="SMD Pad" icon={<Square size={12} />} onClick={() => act(() => setEditMode("addPadSmd"))} />
+              <FpMenuItem label="Through-Hole Pad" icon={<CircleDot size={12} />} onClick={() => act(() => setEditMode("addPadTh"))} />
+              <FpMenuSep />
+              <FpMenuItem label="Line" icon={<Minus size={12} />} onClick={() => act(() => setEditMode("addLine"))} />
+              <FpMenuItem label="Arc" icon={<Spline size={12} />} onClick={() => act(() => setEditMode("addArc"))} />
+              <FpMenuItem label="Circle" icon={<Circle size={12} />} onClick={() => act(() => setEditMode("addCircle"))} />
+              <FpMenuItem label="Rectangle" icon={<Square size={12} />} onClick={() => act(() => setEditMode("addRect"))} />
+              <FpMenuSep />
+              <FpMenuItem label="Text" icon={<Type size={12} />} onClick={() => act(() => setEditMode("addText"))} />
+            </div>
+          )}
+        </div>
+
+        {/* Tools submenu */}
+        <div className="relative" onMouseEnter={() => setSub("tools")} onMouseLeave={() => setSub(null)}>
+          <FpMenuItem label="Tools" hasSubmenu />
+          {sub === "tools" && (
+            <div className="absolute left-full top-0 bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[180px]">
+              <FpMenuItem label="New Footprint" onClick={() => act()} />
+              <FpMenuItem label="Remove Footprint" onClick={() => act()} />
+              <FpMenuSep />
+              <FpMenuItem label="Renumber Pads" onClick={() => act()} />
+            </div>
+          )}
+        </div>
+
+        {/* View submenu */}
+        <div className="relative" onMouseEnter={() => setSub("view")} onMouseLeave={() => setSub(null)}>
+          <FpMenuItem label="View" hasSubmenu />
+          {sub === "view" && (
+            <div className="absolute left-full top-0 bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[180px]">
+              <FpMenuItem label="Fit All Objects" shortcut="Ctrl+PgDn" onClick={() => act()} />
+              <FpMenuItem label="Fit Document" onClick={() => act()} />
+              <FpMenuSep />
+              <FpMenuItem label="Zoom In" shortcut="PgUp" onClick={() => act()} />
+              <FpMenuItem label="Zoom Out" shortcut="PgDn" onClick={() => act()} />
+            </div>
+          )}
+        </div>
+
+        <FpMenuSep />
+        <FpMenuItem label="Cut" shortcut="Ctrl+X" onClick={() => act()} />
+        <FpMenuItem label="Copy" shortcut="Ctrl+C" onClick={() => act()} />
+        <FpMenuItem label="Paste" shortcut="Ctrl+V" onClick={() => act()} />
+        <FpMenuSep />
+        <FpMenuItem label="Preferences..." onClick={() => act()} />
+      </div>
+    </>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════
+// ACTIVE BAR — floating toolbar on canvas (Altium-style)
+// ═══════════════════════════════════════════════════════════════
+
+function FpActiveBar({ editMode }: { editMode: FpEditMode }) {
+  const setEditMode = useFootprintEditorStore(s => s.setEditMode);
+  const [openMenu, setOpenMenu] = useState<string | null>(null);
+
+  const close = () => setOpenMenu(null);
+
+  return (
+    <>
+      {openMenu && <div className="absolute inset-0 z-30" onClick={close} />}
+      <div className="absolute top-3 left-1/2 -translate-x-1/2 z-40 flex items-center gap-px bg-bg-secondary/95 border border-border-subtle rounded-lg shadow-lg px-1 py-0.5">
+        {/* Filter */}
+        <ABBtn icon={<svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M3 4a1 1 0 011-1h16a1 1 0 01.8 1.6L14 14v5a1 1 0 01-.55.9l-4 2A1 1 0 018 21v-7L1.2 4.6A1 1 0 012 3h1z"/></svg>}
+          title="Filter" />
+
+        {/* Move — with dropdown */}
+        <ABBtn icon={<Move size={14} />} title="Move" hasMenu
+          menuOpen={openMenu === "move"} onMenuToggle={() => setOpenMenu(openMenu === "move" ? null : "move")}
+          menu={<>
+            <FpMenuItem label="Move" onClick={close} />
+            <FpMenuItem label="Rotate Selection" onClick={close} />
+            <FpMenuItem label="Bring To Front" onClick={close} />
+            <FpMenuItem label="Send To Back" onClick={close} />
+          </>} />
+
+        {/* Selection — with dropdown */}
+        <ABBtn icon={<MousePointer2 size={14} />} title="Select"
+          active={editMode === "select"}
+          onClick={() => setEditMode("select")}
+          hasMenu menuOpen={openMenu === "sel"} onMenuToggle={() => setOpenMenu(openMenu === "sel" ? null : "sel")}
+          menu={<>
+            <FpMenuItem label="Lasso Select" onClick={close} />
+            <FpMenuItem label="Inside Area" onClick={close} />
+            <FpMenuItem label="Touching Rectangle" onClick={close} />
+            <FpMenuItem label="All" onClick={close} />
+            <FpMenuItem label="Toggle Selection" onClick={close} />
+          </>} />
+
+        {/* Pad placement — with dropdown */}
+        <ABBtn icon={<Square size={14} />} title="Place Pad"
+          active={editMode === "addPadSmd" || editMode === "addPadTh"}
+          onClick={() => setEditMode("addPadSmd")}
+          hasMenu menuOpen={openMenu === "pad"} onMenuToggle={() => setOpenMenu(openMenu === "pad" ? null : "pad")}
+          menu={<>
+            <FpMenuItem label="SMD Pad" icon={<Square size={12} />} onClick={() => { setEditMode("addPadSmd"); close(); }} />
+            <FpMenuItem label="Through-Hole Pad" icon={<CircleDot size={12} />} onClick={() => { setEditMode("addPadTh"); close(); }} />
+          </>} />
+
+        {/* Align — with dropdown */}
+        <ABBtn icon={<AlignLeft size={14} />} title="Align" hasMenu
+          menuOpen={openMenu === "align"} onMenuToggle={() => setOpenMenu(openMenu === "align" ? null : "align")}
+          menu={<>
+            <FpMenuItem label="Align Left" onClick={close} />
+            <FpMenuItem label="Align Right" onClick={close} />
+            <FpMenuItem label="Align Horizontal Centers" onClick={close} />
+            <FpMenuItem label="Distribute Horizontally" onClick={close} />
+            <FpMenuSep />
+            <FpMenuItem label="Align Top" onClick={close} />
+            <FpMenuItem label="Align Bottom" onClick={close} />
+            <FpMenuItem label="Align Vertical Centers" onClick={close} />
+            <FpMenuItem label="Distribute Vertically" onClick={close} />
+            <FpMenuSep />
+            <FpMenuItem label="Align To Grid" onClick={close} />
+          </>} />
+
+        {/* Draw — with dropdown */}
+        <ABBtn icon={<Minus size={14} />} title="Draw"
+          active={editMode === "addLine" || editMode === "addArc" || editMode === "addCircle" || editMode === "addRect"}
+          onClick={() => setEditMode("addLine")}
+          hasMenu menuOpen={openMenu === "draw"} onMenuToggle={() => setOpenMenu(openMenu === "draw" ? null : "draw")}
+          menu={<>
+            <FpMenuItem label="Line" icon={<Minus size={12} />} onClick={() => { setEditMode("addLine"); close(); }} />
+            <FpMenuItem label="Arc" icon={<Spline size={12} />} onClick={() => { setEditMode("addArc"); close(); }} />
+            <FpMenuItem label="Circle" icon={<Circle size={12} />} onClick={() => { setEditMode("addCircle"); close(); }} />
+            <FpMenuItem label="Rectangle" icon={<Square size={12} />} onClick={() => { setEditMode("addRect"); close(); }} />
+          </>} />
+
+        {/* Text — with dropdown */}
+        <ABBtn icon={<Type size={14} />} title="Text"
+          active={editMode === "addText"}
+          onClick={() => setEditMode("addText")}
+          hasMenu menuOpen={openMenu === "text"} onMenuToggle={() => setOpenMenu(openMenu === "text" ? null : "text")}
+          menu={<>
+            <FpMenuItem label="Text String" icon={<Type size={12} />} onClick={() => { setEditMode("addText"); close(); }} />
+          </>} />
+      </div>
+    </>
+  );
+}
+
+function ABBtn({ icon, title, active, onClick, hasMenu, menuOpen, onMenuToggle, menu }: {
+  icon: React.ReactNode; title: string; active?: boolean; onClick?: () => void;
+  hasMenu?: boolean; menuOpen?: boolean; onMenuToggle?: () => void; menu?: React.ReactNode;
+}) {
+  return (
+    <div className="relative">
+      <div className="flex items-center">
+        <button title={title} onClick={onClick}
+          className={cn("p-1.5 rounded-l transition-colors",
+            active ? "bg-accent/20 text-accent" : "text-text-secondary hover:bg-bg-hover hover:text-text-primary",
+            !hasMenu && "rounded-r"
+          )}>
+          {icon}
+        </button>
+        {hasMenu && (
+          <button onClick={onMenuToggle}
+            className={cn("px-0.5 py-1.5 rounded-r transition-colors border-l border-border-subtle/30",
+              menuOpen ? "bg-accent/20 text-accent" : "text-text-muted/40 hover:bg-bg-hover hover:text-text-primary"
+            )}>
+            <ChevronDown size={8} />
+          </button>
+        )}
+      </div>
+      {menuOpen && menu && (
+        <div className="absolute top-full left-0 mt-1 bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[160px] z-50">
+          {menu}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FpMenuItem({ label, icon, onClick, shortcut, hasSubmenu }: { label: string; icon?: React.ReactNode; onClick?: () => void; shortcut?: string; hasSubmenu?: boolean }) {
+  return (
+    <button onClick={onClick}
+      className="flex items-center gap-2 w-full px-3 py-1 text-[11px] text-text-secondary hover:bg-bg-hover hover:text-text-primary text-left">
+      {icon && <span className="w-4 shrink-0">{icon}</span>}
+      <span className="flex-1">{label}</span>
+      {shortcut && <span className="text-text-muted/40 text-[10px]">{shortcut}</span>}
+      {hasSubmenu && <ChevronRight size={10} className="text-text-muted/40" />}
+    </button>
+  );
+}
+
+function FpMenuSep() {
+  return <div className="my-1 border-t border-border-subtle" />;
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/src/canvas/FootprintEditorCanvas.tsx
+++ b/src/canvas/FootprintEditorCanvas.tsx
@@ -1,0 +1,437 @@
+import { useRef, useEffect, useCallback } from "react";
+import { useFootprintEditorStore } from "@/stores/footprintEditor";
+import type { FootprintData } from "@/stores/footprintEditor";
+import type { PcbGraphic } from "@/types/pcb";
+import { DEFAULT_LAYER_COLORS } from "@/types/pcb";
+
+const GRID_MM = 0.1; // 0.1mm grid for PCB
+const PAD_HIT_RADIUS = 0.3;
+
+const COLORS = {
+  bg: "#1a1b26",
+  grid: "#252535",
+  gridMajor: "#303050",
+  origin: "#e8667a",
+  selected: "#f9e04b",
+  cursor: "rgba(137, 180, 250, 0.4)",
+  padSmd: "#cc3333",
+  padTh: "#cc9933",
+  drill: "#1a1b26",
+};
+
+function layerColor(layer: string): string {
+  return DEFAULT_LAYER_COLORS[layer] || "#666666";
+}
+
+export function FootprintEditorCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef({ ox: 0, oy: 0, zoom: 80 }); // pixels per mm
+  const isPanningRef = useRef(false);
+  const panStartRef = useRef({ x: 0, y: 0, ox: 0, oy: 0 });
+  const cursorRef = useRef({ x: 0, y: 0 });
+  const rafRef = useRef(0);
+
+  const footprint = useFootprintEditorStore(s => s.footprint);
+  const selectedItem = useFootprintEditorStore(s => s.selectedItem);
+  const editMode = useFootprintEditorStore(s => s.editMode);
+  useFootprintEditorStore(s => s.activeLayer); // subscribe for re-render
+
+  const snap = useCallback((v: number) => Math.round(v / GRID_MM) * GRID_MM, []);
+
+  const screenToWorld = useCallback((sx: number, sy: number) => {
+    const v = viewRef.current;
+    return { x: (sx - v.ox) / v.zoom, y: (sy - v.oy) / v.zoom };
+  }, []);
+
+  const render = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    const v = viewRef.current;
+    const w = canvas.width / dpr, h = canvas.height / dpr;
+
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, w, h);
+    ctx.fillStyle = COLORS.bg;
+    ctx.fillRect(0, 0, w, h);
+
+    ctx.save();
+    ctx.translate(v.ox, v.oy);
+    ctx.scale(v.zoom, v.zoom);
+
+    // Grid
+    const tl = screenToWorld(0, 0);
+    const br = screenToWorld(w, h);
+    const gs = GRID_MM;
+    const majorEvery = 10;
+    ctx.globalAlpha = 0.3;
+
+    // Minor dots
+    ctx.fillStyle = COLORS.grid;
+    const startX = Math.floor(tl.x / gs) * gs;
+    const startY = Math.floor(tl.y / gs) * gs;
+    if (v.zoom > 30) {
+      for (let x = startX; x <= br.x; x += gs) {
+        for (let y = startY; y <= br.y; y += gs) {
+          ctx.fillRect(x - 0.01, y - 0.01, 0.02, 0.02);
+        }
+      }
+    }
+
+    // Major grid lines
+    const majorGs = gs * majorEvery;
+    ctx.strokeStyle = COLORS.gridMajor;
+    ctx.lineWidth = 0.01;
+    ctx.beginPath();
+    const smx = Math.floor(tl.x / majorGs) * majorGs;
+    const smy = Math.floor(tl.y / majorGs) * majorGs;
+    for (let x = smx; x <= br.x; x += majorGs) { ctx.moveTo(x, tl.y); ctx.lineTo(x, br.y); }
+    for (let y = smy; y <= br.y; y += majorGs) { ctx.moveTo(tl.x, y); ctx.lineTo(br.x, y); }
+    ctx.stroke();
+    ctx.globalAlpha = 1;
+
+    // Origin cross
+    ctx.strokeStyle = COLORS.origin;
+    ctx.lineWidth = 0.02;
+    ctx.beginPath();
+    ctx.moveTo(-1, 0); ctx.lineTo(1, 0);
+    ctx.moveTo(0, -1); ctx.lineTo(0, 1);
+    ctx.stroke();
+
+    if (footprint) {
+      renderFootprint(ctx, footprint, selectedItem, v.zoom);
+    }
+
+    // Cursor crosshair
+    const cw = cursorRef.current;
+    ctx.strokeStyle = COLORS.cursor;
+    ctx.lineWidth = 0.02;
+    ctx.setLineDash([0.1, 0.1]);
+    ctx.beginPath();
+    ctx.moveTo(cw.x - 1, cw.y); ctx.lineTo(cw.x + 1, cw.y);
+    ctx.moveTo(cw.x, cw.y - 1); ctx.lineTo(cw.x, cw.y + 1);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    ctx.restore();
+  }, [footprint, selectedItem, screenToWorld]);
+
+  // Resize
+  useEffect(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    if (!container || !canvas) return;
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const rect = container.getBoundingClientRect();
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.width = rect.width + "px";
+      canvas.style.height = rect.height + "px";
+      viewRef.current.ox = rect.width / 2;
+      viewRef.current.oy = rect.height / 2;
+      render();
+    };
+    const ro = new ResizeObserver(resize);
+    ro.observe(container);
+    resize();
+    return () => ro.disconnect();
+  }, [render]);
+
+  useEffect(() => {
+    cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(render);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [render]);
+
+  // Mouse handlers
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const sx = e.clientX - rect.left, sy = e.clientY - rect.top;
+
+    if (e.button === 1 || (e.button === 0 && e.altKey)) {
+      isPanningRef.current = true;
+      panStartRef.current = { x: e.clientX, y: e.clientY, ox: viewRef.current.ox, oy: viewRef.current.oy };
+      return;
+    }
+    if (e.button !== 0) return;
+
+    const world = screenToWorld(sx, sy);
+    const sw = { x: snap(world.x), y: snap(world.y) };
+    const store = useFootprintEditorStore.getState();
+    const fp = store.footprint;
+
+    if (store.editMode === "select" && fp) {
+      // Hit test pads
+      for (let i = 0; i < fp.pads.length; i++) {
+        const p = fp.pads[i];
+        const dx = world.x - p.position.x, dy = world.y - p.position.y;
+        if (Math.abs(dx) < p.size[0] / 2 + PAD_HIT_RADIUS && Math.abs(dy) < p.size[1] / 2 + PAD_HIT_RADIUS) {
+          store.setSelectedItem({ type: "pad", index: i });
+          return;
+        }
+      }
+      // Hit test graphics
+      for (let i = 0; i < fp.graphics.length; i++) {
+        if (hitTestGraphic(world, fp.graphics[i])) {
+          store.setSelectedItem({ type: "graphic", index: i });
+          return;
+        }
+      }
+      store.setSelectedItem(null);
+    } else if (store.editMode === "addPadSmd") {
+      const usedNums = new Set(fp ? fp.pads.map(p => parseInt(p.number)).filter(n => !isNaN(n)) : []);
+      let next = 1;
+      while (usedNums.has(next)) next++;
+      store.addPad({
+        uuid: crypto.randomUUID(),
+        number: String(next),
+        type: "smd",
+        shape: "roundrect",
+        position: sw,
+        size: [1.0, 1.2],
+        layers: ["F.Cu", "F.Paste", "F.Mask"],
+        roundrectRatio: 0.25,
+      });
+    } else if (store.editMode === "addPadTh") {
+      const usedNums = new Set(fp ? fp.pads.map(p => parseInt(p.number)).filter(n => !isNaN(n)) : []);
+      let next = 1;
+      while (usedNums.has(next)) next++;
+      store.addPad({
+        uuid: crypto.randomUUID(),
+        number: String(next),
+        type: "thru_hole",
+        shape: "circle",
+        position: sw,
+        size: [1.7, 1.7],
+        drill: { diameter: 1.0 },
+        layers: ["*.Cu", "*.Mask"],
+      });
+    } else if (store.editMode === "addLine") {
+      store.addGraphic({ type: "line", start: sw, end: { x: sw.x + 1, y: sw.y }, layer: store.activeLayer, width: 0.12 });
+      store.setEditMode("select");
+    } else if (store.editMode === "addRect") {
+      store.addGraphic({ type: "rect", start: { x: sw.x - 1, y: sw.y - 1 }, end: { x: sw.x + 1, y: sw.y + 1 }, layer: store.activeLayer, width: 0.12 });
+      store.setEditMode("select");
+    } else if (store.editMode === "addCircle") {
+      store.addGraphic({ type: "circle", center: sw, radius: 0.5, layer: store.activeLayer, width: 0.12 });
+      store.setEditMode("select");
+    } else if (store.editMode === "addArc") {
+      store.addGraphic({ type: "arc", start: { x: sw.x - 1, y: sw.y }, mid: { x: sw.x, y: sw.y - 1 }, end: { x: sw.x + 1, y: sw.y }, layer: store.activeLayer, width: 0.12 });
+      store.setEditMode("select");
+    } else if (store.editMode === "addText") {
+      const text = prompt("Enter text:");
+      if (text) {
+        store.addGraphic({ type: "text", text, position: sw, layer: store.activeLayer, fontSize: 1.0, rotation: 0 });
+      }
+      store.setEditMode("select");
+    }
+  }, [footprint, snap, screenToWorld]);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (isPanningRef.current) {
+      viewRef.current.ox = panStartRef.current.ox + e.clientX - panStartRef.current.x;
+      viewRef.current.oy = panStartRef.current.oy + e.clientY - panStartRef.current.y;
+      return;
+    }
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const world = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
+    cursorRef.current = { x: snap(world.x), y: snap(world.y) };
+  }, [snap, screenToWorld]);
+
+  const handleMouseUp = useCallback(() => { isPanningRef.current = false; }, []);
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const sx = e.clientX - rect.left, sy = e.clientY - rect.top;
+    const v = viewRef.current;
+    const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
+    const newZoom = Math.max(5, Math.min(1000, v.zoom * factor));
+    v.ox = sx - (sx - v.ox) * (newZoom / v.zoom);
+    v.oy = sy - (sy - v.oy) * (newZoom / v.zoom);
+    v.zoom = newZoom;
+  }, []);
+
+  // Keyboard
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      const store = useFootprintEditorStore.getState();
+      if (!store.active) return;
+      if (e.key === "Delete" || e.key === "Backspace") {
+        if (store.selectedItem?.type === "pad") store.removePad(store.selectedItem.index);
+        else if (store.selectedItem?.type === "graphic") store.removeGraphic(store.selectedItem.index);
+      }
+      if (e.ctrlKey && e.key === "z") { e.preventDefault(); store.undo(); }
+      if (e.ctrlKey && e.key === "y") { e.preventDefault(); store.redo(); }
+      if (e.key === "Escape") { store.setEditMode("select"); store.setSelectedItem(null); }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="w-full h-full relative">
+      <canvas ref={canvasRef}
+        onMouseDown={handleMouseDown} onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp} onMouseLeave={handleMouseUp}
+        onWheel={handleWheel}
+        className="absolute inset-0"
+        style={{ cursor: editMode === "select" ? "default" : "crosshair" }}
+      />
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════
+// RENDERING
+// ═══════════════════════════════════════════════════════════════
+
+function renderFootprint(
+  ctx: CanvasRenderingContext2D,
+  fp: FootprintData,
+  sel: ReturnType<typeof useFootprintEditorStore.getState>["selectedItem"],
+  zoom: number,
+) {
+  // Graphics (silkscreen, fab, courtyard)
+  for (let i = 0; i < fp.graphics.length; i++) {
+    const g = fp.graphics[i];
+    const isSelected = sel?.type === "graphic" && sel.index === i;
+    const color = isSelected ? COLORS.selected : layerColor(g.layer);
+    ctx.strokeStyle = color;
+    ctx.fillStyle = color;
+    ctx.lineWidth = Math.max("width" in g ? g.width : 0.1, 0.02);
+
+    if (g.type === "line") {
+      ctx.beginPath();
+      ctx.moveTo(g.start.x, g.start.y); ctx.lineTo(g.end.x, g.end.y);
+      ctx.stroke();
+    } else if (g.type === "rect") {
+      const rx = Math.min(g.start.x, g.end.x), ry = Math.min(g.start.y, g.end.y);
+      const rw = Math.abs(g.end.x - g.start.x), rh = Math.abs(g.end.y - g.start.y);
+      if (g.fill) { ctx.globalAlpha = 0.3; ctx.fillRect(rx, ry, rw, rh); ctx.globalAlpha = 1; }
+      ctx.strokeRect(rx, ry, rw, rh);
+    } else if (g.type === "circle") {
+      ctx.beginPath();
+      ctx.arc(g.center.x, g.center.y, g.radius, 0, Math.PI * 2);
+      if (g.fill) { ctx.globalAlpha = 0.3; ctx.fill(); ctx.globalAlpha = 1; }
+      ctx.stroke();
+    } else if (g.type === "arc") {
+      ctx.beginPath();
+      ctx.moveTo(g.start.x, g.start.y);
+      ctx.quadraticCurveTo(g.mid.x, g.mid.y, g.end.x, g.end.y);
+      ctx.stroke();
+    } else if (g.type === "poly" && g.points.length >= 2) {
+      ctx.beginPath();
+      ctx.moveTo(g.points[0].x, g.points[0].y);
+      for (let j = 1; j < g.points.length; j++) ctx.lineTo(g.points[j].x, g.points[j].y);
+      ctx.closePath();
+      if (g.fill) { ctx.globalAlpha = 0.3; ctx.fill(); ctx.globalAlpha = 1; }
+      ctx.stroke();
+    } else if (g.type === "text") {
+      const fs = g.fontSize * 0.8;
+      ctx.font = `${fs}px sans-serif`;
+      ctx.textBaseline = "middle";
+      ctx.textAlign = "center";
+      ctx.fillText(g.text, g.position.x, g.position.y);
+    }
+  }
+
+  // Pads
+  for (let i = 0; i < fp.pads.length; i++) {
+    const p = fp.pads[i];
+    const isSelected = sel?.type === "pad" && sel.index === i;
+    const px = p.position.x, py = p.position.y;
+    const sw = p.size[0], sh = p.size[1];
+
+    ctx.fillStyle = isSelected ? COLORS.selected : (p.type === "smd" ? COLORS.padSmd : COLORS.padTh);
+
+    if (p.shape === "circle") {
+      ctx.beginPath(); ctx.arc(px, py, sw / 2, 0, Math.PI * 2); ctx.fill();
+    } else if (p.shape === "roundrect") {
+      const r = (p.roundrectRatio ?? 0.25) * Math.min(sw, sh) / 2;
+      drawRoundRect(ctx, px - sw / 2, py - sh / 2, sw, sh, r);
+      ctx.fill();
+    } else if (p.shape === "oval") {
+      ctx.beginPath(); ctx.ellipse(px, py, sw / 2, sh / 2, 0, 0, Math.PI * 2); ctx.fill();
+    } else {
+      ctx.fillRect(px - sw / 2, py - sh / 2, sw, sh);
+    }
+
+    // Drill hole
+    if (p.type === "thru_hole" && p.drill) {
+      ctx.fillStyle = COLORS.drill;
+      ctx.beginPath(); ctx.arc(px, py, p.drill.diameter / 2, 0, Math.PI * 2); ctx.fill();
+    }
+
+    // Pad number
+    if (p.number) {
+      const fs = Math.min(sw, sh) * 0.45;
+      if (fs * zoom > 4) {
+        ctx.fillStyle = isSelected ? "#000" : "#fff";
+        ctx.font = `${fs}px sans-serif`;
+        ctx.textAlign = "center"; ctx.textBaseline = "middle";
+        ctx.fillText(p.number, px, py);
+      }
+    }
+
+    // Selection outline
+    if (isSelected) {
+      ctx.strokeStyle = COLORS.selected;
+      ctx.lineWidth = 0.05;
+      ctx.setLineDash([0.1, 0.1]);
+      ctx.strokeRect(px - sw / 2 - 0.1, py - sh / 2 - 0.1, sw + 0.2, sh + 0.2);
+      ctx.setLineDash([]);
+    }
+  }
+}
+
+function drawRoundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
+  r = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y); ctx.arcTo(x + w, y, x + w, y + r, r);
+  ctx.lineTo(x + w, y + h - r); ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+  ctx.lineTo(x + r, y + h); ctx.arcTo(x, y + h, x, y + h - r, r);
+  ctx.lineTo(x, y + r); ctx.arcTo(x, y, x + r, y, r);
+  ctx.closePath();
+}
+
+function hitTestGraphic(point: { x: number; y: number }, g: PcbGraphic): boolean {
+  const tol = 0.3;
+  if (g.type === "line") {
+    return pointToSegDist(point, g.start, g.end) < tol;
+  }
+  if (g.type === "rect") {
+    const rx = Math.min(g.start.x, g.end.x) - tol, ry = Math.min(g.start.y, g.end.y) - tol;
+    return point.x >= rx && point.x <= Math.max(g.start.x, g.end.x) + tol &&
+           point.y >= ry && point.y <= Math.max(g.start.y, g.end.y) + tol;
+  }
+  if (g.type === "circle") {
+    const d = Math.hypot(point.x - g.center.x, point.y - g.center.y);
+    return g.fill ? d <= g.radius + tol : Math.abs(d - g.radius) < tol;
+  }
+  if (g.type === "text") {
+    return Math.hypot(point.x - g.position.x, point.y - g.position.y) < 1;
+  }
+  return false;
+}
+
+function pointToSegDist(p: { x: number; y: number }, a: { x: number; y: number }, b: { x: number; y: number }): number {
+  const dx = b.x - a.x, dy = b.y - a.y;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq === 0) return Math.hypot(p.x - a.x, p.y - a.y);
+  let t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / lenSq;
+  t = Math.max(0, Math.min(1, t));
+  return Math.hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy));
+}

--- a/src/canvas/LibraryEditorCanvas.tsx
+++ b/src/canvas/LibraryEditorCanvas.tsx
@@ -201,24 +201,32 @@ export function LibraryEditorCanvas() {
 
       const store = useLibraryEditorStore.getState();
 
-      if (store.editMode === "select" && symbol) {
+      if (store.editMode === "select") {
+        const sym = store.symbol;
+        if (!sym) return;
         // Hit test pins
-        for (let i = 0; i < symbol.pins.length; i++) {
-          const pin = symbol.pins[i];
+        for (let i = 0; i < sym.pins.length; i++) {
+          const pin = sym.pins[i];
           const pe = pinEnd(pin);
           if (dist(world, pin.position) < PIN_HIT_RADIUS || dist(world, pe) < PIN_HIT_RADIUS) {
             store.setSelectedItem({ type: "pin", index: i });
+            cancelAnimationFrame(rafRef.current);
+            rafRef.current = requestAnimationFrame(render);
             return;
           }
         }
         // Hit test graphics
-        for (let i = 0; i < symbol.graphics.length; i++) {
-          if (hitTestGraphic(world, symbol.graphics[i])) {
+        for (let i = 0; i < sym.graphics.length; i++) {
+          if (hitTestGraphic(world, sym.graphics[i])) {
             store.setSelectedItem({ type: "graphic", index: i });
+            cancelAnimationFrame(rafRef.current);
+            rafRef.current = requestAnimationFrame(render);
             return;
           }
         }
         store.setSelectedItem(null);
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = requestAnimationFrame(render);
       } else if (store.editMode === "addPin") {
         // Auto-increment: find next unused pin number
         const usedNums = new Set(symbol ? symbol.pins.map((p) => parseInt(p.number, 10)).filter((n) => !isNaN(n)) : []);
@@ -236,6 +244,8 @@ export function LibraryEditorCanvas() {
           number_visible: true,
         });
         // Stay in addPin mode for rapid placement (right-click or Escape to exit)
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = requestAnimationFrame(render);
       } else if (store.editMode === "addRect") {
         store.addGraphic({
           type: "Rectangle",
@@ -327,6 +337,8 @@ export function LibraryEditorCanvas() {
         const dy = e.clientY - panStartRef.current.y;
         viewRef.current.offsetX = panStartRef.current.ox + dx;
         viewRef.current.offsetY = panStartRef.current.oy + dy;
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = requestAnimationFrame(render);
         return;
       }
       const canvas = canvasRef.current;
@@ -336,8 +348,10 @@ export function LibraryEditorCanvas() {
       const sy = e.clientY - rect.top;
       const world = screenToWorld(sx, sy);
       cursorWorldRef.current = { x: snap(world.x), y: snap(world.y) };
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(render);
     },
-    [snap, screenToWorld]
+    [snap, screenToWorld, render]
   );
 
   const handleMouseUp = useCallback(() => {
@@ -358,8 +372,10 @@ export function LibraryEditorCanvas() {
       v.offsetX = sx - (sx - v.offsetX) * (newZoom / v.zoom);
       v.offsetY = sy - (sy - v.offsetY) * (newZoom / v.zoom);
       v.zoom = newZoom;
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(render);
     },
-    []
+    [render]
   );
 
   // Keyboard

--- a/src/canvas/LibraryEditorCanvas.tsx
+++ b/src/canvas/LibraryEditorCanvas.tsx
@@ -4,7 +4,7 @@ import { useEditorStore } from "@/stores/editor";
 import type { LibSymbol, SchPin, Graphic, SchPoint } from "@/types";
 import {
   MousePointer2, Move, Pin, Square, Minus, Circle, Spline, Type, Hexagon,
-  AlignLeft, X as XIcon, ChevronDown,
+  AlignLeft, X as XIcon, ChevronDown, ChevronRight,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { LibEditMode } from "@/stores/libraryEditor";
@@ -403,6 +403,13 @@ export function LibraryEditorCanvas() {
     return () => window.removeEventListener("keydown", handler);
   }, []);
 
+  const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
+
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setCtxMenu({ x: e.clientX, y: e.clientY });
+  }, []);
+
   return (
     <div ref={containerRef} className="w-full h-full relative">
       <canvas
@@ -412,12 +419,93 @@ export function LibraryEditorCanvas() {
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseUp}
         onWheel={handleWheel}
+        onContextMenu={handleContextMenu}
         className="absolute inset-0"
         style={{ cursor: editMode === "select" ? "default" : "crosshair" }}
       />
       {/* Floating Active Bar (Altium-style) */}
       <LibActiveBar editMode={editMode} />
+      {/* Right-click context menu */}
+      {ctxMenu && <LibCanvasContextMenu x={ctxMenu.x} y={ctxMenu.y} onClose={() => setCtxMenu(null)} />}
     </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════
+// CANVAS RIGHT-CLICK CONTEXT MENU (Altium-style)
+// ═══════════════════════════════════════════════════════════════
+
+function LibCanvasContextMenu({ x, y, onClose }: { x: number; y: number; onClose: () => void }) {
+  const setEditMode = useLibraryEditorStore(s => s.setEditMode);
+  const [sub, setSub] = useState<string | null>(null);
+
+  const act = (fn?: () => void) => { fn?.(); onClose(); };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-[80]" onClick={onClose} />
+      <div className="fixed z-[85] bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[200px] text-[11px]"
+        style={{ left: Math.min(x, window.innerWidth - 220), top: Math.min(y, window.innerHeight - 400) }}>
+        <MenuItem label="Find Similar Objects..." onClick={() => act()} />
+        <MenuItem label="Clear Filter" shortcut="Shift+C" onClick={() => act()} />
+        <MenuSep />
+
+        {/* Place submenu */}
+        <div className="relative" onMouseEnter={() => setSub("place")} onMouseLeave={() => setSub(null)}>
+          <MenuItem label="Place" hasSubmenu />
+          {sub === "place" && (
+            <div className="absolute left-full top-0 bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[180px]">
+              <MenuItem label="Pin" icon={<Pin size={12} />} onClick={() => act(() => setEditMode("addPin"))} />
+              <MenuItem label="Arc" icon={<Spline size={12} />} onClick={() => act(() => setEditMode("addArc"))} />
+              <MenuItem label="Full Circle" icon={<Circle size={12} />} onClick={() => act(() => setEditMode("addCircle"))} />
+              <MenuItem label="Ellipse" icon={<Circle size={12} />} onClick={() => act(() => setEditMode("addEllipse"))} />
+              <MenuItem label="Line" icon={<Minus size={12} />} onClick={() => act(() => setEditMode("addPolyline"))} />
+              <MenuItem label="Rectangle" icon={<Square size={12} />} onClick={() => act(() => setEditMode("addRect"))} />
+              <MenuItem label="Polygon" icon={<Hexagon size={12} />} onClick={() => act(() => setEditMode("addPolygon"))} />
+              <MenuSep />
+              <MenuItem label="Text String" icon={<Type size={12} />} onClick={() => act(() => setEditMode("addText"))} />
+            </div>
+          )}
+        </div>
+
+        {/* Tools submenu */}
+        <div className="relative" onMouseEnter={() => setSub("tools")} onMouseLeave={() => setSub(null)}>
+          <MenuItem label="Tools" hasSubmenu />
+          {sub === "tools" && (
+            <div className="absolute left-full top-0 bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[180px]">
+              <MenuItem label="New Component" onClick={() => act()} />
+              <MenuItem label="Remove Component" onClick={() => act()} />
+              <MenuSep />
+              <MenuItem label="New Part" onClick={() => act()} />
+              <MenuItem label="Remove Part" onClick={() => act()} />
+              <MenuItem label="Next Part" onClick={() => act()} />
+            </div>
+          )}
+        </div>
+
+        {/* View submenu */}
+        <div className="relative" onMouseEnter={() => setSub("view")} onMouseLeave={() => setSub(null)}>
+          <MenuItem label="View" hasSubmenu />
+          {sub === "view" && (
+            <div className="absolute left-full top-0 bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[180px]">
+              <MenuItem label="Fit All Objects" shortcut="Ctrl+PgDn" onClick={() => act()} />
+              <MenuItem label="Fit Document" onClick={() => act()} />
+              <MenuSep />
+              <MenuItem label="Zoom In" shortcut="PgUp" onClick={() => act()} />
+              <MenuItem label="Zoom Out" shortcut="PgDn" onClick={() => act()} />
+            </div>
+          )}
+        </div>
+
+        <MenuSep />
+        <MenuItem label="Cut" shortcut="Ctrl+X" onClick={() => act()} />
+        <MenuItem label="Copy" shortcut="Ctrl+C" onClick={() => act()} />
+        <MenuItem label="Paste" shortcut="Ctrl+V" onClick={() => act()} />
+        <MenuSep />
+        <MenuItem label="Preferences..." onClick={() => act()} />
+        <MenuItem label="Supplier Links..." onClick={() => act()} />
+      </div>
+    </>
   );
 }
 
@@ -546,12 +634,14 @@ function ABBtn({ icon, title, active, onClick, hasMenu, menuOpen, onMenuToggle, 
   );
 }
 
-function MenuItem({ label, icon, onClick }: { label: string; icon?: React.ReactNode; onClick?: () => void }) {
+function MenuItem({ label, icon, onClick, shortcut, hasSubmenu }: { label: string; icon?: React.ReactNode; onClick?: () => void; shortcut?: string; hasSubmenu?: boolean }) {
   return (
     <button onClick={onClick}
       className="flex items-center gap-2 w-full px-3 py-1 text-[11px] text-text-secondary hover:bg-bg-hover hover:text-text-primary text-left">
       {icon && <span className="w-4 shrink-0">{icon}</span>}
-      {label}
+      <span className="flex-1">{label}</span>
+      {shortcut && <span className="text-text-muted/40 text-[10px]">{shortcut}</span>}
+      {hasSubmenu && <ChevronRight size={10} className="text-text-muted/40" />}
     </button>
   );
 }

--- a/src/canvas/LibraryEditorCanvas.tsx
+++ b/src/canvas/LibraryEditorCanvas.tsx
@@ -1,7 +1,13 @@
-import { useRef, useEffect, useCallback } from "react";
+import { useRef, useEffect, useCallback, useState } from "react";
 import { useLibraryEditorStore } from "@/stores/libraryEditor";
 import { useEditorStore } from "@/stores/editor";
 import type { LibSymbol, SchPin, Graphic, SchPoint } from "@/types";
+import {
+  MousePointer2, Move, Pin, Square, Minus, Circle, Spline, Type, Hexagon,
+  AlignLeft, X as XIcon, ChevronDown,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { LibEditMode } from "@/stores/libraryEditor";
 
 const GRID_SIZE = 1.27; // mm
 const PIN_HIT_RADIUS = 1.0;
@@ -409,8 +415,149 @@ export function LibraryEditorCanvas() {
         className="absolute inset-0"
         style={{ cursor: editMode === "select" ? "default" : "crosshair" }}
       />
+      {/* Floating Active Bar (Altium-style) */}
+      <LibActiveBar editMode={editMode} />
     </div>
   );
+}
+
+// ═══════════════════════════════════════════════════════════════
+// ACTIVE BAR — floating toolbar on canvas (Altium-style)
+// ═══════════════════════════════════════════════════════════════
+
+function LibActiveBar({ editMode }: { editMode: LibEditMode }) {
+  const setEditMode = useLibraryEditorStore(s => s.setEditMode);
+  const [openMenu, setOpenMenu] = useState<string | null>(null);
+
+  const close = () => setOpenMenu(null);
+
+  return (
+    <>
+      {openMenu && <div className="absolute inset-0 z-30" onClick={close} />}
+      <div className="absolute top-3 left-1/2 -translate-x-1/2 z-40 flex items-center gap-px bg-bg-secondary/95 border border-border-subtle rounded-lg shadow-lg px-1 py-0.5">
+        {/* Filter */}
+        <ABBtn icon={<svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M3 4a1 1 0 011-1h16a1 1 0 01.8 1.6L14 14v5a1 1 0 01-.55.9l-4 2A1 1 0 018 21v-7L1.2 4.6A1 1 0 012 3h1z"/></svg>}
+          title="Filter" />
+
+        {/* Move — with dropdown */}
+        <ABBtn icon={<Move size={14} />} title="Move" hasMenu
+          menuOpen={openMenu === "move"} onMenuToggle={() => setOpenMenu(openMenu === "move" ? null : "move")}
+          menu={<>
+            <MenuItem label="Move" onClick={close} />
+            <MenuItem label="Rotate Selection" onClick={() => { close(); }} />
+            <MenuItem label="Bring To Front" onClick={close} />
+            <MenuItem label="Send To Back" onClick={close} />
+          </>} />
+
+        {/* Selection — with dropdown */}
+        <ABBtn icon={<MousePointer2 size={14} />} title="Select"
+          active={editMode === "select"}
+          onClick={() => setEditMode("select")}
+          hasMenu menuOpen={openMenu === "sel"} onMenuToggle={() => setOpenMenu(openMenu === "sel" ? null : "sel")}
+          menu={<>
+            <MenuItem label="Lasso Select" onClick={close} />
+            <MenuItem label="Inside Area" onClick={close} />
+            <MenuItem label="Touching Rectangle" onClick={close} />
+            <MenuItem label="All" onClick={close} />
+            <MenuItem label="Toggle Selection" onClick={close} />
+          </>} />
+
+        {/* Place Component */}
+        <ABBtn icon={<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>}
+          title="Place Component" />
+
+        {/* Place Pin */}
+        <ABBtn icon={<Pin size={14} />} title="Place Pin"
+          active={editMode === "addPin"}
+          onClick={() => setEditMode("addPin")} />
+
+        {/* Align — with dropdown */}
+        <ABBtn icon={<AlignLeft size={14} />} title="Align" hasMenu
+          menuOpen={openMenu === "align"} onMenuToggle={() => setOpenMenu(openMenu === "align" ? null : "align")}
+          menu={<>
+            <MenuItem label="Align Left" onClick={close} />
+            <MenuItem label="Align Right" onClick={close} />
+            <MenuItem label="Align Horizontal Centers" onClick={close} />
+            <MenuItem label="Distribute Horizontally" onClick={close} />
+            <MenuSep />
+            <MenuItem label="Align Top" onClick={close} />
+            <MenuItem label="Align Bottom" onClick={close} />
+            <MenuItem label="Align Vertical Centers" onClick={close} />
+            <MenuItem label="Distribute Vertically" onClick={close} />
+            <MenuSep />
+            <MenuItem label="Align To Grid" onClick={close} />
+          </>} />
+
+        {/* No Connect */}
+        <ABBtn icon={<XIcon size={14} />} title="No Connect" />
+
+        {/* Draw — with dropdown */}
+        <ABBtn icon={<Minus size={14} />} title="Draw" hasMenu
+          menuOpen={openMenu === "draw"} onMenuToggle={() => setOpenMenu(openMenu === "draw" ? null : "draw")}
+          menu={<>
+            <MenuItem label="Line" icon={<Minus size={12} />} onClick={() => { setEditMode("addPolyline"); close(); }} />
+            <MenuItem label="Arc" icon={<Spline size={12} />} onClick={() => { setEditMode("addArc"); close(); }} />
+            <MenuItem label="Full Circle" icon={<Circle size={12} />} onClick={() => { setEditMode("addCircle"); close(); }} />
+            <MenuItem label="Ellipse" icon={<Circle size={12} />} onClick={() => { setEditMode("addEllipse"); close(); }} />
+            <MenuItem label="Rectangle" icon={<Square size={12} />} onClick={() => { setEditMode("addRect"); close(); }} />
+            <MenuItem label="Polygon" icon={<Hexagon size={12} />} onClick={() => { setEditMode("addPolygon"); close(); }} />
+          </>} />
+
+        {/* Text — with dropdown */}
+        <ABBtn icon={<Type size={14} />} title="Text" hasMenu
+          menuOpen={openMenu === "text"} onMenuToggle={() => setOpenMenu(openMenu === "text" ? null : "text")}
+          menu={<>
+            <MenuItem label="Text String" icon={<Type size={12} />} onClick={() => { setEditMode("addText"); close(); }} />
+          </>} />
+      </div>
+    </>
+  );
+}
+
+function ABBtn({ icon, title, active, onClick, hasMenu, menuOpen, onMenuToggle, menu }: {
+  icon: React.ReactNode; title: string; active?: boolean; onClick?: () => void;
+  hasMenu?: boolean; menuOpen?: boolean; onMenuToggle?: () => void; menu?: React.ReactNode;
+}) {
+  return (
+    <div className="relative">
+      <div className="flex items-center">
+        <button title={title} onClick={onClick}
+          className={cn("p-1.5 rounded-l transition-colors",
+            active ? "bg-accent/20 text-accent" : "text-text-secondary hover:bg-bg-hover hover:text-text-primary",
+            !hasMenu && "rounded-r"
+          )}>
+          {icon}
+        </button>
+        {hasMenu && (
+          <button onClick={onMenuToggle}
+            className={cn("px-0.5 py-1.5 rounded-r transition-colors border-l border-border-subtle/30",
+              menuOpen ? "bg-accent/20 text-accent" : "text-text-muted/40 hover:bg-bg-hover hover:text-text-primary"
+            )}>
+            <ChevronDown size={8} />
+          </button>
+        )}
+      </div>
+      {menuOpen && menu && (
+        <div className="absolute top-full left-0 mt-1 bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[160px] z-50">
+          {menu}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MenuItem({ label, icon, onClick }: { label: string; icon?: React.ReactNode; onClick?: () => void }) {
+  return (
+    <button onClick={onClick}
+      className="flex items-center gap-2 w-full px-3 py-1 text-[11px] text-text-secondary hover:bg-bg-hover hover:text-text-primary text-left">
+      {icon && <span className="w-4 shrink-0">{icon}</span>}
+      {label}
+    </button>
+  );
+}
+
+function MenuSep() {
+  return <div className="my-1 border-t border-border-subtle" />;
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/src/canvas/PcbRenderer.tsx
+++ b/src/canvas/PcbRenderer.tsx
@@ -644,6 +644,30 @@ export function PcbRenderer() {
       ctx.stroke();
       ctx.setLineDash([]);
       ctx.globalAlpha = 1;
+
+      // Online DRC during routing — show violation markers
+      if (routingPoints.length >= 2) {
+        import("@/lib/pcbRouter").then(({ checkOnlineDrc }) => {
+          const routeSegs = [];
+          const store = usePcbStore.getState();
+          for (let i = 1; i < routingPoints.length; i++) {
+            routeSegs.push({
+              uuid: "", start: routingPoints[i - 1], end: routingPoints[i],
+              width: store.routingWidth, layer: store.routingLayer, net: store.routingNet,
+            });
+          }
+          const violations = checkOnlineDrc(data, routeSegs, data.board?.setup?.clearance || 0.2);
+          for (const v of violations) {
+            ctx.fillStyle = "rgba(255, 0, 0, 0.4)";
+            ctx.beginPath();
+            ctx.arc(v.position.x, v.position.y, 0.5, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.strokeStyle = "#ff0000";
+            ctx.lineWidth = 0.08;
+            ctx.stroke();
+          }
+        });
+      }
     }
 
     // Selection highlight

--- a/src/canvas/PcbRenderer.tsx
+++ b/src/canvas/PcbRenderer.tsx
@@ -6,6 +6,9 @@ import { useProjectStore } from "@/stores/project";
 import { DEFAULT_LAYER_COLORS, LAYER_DISPLAY_NAMES } from "@/types/pcb";
 import { computeRatsnest, getPadPosition } from "@/lib/pcbRatsnest";
 import { ContextMenu, type ContextMenuItem } from "@/components/ContextMenu";
+import { checkOnlineDrc, generateTeardrops } from "@/lib/pcbRouter";
+import { alignFootprints } from "@/lib/pcbPlacement";
+import { fillZones } from "@/lib/pcbCopperPour";
 import type { PcbData, PcbPoint, PcbLayerId } from "@/types/pcb";
 
 interface Camera { x: number; y: number; zoom: number }
@@ -645,28 +648,26 @@ export function PcbRenderer() {
       ctx.setLineDash([]);
       ctx.globalAlpha = 1;
 
-      // Online DRC during routing — show violation markers
+      // Online DRC during routing — show violation markers (synchronous)
       if (routingPoints.length >= 2) {
-        import("@/lib/pcbRouter").then(({ checkOnlineDrc }) => {
-          const routeSegs = [];
-          const store = usePcbStore.getState();
-          for (let i = 1; i < routingPoints.length; i++) {
-            routeSegs.push({
-              uuid: "", start: routingPoints[i - 1], end: routingPoints[i],
-              width: store.routingWidth, layer: store.routingLayer, net: store.routingNet,
-            });
-          }
-          const violations = checkOnlineDrc(data, routeSegs, data.board?.setup?.clearance || 0.2);
-          for (const v of violations) {
-            ctx.fillStyle = "rgba(255, 0, 0, 0.4)";
-            ctx.beginPath();
-            ctx.arc(v.position.x, v.position.y, 0.5, 0, Math.PI * 2);
-            ctx.fill();
-            ctx.strokeStyle = "#ff0000";
-            ctx.lineWidth = 0.08;
-            ctx.stroke();
-          }
-        });
+        const routeSegs = [];
+        const pcbState = usePcbStore.getState();
+        for (let i = 1; i < routingPoints.length; i++) {
+          routeSegs.push({
+            uuid: "", start: routingPoints[i - 1], end: routingPoints[i],
+            width: pcbState.routingWidth, layer: pcbState.routingLayer, net: pcbState.routingNet,
+          });
+        }
+        const violations = checkOnlineDrc(data, routeSegs, data.board?.setup?.clearance || 0.2);
+        for (const v of violations) {
+          ctx.fillStyle = "rgba(255, 0, 0, 0.4)";
+          ctx.beginPath();
+          ctx.arc(v.position.x, v.position.y, 0.5, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.strokeStyle = "#ff0000";
+          ctx.lineWidth = 0.08;
+          ctx.stroke();
+        }
       }
     }
 
@@ -799,10 +800,10 @@ export function PcbRenderer() {
         items.push({ separator: true, label: "", action: () => {} });
         // Alignment (when multiple selected)
         if (sel.size >= 2) {
-          items.push({ label: "Align Left", action: () => { import("@/lib/pcbPlacement").then(m => m.alignFootprints("left")); } });
-          items.push({ label: "Align Right", action: () => { import("@/lib/pcbPlacement").then(m => m.alignFootprints("right")); } });
-          items.push({ label: "Align Top", action: () => { import("@/lib/pcbPlacement").then(m => m.alignFootprints("top")); } });
-          items.push({ label: "Align Bottom", action: () => { import("@/lib/pcbPlacement").then(m => m.alignFootprints("bottom")); } });
+          items.push({ label: "Align Left", action: () => { alignFootprints("left"); } });
+          items.push({ label: "Align Right", action: () => { alignFootprints("right"); } });
+          items.push({ label: "Align Top", action: () => { alignFootprints("top"); } });
+          items.push({ label: "Align Bottom", action: () => { alignFootprints("bottom"); } });
           items.push({ separator: true, label: "", action: () => {} });
         }
         items.push({ label: "Select All", shortcut: "Ctrl+A", action: () => store.selectAll() });
@@ -815,23 +816,19 @@ export function PcbRenderer() {
         items.push({ label: "Place Zone", action: () => store.setEditMode("placeZone") });
         items.push({ separator: true, label: "", action: () => {} });
         items.push({ label: "Fill All Zones", action: () => {
-          import("@/lib/pcbCopperPour").then(m => {
-            if (!data) return;
-            store.pushUndo();
-            const nd = structuredClone(data);
-            m.fillZones(nd);
-            usePcbStore.setState({ data: nd, dirty: true });
-          });
+          if (!data) return;
+          store.pushUndo();
+          const nd = structuredClone(data);
+          fillZones(nd);
+          usePcbStore.setState({ data: nd, dirty: true });
         }});
         items.push({ label: "Generate Teardrops", action: () => {
-          import("@/lib/pcbRouter").then(m => {
-            if (!data) return;
-            store.pushUndo();
-            const nd = structuredClone(data);
-            const newSegs = m.generateTeardrops(nd, 0.5, 0.5);
-            nd.segments = [...nd.segments, ...newSegs];
-            usePcbStore.setState({ data: nd, dirty: true });
-          });
+          if (!data) return;
+          store.pushUndo();
+          const nd = structuredClone(data);
+          const newSegs = generateTeardrops(nd, 0.5, 0.5);
+          nd.segments = [...nd.segments, ...newSegs];
+          usePcbStore.setState({ data: nd, dirty: true });
         }});
       }
 

--- a/src/canvas/PcbRenderer.tsx
+++ b/src/canvas/PcbRenderer.tsx
@@ -773,6 +773,14 @@ export function PcbRenderer() {
         items.push({ label: "Rotate 90\u00b0", shortcut: "Space", action: () => { for (const id of sel) store.rotateFootprint(id, 90); } });
         items.push({ label: "Flip Side", shortcut: "F", action: () => { for (const id of sel) store.flipFootprint(id); } });
         items.push({ separator: true, label: "", action: () => {} });
+        // Alignment (when multiple selected)
+        if (sel.size >= 2) {
+          items.push({ label: "Align Left", action: () => { import("@/lib/pcbPlacement").then(m => m.alignFootprints("left")); } });
+          items.push({ label: "Align Right", action: () => { import("@/lib/pcbPlacement").then(m => m.alignFootprints("right")); } });
+          items.push({ label: "Align Top", action: () => { import("@/lib/pcbPlacement").then(m => m.alignFootprints("top")); } });
+          items.push({ label: "Align Bottom", action: () => { import("@/lib/pcbPlacement").then(m => m.alignFootprints("bottom")); } });
+          items.push({ separator: true, label: "", action: () => {} });
+        }
         items.push({ label: "Select All", shortcut: "Ctrl+A", action: () => store.selectAll() });
       } else {
         items.push({ label: "Select All", shortcut: "Ctrl+A", action: () => store.selectAll() });
@@ -781,6 +789,26 @@ export function PcbRenderer() {
         items.push({ label: "Place Via", action: () => store.setEditMode("placeVia") });
         items.push({ label: "Board Outline", action: () => store.setEditMode("drawBoardOutline") });
         items.push({ label: "Place Zone", action: () => store.setEditMode("placeZone") });
+        items.push({ separator: true, label: "", action: () => {} });
+        items.push({ label: "Fill All Zones", action: () => {
+          import("@/lib/pcbCopperPour").then(m => {
+            if (!data) return;
+            store.pushUndo();
+            const nd = structuredClone(data);
+            m.fillZones(nd);
+            usePcbStore.setState({ data: nd, dirty: true });
+          });
+        }});
+        items.push({ label: "Generate Teardrops", action: () => {
+          import("@/lib/pcbRouter").then(m => {
+            if (!data) return;
+            store.pushUndo();
+            const nd = structuredClone(data);
+            const newSegs = m.generateTeardrops(nd, 0.5, 0.5);
+            nd.segments = [...nd.segments, ...newSegs];
+            usePcbStore.setState({ data: nd, dirty: true });
+          });
+        }});
       }
 
       if (items.length > 0) {

--- a/src/components/BackAnnotationDialog.tsx
+++ b/src/components/BackAnnotationDialog.tsx
@@ -1,0 +1,138 @@
+import { useState, useMemo } from "react";
+import { X, ArrowRight, AlertTriangle, CheckCircle2 } from "lucide-react";
+import { useSchematicStore } from "@/stores/schematic";
+import { usePcbStore } from "@/stores/pcb";
+import { detectEcoChanges, applyEcoChanges } from "@/lib/pcbBackAnnotation";
+import type { EcoChange } from "@/lib/pcbBackAnnotation";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  reference_changed: "Reference Changed",
+  value_changed: "Value Changed",
+  footprint_changed: "Footprint Changed",
+  component_added: "Added in PCB",
+  component_removed: "Removed from PCB",
+};
+
+const TYPE_COLORS: Record<string, string> = {
+  reference_changed: "text-accent",
+  value_changed: "text-warning",
+  footprint_changed: "text-info",
+  component_added: "text-success",
+  component_removed: "text-error",
+};
+
+export function BackAnnotationDialog({ open, onClose }: Props) {
+  const schData = useSchematicStore((s) => s.data);
+  const pcbData = usePcbStore((s) => s.data);
+  const [applied, setApplied] = useState(false);
+
+  const changes = useMemo<EcoChange[]>(() => {
+    if (!schData || !pcbData) return [];
+    return detectEcoChanges(schData, pcbData);
+  }, [schData, pcbData]);
+
+  if (!open) return null;
+
+  const handleApply = () => {
+    if (!schData || changes.length === 0) return;
+    const count = applyEcoChanges(schData, changes);
+    if (count > 0) {
+      useSchematicStore.setState({ dirty: true });
+    }
+    setApplied(true);
+  };
+
+  const handleClose = () => {
+    setApplied(false);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
+      <div className="bg-bg-secondary border border-border-subtle rounded-lg shadow-2xl w-[560px] max-h-[80vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-2.5 border-b border-border-subtle">
+          <span className="text-xs font-semibold">Back Annotate from PCB</span>
+          <button onClick={handleClose} className="p-0.5 hover:bg-bg-hover rounded"><X size={14} /></button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {!schData || !pcbData ? (
+            <div className="text-[11px] text-text-muted text-center py-8">
+              Both schematic and PCB must be loaded to detect changes.
+            </div>
+          ) : changes.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-8">
+              <CheckCircle2 size={24} className="text-success" />
+              <span className="text-[11px] text-text-muted">Schematic and PCB are in sync. No changes needed.</span>
+            </div>
+          ) : (
+            <>
+              <div className="text-[11px] text-text-secondary mb-3">
+                {changes.length} change{changes.length !== 1 ? "s" : ""} detected between PCB and schematic:
+              </div>
+              <table className="w-full text-[10px]">
+                <thead>
+                  <tr className="text-text-muted border-b border-border-subtle">
+                    <th className="text-left py-1 px-2">Reference</th>
+                    <th className="text-left py-1 px-2">Change</th>
+                    <th className="text-left py-1 px-2">Schematic</th>
+                    <th className="text-center py-1 px-2"></th>
+                    <th className="text-left py-1 px-2">PCB</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {changes.map((c, i) => (
+                    <tr key={i} className="border-b border-border-subtle/30 hover:bg-bg-hover/30">
+                      <td className="py-1.5 px-2 font-mono font-medium">{c.reference}</td>
+                      <td className={cn("py-1.5 px-2", TYPE_COLORS[c.type])}>
+                        {TYPE_LABELS[c.type] || c.type}
+                      </td>
+                      <td className="py-1.5 px-2 text-text-muted font-mono">{c.oldValue || "-"}</td>
+                      <td className="py-1.5 px-2 text-center"><ArrowRight size={10} className="text-text-muted/40" /></td>
+                      <td className="py-1.5 px-2 text-text-primary font-mono">{c.newValue || "-"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </>
+          )}
+
+          {applied && (
+            <div className="flex items-center gap-2 mt-3 p-2 rounded bg-success/10 text-success text-[10px]">
+              <CheckCircle2 size={12} />
+              Changes applied to schematic.
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-4 py-2.5 border-t border-border-subtle">
+          <div className="flex items-center gap-1 text-[10px] text-text-muted">
+            <AlertTriangle size={10} />
+            Only value and footprint changes are applied automatically.
+          </div>
+          <div className="flex items-center gap-2">
+            <button onClick={handleClose}
+              className="px-3 py-1 text-[10px] text-text-secondary hover:bg-bg-hover rounded">
+              Close
+            </button>
+            <button onClick={handleApply}
+              disabled={changes.length === 0 || applied || !schData}
+              className={cn("px-3 py-1 text-[10px] rounded",
+                changes.length > 0 && !applied ? "bg-accent text-white hover:bg-accent/80" : "bg-bg-hover text-text-muted cursor-default")}>
+              Apply Changes
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/BackAnnotationDialog.tsx
+++ b/src/components/BackAnnotationDialog.tsx
@@ -58,7 +58,7 @@ export function BackAnnotationDialog({ open, onClose }: Props) {
   };
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50" role="dialog" aria-modal="true" aria-label="Back Annotate from PCB">
       <div className="bg-bg-secondary border border-border-subtle rounded-lg shadow-2xl w-[560px] max-h-[80vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border-subtle">
@@ -93,8 +93,8 @@ export function BackAnnotationDialog({ open, onClose }: Props) {
                   </tr>
                 </thead>
                 <tbody>
-                  {changes.map((c, i) => (
-                    <tr key={i} className="border-b border-border-subtle/30 hover:bg-bg-hover/30">
+                  {changes.map((c) => (
+                    <tr key={`${c.reference}-${c.type}`} className="border-b border-border-subtle/30 hover:bg-bg-hover/30">
                       <td className="py-1.5 px-2 font-mono font-medium">{c.reference}</td>
                       <td className={cn("py-1.5 px-2", TYPE_COLORS[c.type])}>
                         {TYPE_LABELS[c.type] || c.type}

--- a/src/components/BackAnnotationDialog.tsx
+++ b/src/components/BackAnnotationDialog.tsx
@@ -41,9 +41,13 @@ export function BackAnnotationDialog({ open, onClose }: Props) {
 
   const handleApply = () => {
     if (!schData || changes.length === 0) return;
-    const count = applyEcoChanges(schData, changes);
+    // Clone data to avoid mutating the live store object
+    const store = useSchematicStore.getState();
+    store.pushUndo();
+    const cloned = structuredClone(schData);
+    const count = applyEcoChanges(cloned, changes);
     if (count > 0) {
-      useSchematicStore.setState({ dirty: true });
+      useSchematicStore.setState({ data: cloned, dirty: true });
     }
     setApplied(true);
   };

--- a/src/components/BgaFanoutDialog.tsx
+++ b/src/components/BgaFanoutDialog.tsx
@@ -41,7 +41,7 @@ export function BgaFanoutDialog({ open, onClose }: Props) {
   };
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50" role="dialog" aria-modal="true" aria-label="BGA Fanout">
       <div className="bg-bg-secondary border border-border-subtle rounded-lg shadow-2xl w-[360px]">
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border-subtle">
           <span className="text-xs font-semibold">BGA Fanout</span>

--- a/src/components/BgaFanoutDialog.tsx
+++ b/src/components/BgaFanoutDialog.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import { usePcbStore } from "@/stores/pcb";
+import { generateBgaFanout, applyBgaFanout } from "@/lib/pcbAdvancedRouting";
+import type { PcbLayerId } from "@/types/pcb";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function BgaFanoutDialog({ open, onClose }: Props) {
+  const [viaDiameter, setViaDiameter] = useState(0.4);
+  const [viaDrill, setViaDrill] = useState(0.2);
+  const [traceWidth, setTraceWidth] = useState(0.15);
+  const [dogboneLength, setDogboneLength] = useState(0.6);
+  const [escapeDir, setEscapeDir] = useState<"outward" | "inward" | "alternating">("outward");
+
+  const pcbData = usePcbStore((s) => s.data);
+  const selectedIds = usePcbStore((s) => s.selectedIds);
+
+  if (!open) return null;
+
+  const selectedFp = pcbData?.footprints.find((f) => selectedIds.has(f.uuid));
+
+  const handleApply = () => {
+    if (!pcbData || !selectedFp) return;
+    const result = generateBgaFanout(pcbData, {
+      footprintUuid: selectedFp.uuid,
+      viaDiameter,
+      viaDrill,
+      traceWidth,
+      dogboneLength,
+      escapeDirection: escapeDir,
+      topLayer: "F.Cu" as PcbLayerId,
+      innerLayer: "In1.Cu" as PcbLayerId,
+    });
+    applyBgaFanout(result);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
+      <div className="bg-bg-secondary border border-border-subtle rounded-lg shadow-2xl w-[360px]">
+        <div className="flex items-center justify-between px-4 py-2.5 border-b border-border-subtle">
+          <span className="text-xs font-semibold">BGA Fanout</span>
+          <button onClick={onClose} className="p-0.5 hover:bg-bg-hover rounded"><X size={14} /></button>
+        </div>
+
+        <div className="p-4 space-y-3">
+          {!selectedFp ? (
+            <div className="text-[10px] text-warning text-center py-4">
+              Select a BGA footprint first.
+            </div>
+          ) : (
+            <>
+              <div className="text-[10px] text-text-muted mb-2">
+                Footprint: <span className="text-text-primary font-mono">{selectedFp.reference}</span> ({selectedFp.pads.length} pads)
+              </div>
+
+              <Row label="Via Diameter" value={viaDiameter} onChange={setViaDiameter} step={0.05} unit="mm" />
+              <Row label="Via Drill" value={viaDrill} onChange={setViaDrill} step={0.05} unit="mm" />
+              <Row label="Trace Width" value={traceWidth} onChange={setTraceWidth} step={0.05} unit="mm" />
+              <Row label="Dogbone Len" value={dogboneLength} onChange={setDogboneLength} step={0.1} unit="mm" />
+
+              <div className="flex items-center gap-2">
+                <span className="text-[10px] text-text-muted w-20">Direction</span>
+                <select value={escapeDir} onChange={(e) => setEscapeDir(e.target.value as typeof escapeDir)}
+                  className="flex-1 bg-bg-surface border border-border-subtle rounded px-2 py-0.5 text-[10px] outline-none">
+                  <option value="outward">Outward</option>
+                  <option value="inward">Inward</option>
+                  <option value="alternating">Alternating</option>
+                </select>
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 px-4 py-2.5 border-t border-border-subtle">
+          <button onClick={onClose} className="px-3 py-1 text-[10px] text-text-secondary hover:bg-bg-hover rounded">Cancel</button>
+          <button onClick={handleApply} disabled={!selectedFp || !pcbData}
+            className={cn("px-3 py-1 text-[10px] rounded",
+              selectedFp ? "bg-accent text-white hover:bg-accent/80" : "bg-bg-hover text-text-muted cursor-default")}>
+            Generate Fanout
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, value, onChange, step, unit }: {
+  label: string; value: number; onChange: (v: number) => void; step: number; unit: string;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-[10px] text-text-muted w-20">{label}</span>
+      <input type="number" step={step} min={0.05} value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="flex-1 bg-bg-surface border border-border-subtle rounded px-2 py-0.5 text-[10px] outline-none" />
+      <span className="text-[9px] text-text-muted">{unit}</span>
+    </div>
+  );
+}

--- a/src/components/ConstraintEditorDialog.tsx
+++ b/src/components/ConstraintEditorDialog.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { X, Plus, Trash2 } from "lucide-react";
+import { useSchematicStore } from "@/stores/schematic";
+import { cn } from "@/lib/utils";
+import type { DesignConstraint } from "@/types";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const CONSTRAINT_TYPES: DesignConstraint["type"][] = [
+  "clearance", "trace_width", "via_size", "diff_pair_gap", "length_match", "custom",
+];
+
+const TYPE_LABELS: Record<string, string> = {
+  clearance: "Clearance",
+  trace_width: "Trace Width",
+  via_size: "Via Size",
+  diff_pair_gap: "Diff Pair Gap",
+  length_match: "Length Match",
+  custom: "Custom",
+};
+
+export function ConstraintEditorDialog({ open, onClose }: Props) {
+  const data = useSchematicStore((s) => s.data);
+  const addConstraint = useSchematicStore((s) => s.addConstraint);
+  const removeConstraint = useSchematicStore((s) => s.removeConstraint);
+  const updateConstraintEnabled = useSchematicStore((s) => s.updateConstraintEnabled);
+  const [newType, setNewType] = useState<DesignConstraint["type"]>("clearance");
+
+  if (!open) return null;
+
+  const constraints = data?.constraints ?? [];
+
+  const handleAdd = () => {
+    const value = newType === "clearance" ? 0.2 : newType === "trace_width" ? 0.25 : 0.4;
+    addConstraint(`${TYPE_LABELS[newType]} Rule`, newType, "all", value, "mm");
+  };
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
+      <div className="bg-bg-secondary border border-border-subtle rounded-lg shadow-2xl w-[600px] max-h-[80vh] flex flex-col">
+        <div className="flex items-center justify-between px-4 py-2.5 border-b border-border-subtle">
+          <span className="text-xs font-semibold">Design Constraints</span>
+          <button onClick={onClose} className="p-0.5 hover:bg-bg-hover rounded"><X size={14} /></button>
+        </div>
+
+        {/* Add bar */}
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-border-subtle">
+          <select value={newType} onChange={(e) => setNewType(e.target.value as DesignConstraint["type"])}
+            className="bg-bg-surface border border-border-subtle rounded px-2 py-0.5 text-[10px] outline-none">
+            {CONSTRAINT_TYPES.map((t) => <option key={t} value={t}>{TYPE_LABELS[t]}</option>)}
+          </select>
+          <button onClick={handleAdd}
+            className="flex items-center gap-1 px-2 py-0.5 rounded bg-accent/15 text-accent hover:bg-accent/25 text-[10px]">
+            <Plus size={10} /> Add Rule
+          </button>
+          <div className="flex-1" />
+          <span className="text-[9px] text-text-muted">{constraints.length} rules</span>
+        </div>
+
+        {/* Table */}
+        <div className="flex-1 overflow-y-auto">
+          {constraints.length === 0 ? (
+            <div className="flex items-center justify-center py-12 text-[10px] text-text-muted/40">
+              No design constraints defined. Add a rule above.
+            </div>
+          ) : (
+            <table className="w-full text-[10px]">
+              <thead>
+                <tr className="text-text-muted border-b border-border-subtle bg-bg-secondary/40">
+                  <th className="text-left py-1 px-3 w-8"></th>
+                  <th className="text-left py-1 px-2">Name</th>
+                  <th className="text-left py-1 px-2">Type</th>
+                  <th className="text-left py-1 px-2">Scope</th>
+                  <th className="text-right py-1 px-2">Value</th>
+                  <th className="text-right py-1 px-2">Unit</th>
+                  <th className="text-right py-1 px-2">Priority</th>
+                  <th className="text-center py-1 px-2 w-8"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {constraints.map((c) => (
+                  <tr key={c.uuid} className={cn("border-b border-border-subtle/30 hover:bg-bg-hover/30", !c.enabled && "opacity-40")}>
+                    <td className="py-1 px-3">
+                      <input type="checkbox" checked={c.enabled}
+                        onChange={() => updateConstraintEnabled(c.uuid, !c.enabled)}
+                        className="accent-[#89b4fa]" />
+                    </td>
+                    <td className="py-1 px-2 font-medium">{c.name}</td>
+                    <td className="py-1 px-2 text-text-muted">{TYPE_LABELS[c.type] || c.type}</td>
+                    <td className="py-1 px-2 text-text-muted capitalize">{c.scope.kind}</td>
+                    <td className="py-1 px-2 text-right font-mono text-accent">{c.value.toFixed(2)}</td>
+                    <td className="py-1 px-2 text-right font-mono text-text-muted">{c.unit}</td>
+                    <td className="py-1 px-2 text-right font-mono text-text-muted">{c.priority}</td>
+                    <td className="py-1 px-2 text-center">
+                      <button onClick={() => removeConstraint(c.uuid)}
+                        className="p-0.5 text-text-muted/30 hover:text-error">
+                        <Trash2 size={10} />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <div className="flex justify-end px-4 py-2.5 border-t border-border-subtle">
+          <button onClick={onClose}
+            className="px-3 py-1 text-[10px] bg-accent text-white rounded hover:bg-accent/80">
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ConstraintEditorDialog.tsx
+++ b/src/components/ConstraintEditorDialog.tsx
@@ -39,7 +39,7 @@ export function ConstraintEditorDialog({ open, onClose }: Props) {
   };
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50" role="dialog" aria-modal="true" aria-label="Design Constraints">
       <div className="bg-bg-secondary border border-border-subtle rounded-lg shadow-2xl w-[600px] max-h-[80vh] flex flex-col">
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border-subtle">
           <span className="text-xs font-semibold">Design Constraints</span>

--- a/src/components/ErcMatrixDialog.tsx
+++ b/src/components/ErcMatrixDialog.tsx
@@ -1,0 +1,122 @@
+import { X } from "lucide-react";
+import { checkPinConnection } from "@/lib/ercMatrix";
+import type { PinType, ErcSeverity } from "@/lib/ercMatrix";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const PIN_TYPES: PinType[] = [
+  "input", "output", "bidirectional", "passive", "tri_state",
+  "open_collector", "open_emitter", "power_in", "power_out",
+  "unconnected", "free", "unspecified",
+];
+
+const PIN_LABELS: Record<string, string> = {
+  input: "Input",
+  output: "Output",
+  bidirectional: "Bidir",
+  passive: "Passive",
+  tri_state: "Tri-St",
+  open_collector: "Open C",
+  open_emitter: "Open E",
+  power_in: "Pwr In",
+  power_out: "Pwr Out",
+  unconnected: "Uncon",
+  free: "Free",
+  unspecified: "Unspec",
+};
+
+const SEVERITY_COLORS: Record<ErcSeverity, string> = {
+  ok: "bg-success/20 text-success",
+  warning: "bg-warning/20 text-warning",
+  error: "bg-error/20 text-error",
+};
+
+const SEVERITY_LABELS: Record<ErcSeverity, string> = {
+  ok: "",
+  warning: "W",
+  error: "E",
+};
+
+export function ErcMatrixDialog({ open, onClose }: Props) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
+      <div className="bg-bg-secondary border border-border-subtle rounded-lg shadow-2xl max-w-[680px] max-h-[80vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-2.5 border-b border-border-subtle">
+          <span className="text-xs font-semibold">ERC Pin Connection Matrix</span>
+          <button onClick={onClose} className="p-0.5 hover:bg-bg-hover rounded"><X size={14} /></button>
+        </div>
+
+        {/* Matrix */}
+        <div className="flex-1 overflow-auto p-3">
+          <div className="text-[10px] text-text-muted mb-2">
+            Each cell shows the ERC severity when two pin types connect on the same net.
+          </div>
+          <table className="text-[9px] border-collapse">
+            <thead>
+              <tr>
+                <th className="p-1 text-left text-text-muted border-b border-border-subtle sticky left-0 bg-bg-secondary z-10"></th>
+                {PIN_TYPES.map((t) => (
+                  <th key={t} className="p-1 text-center text-text-muted border-b border-border-subtle min-w-[38px] font-medium">
+                    <span className="writing-mode-vertical" style={{ writingMode: "vertical-rl", transform: "rotate(180deg)" }}>
+                      {PIN_LABELS[t]}
+                    </span>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {PIN_TYPES.map((row) => (
+                <tr key={row}>
+                  <td className="p-1 text-right text-text-muted font-medium pr-2 border-r border-border-subtle sticky left-0 bg-bg-secondary z-10 whitespace-nowrap">
+                    {PIN_LABELS[row]}
+                  </td>
+                  {PIN_TYPES.map((col) => {
+                    const severity = checkPinConnection(row, col);
+                    return (
+                      <td key={col}
+                        className={cn("p-1 text-center border border-border-subtle/20 min-w-[38px]", SEVERITY_COLORS[severity])}
+                        title={`${PIN_LABELS[row]} + ${PIN_LABELS[col]}: ${severity}`}>
+                        {SEVERITY_LABELS[severity]}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {/* Legend */}
+          <div className="flex items-center gap-4 mt-3 text-[9px] text-text-muted">
+            <div className="flex items-center gap-1">
+              <div className="w-3 h-3 rounded bg-success/20 border border-success/30" />
+              <span>OK</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <div className="w-3 h-3 rounded bg-warning/20 border border-warning/30 text-center text-[8px] text-warning font-bold leading-[12px]">W</div>
+              <span>Warning</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <div className="w-3 h-3 rounded bg-error/20 border border-error/30 text-center text-[8px] text-error font-bold leading-[12px]">E</div>
+              <span>Error</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end px-4 py-2.5 border-t border-border-subtle">
+          <button onClick={onClose}
+            className="px-3 py-1 text-[10px] text-text-secondary hover:bg-bg-hover rounded">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ErcMatrixDialog.tsx
+++ b/src/components/ErcMatrixDialog.tsx
@@ -41,11 +41,16 @@ const SEVERITY_LABELS: Record<ErcSeverity, string> = {
   error: "E",
 };
 
+// Precompute the static matrix — only calculated once at module load
+const MATRIX_CELLS = PIN_TYPES.map((row) =>
+  PIN_TYPES.map((col) => checkPinConnection(row, col))
+);
+
 export function ErcMatrixDialog({ open, onClose }: Props) {
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50" role="dialog" aria-modal="true" aria-label="ERC Pin Connection Matrix">
       <div className="bg-bg-secondary border border-border-subtle rounded-lg shadow-2xl max-w-[680px] max-h-[80vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border-subtle">
@@ -72,13 +77,13 @@ export function ErcMatrixDialog({ open, onClose }: Props) {
               </tr>
             </thead>
             <tbody>
-              {PIN_TYPES.map((row) => (
+              {PIN_TYPES.map((row, ri) => (
                 <tr key={row}>
                   <td className="p-1 text-right text-text-muted font-medium pr-2 border-r border-border-subtle sticky left-0 bg-bg-secondary z-10 whitespace-nowrap">
                     {PIN_LABELS[row]}
                   </td>
-                  {PIN_TYPES.map((col) => {
-                    const severity = checkPinConnection(row, col);
+                  {PIN_TYPES.map((col, ci) => {
+                    const severity = MATRIX_CELLS[ri][ci];
                     return (
                       <td key={col}
                         className={cn("p-1 text-center border border-border-subtle/20 min-w-[38px]", SEVERITY_COLORS[severity])}

--- a/src/components/FootprintEditorProperties.tsx
+++ b/src/components/FootprintEditorProperties.tsx
@@ -18,7 +18,7 @@ export function FootprintEditorProperties() {
   if (!footprint) return <div className="w-[280px] border-l border-border bg-bg-primary p-3 text-[10px] text-text-muted/50">No footprint loaded</div>;
 
   return (
-    <div className="flex flex-col h-full w-[280px] border-l border-border bg-bg-primary">
+    <div className="flex flex-col h-full">
       {/* Tabs */}
       <div className="flex border-b border-border-subtle bg-bg-secondary/80 shrink-0">
         {([["properties", "Properties"], ["padTable", "Pad Table"]] as const).map(([id, label]) => (

--- a/src/components/FootprintEditorProperties.tsx
+++ b/src/components/FootprintEditorProperties.tsx
@@ -182,7 +182,7 @@ function PadTable() {
           {footprint.pads.map((pad, i) => {
             const isSel = selectedItem?.type === "pad" && selectedItem.index === i;
             return (
-              <tr key={i} onClick={() => setSelectedItem({ type: "pad", index: i })}
+              <tr key={pad.uuid} onClick={() => setSelectedItem({ type: "pad", index: i })}
                 className={cn("border-b border-border-subtle/20 cursor-pointer", isSel ? "bg-accent/15" : "hover:bg-bg-hover/50")}>
                 <td className="px-1.5 py-0.5 font-mono">{pad.number}</td>
                 <td className="px-1.5 py-0.5">

--- a/src/components/FootprintEditorProperties.tsx
+++ b/src/components/FootprintEditorProperties.tsx
@@ -1,0 +1,232 @@
+import { useCallback, useState } from "react";
+import { useFootprintEditorStore } from "@/stores/footprintEditor";
+import type { PcbPad, PcbGraphic } from "@/types/pcb";
+import { LAYER_DISPLAY_NAMES } from "@/types/pcb";
+import { cn } from "@/lib/utils";
+
+const PAD_TYPES = ["smd", "thru_hole", "np_thru_hole", "connect"] as const;
+const PAD_SHAPES = ["rect", "roundrect", "circle", "oval", "trapezoid", "custom"] as const;
+
+export function FootprintEditorProperties() {
+  const footprint = useFootprintEditorStore(s => s.footprint);
+  const selectedItem = useFootprintEditorStore(s => s.selectedItem);
+  const updatePad = useFootprintEditorStore(s => s.updatePad);
+  const updateGraphic = useFootprintEditorStore(s => s.updateGraphic);
+  const updateFootprintId = useFootprintEditorStore(s => s.updateFootprintId);
+  const [tab, setTab] = useState<"properties" | "padTable">("properties");
+
+  if (!footprint) return <div className="w-[280px] border-l border-border bg-bg-primary p-3 text-[10px] text-text-muted/50">No footprint loaded</div>;
+
+  return (
+    <div className="flex flex-col h-full w-[280px] border-l border-border bg-bg-primary">
+      {/* Tabs */}
+      <div className="flex border-b border-border-subtle bg-bg-secondary/80 shrink-0">
+        {([["properties", "Properties"], ["padTable", "Pad Table"]] as const).map(([id, label]) => (
+          <button key={id} onClick={() => setTab(id)}
+            className={cn("px-3 py-1.5 text-[10px] font-medium transition-colors",
+              tab === id ? "text-accent border-b-2 border-accent" : "text-text-muted/60 hover:text-text-primary"
+            )}>
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex-1 overflow-y-auto text-[10px]">
+        {tab === "properties" ? (
+          <>
+            {/* Footprint metadata */}
+            <Section title="Footprint">
+              <Field label="ID">
+                <input value={footprint.id} onChange={e => updateFootprintId(e.target.value)}
+                  className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none" />
+              </Field>
+              <Field label="Pads">{footprint.pads.length}</Field>
+              <Field label="Graphics">{footprint.graphics.length}</Field>
+              <Field label="3D Model">
+                <input value={footprint.model3d} onChange={() => {}} placeholder="(none)" className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none" disabled />
+              </Field>
+            </Section>
+
+            {/* Selected pad properties */}
+            {selectedItem?.type === "pad" && selectedItem.index < footprint.pads.length && (
+              <PadProperties pad={footprint.pads[selectedItem.index]} index={selectedItem.index} updatePad={updatePad} />
+            )}
+
+            {/* Selected graphic properties */}
+            {selectedItem?.type === "graphic" && selectedItem.index < footprint.graphics.length && (
+              <GraphicProperties graphic={footprint.graphics[selectedItem.index]} index={selectedItem.index} updateGraphic={updateGraphic} />
+            )}
+
+            {!selectedItem && <div className="p-3 text-text-muted/40">Select a pad or graphic to edit</div>}
+          </>
+        ) : (
+          <PadTable />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PadProperties({ pad, index, updatePad }: { pad: PcbPad; index: number; updatePad: (i: number, u: Partial<PcbPad>) => void }) {
+  const u = useCallback((updates: Partial<PcbPad>) => updatePad(index, updates), [index, updatePad]);
+
+  return (
+    <Section title={`Pad ${pad.number}`}>
+      <Field label="Number">
+        <input value={pad.number} onChange={e => u({ number: e.target.value })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16" />
+      </Field>
+      <Field label="Type">
+        <select value={pad.type} onChange={e => u({ type: e.target.value as any })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none">
+          {PAD_TYPES.map(t => <option key={t} value={t}>{t.replace(/_/g, " ")}</option>)}
+        </select>
+      </Field>
+      <Field label="Shape">
+        <select value={pad.shape} onChange={e => u({ shape: e.target.value as any })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none">
+          {PAD_SHAPES.map(s => <option key={s} value={s}>{s}</option>)}
+        </select>
+      </Field>
+      <Field label="Width">
+        <input type="number" step={0.05} value={pad.size[0]}
+          onChange={e => u({ size: [parseFloat(e.target.value) || 0.5, pad.size[1]] })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16" />
+      </Field>
+      <Field label="Height">
+        <input type="number" step={0.05} value={pad.size[1]}
+          onChange={e => u({ size: [pad.size[0], parseFloat(e.target.value) || 0.5] })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16" />
+      </Field>
+      <Field label="X">
+        <input type="number" step={0.1} value={pad.position.x.toFixed(3)}
+          onChange={e => u({ position: { ...pad.position, x: parseFloat(e.target.value) || 0 } })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-20" />
+      </Field>
+      <Field label="Y">
+        <input type="number" step={0.1} value={pad.position.y.toFixed(3)}
+          onChange={e => u({ position: { ...pad.position, y: parseFloat(e.target.value) || 0 } })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-20" />
+      </Field>
+      {pad.type === "thru_hole" && (
+        <Field label="Drill">
+          <input type="number" step={0.05} value={pad.drill?.diameter ?? 0}
+            onChange={e => u({ drill: { ...pad.drill, diameter: parseFloat(e.target.value) || 0.5 } })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16" />
+        </Field>
+      )}
+      {pad.shape === "roundrect" && (
+        <Field label="Corner %">
+          <input type="number" step={5} min={0} max={100} value={Math.round((pad.roundrectRatio ?? 0.25) * 100)}
+            onChange={e => u({ roundrectRatio: (parseInt(e.target.value) || 25) / 100 })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16" />
+        </Field>
+      )}
+      <Field label="Layers">
+        <span className="text-text-muted/60 font-mono">{pad.layers.map(l => LAYER_DISPLAY_NAMES[l] || l).join(", ")}</span>
+      </Field>
+    </Section>
+  );
+}
+
+function GraphicProperties({ graphic, index, updateGraphic }: { graphic: PcbGraphic; index: number; updateGraphic: (i: number, g: PcbGraphic) => void }) {
+  const update = useCallback((partial: Record<string, any>) => {
+    updateGraphic(index, { ...graphic, ...partial } as any);
+  }, [index, graphic, updateGraphic]);
+
+  return (
+    <Section title={`Graphic: ${graphic.type}`}>
+      <Field label="Layer">
+        <span className="font-mono text-text-muted/60">{LAYER_DISPLAY_NAMES[graphic.layer] || graphic.layer}</span>
+      </Field>
+      {"width" in graphic && (
+        <Field label="Line Width">
+          <input type="number" step={0.01} value={(graphic as any).width}
+            onChange={e => update({ width: parseFloat(e.target.value) || 0.12 })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16" />
+        </Field>
+      )}
+      {graphic.type === "circle" && (
+        <Field label="Radius">
+          <input type="number" step={0.05} value={graphic.radius}
+            onChange={e => update({ radius: parseFloat(e.target.value) || 0.5 })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16" />
+        </Field>
+      )}
+      {graphic.type === "text" && (
+        <>
+          <Field label="Text">
+            <input value={graphic.text} onChange={e => update({ text: e.target.value })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none" />
+          </Field>
+          <Field label="Font Size">
+            <input type="number" step={0.1} value={graphic.fontSize}
+              onChange={e => update({ fontSize: parseFloat(e.target.value) || 1 })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16" />
+          </Field>
+        </>
+      )}
+    </Section>
+  );
+}
+
+function PadTable() {
+  const footprint = useFootprintEditorStore(s => s.footprint);
+  const updatePad = useFootprintEditorStore(s => s.updatePad);
+  const selectedItem = useFootprintEditorStore(s => s.selectedItem);
+  const setSelectedItem = useFootprintEditorStore(s => s.setSelectedItem);
+
+  if (!footprint) return null;
+
+  return (
+    <div className="overflow-auto">
+      <table className="w-full border-collapse">
+        <thead className="sticky top-0 z-10 bg-bg-surface">
+          <tr className="border-b border-border-subtle text-left">
+            <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50 w-[32px]">#</th>
+            <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50">Type</th>
+            <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50">Shape</th>
+            <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50 w-[44px]">W</th>
+            <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50 w-[44px]">H</th>
+            <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50 w-[44px]">Drill</th>
+          </tr>
+        </thead>
+        <tbody>
+          {footprint.pads.map((pad, i) => {
+            const isSel = selectedItem?.type === "pad" && selectedItem.index === i;
+            return (
+              <tr key={i} onClick={() => setSelectedItem({ type: "pad", index: i })}
+                className={cn("border-b border-border-subtle/20 cursor-pointer", isSel ? "bg-accent/15" : "hover:bg-bg-hover/50")}>
+                <td className="px-1.5 py-0.5 font-mono">{pad.number}</td>
+                <td className="px-1.5 py-0.5">
+                  <select value={pad.type} onChange={e => updatePad(i, { type: e.target.value as any })}
+                    className="bg-transparent outline-none text-[10px] w-full">
+                    {PAD_TYPES.map(t => <option key={t} value={t}>{t.replace(/_/g, " ")}</option>)}
+                  </select>
+                </td>
+                <td className="px-1.5 py-0.5">
+                  <select value={pad.shape} onChange={e => updatePad(i, { shape: e.target.value as any })}
+                    className="bg-transparent outline-none text-[10px] w-full">
+                    {PAD_SHAPES.map(s => <option key={s} value={s}>{s}</option>)}
+                  </select>
+                </td>
+                <td className="px-1.5 py-0.5 font-mono">{pad.size[0].toFixed(2)}</td>
+                <td className="px-1.5 py-0.5 font-mono">{pad.size[1].toFixed(2)}</td>
+                <td className="px-1.5 py-0.5 font-mono">{pad.drill?.diameter?.toFixed(2) ?? "--"}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {footprint.pads.length === 0 && <div className="p-4 text-center text-text-muted/40">No pads. Use SMD/TH pad tools.</div>}
+      <div className="px-2 py-1 border-t border-border-subtle text-text-muted/50">{footprint.pads.length} pads</div>
+    </div>
+  );
+}
+
+// Shared UI
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="border-b border-border-subtle">
+      <div className="px-3 py-1.5 bg-bg-secondary/60 text-[10px] font-semibold text-text-secondary">{title}</div>
+      <div className="px-3 py-1 space-y-0.5">{children}</div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 py-0.5">
+      <span className="w-20 shrink-0 text-text-muted/60">{label}</span>
+      <div className="flex-1 text-text-primary">{children}</div>
+    </div>
+  );
+}
+

--- a/src/components/FootprintEditorToolbar.tsx
+++ b/src/components/FootprintEditorToolbar.tsx
@@ -34,8 +34,8 @@ export function FootprintEditorToolbar() {
   const setEditMode = useFootprintEditorStore(s => s.setEditMode);
   const selectedItem = useFootprintEditorStore(s => s.selectedItem);
   const dirty = useFootprintEditorStore(s => s.dirty);
-  const undoStack = useFootprintEditorStore(s => s.undoStack);
-  const redoStack = useFootprintEditorStore(s => s.redoStack);
+  const canUndo = useFootprintEditorStore(s => s.undoStack.length > 0);
+  const canRedo = useFootprintEditorStore(s => s.redoStack.length > 0);
   const footprint = useFootprintEditorStore(s => s.footprint);
   const activeLayer = useFootprintEditorStore(s => s.activeLayer);
   const setActiveLayer = useFootprintEditorStore(s => s.setActiveLayer);
@@ -47,10 +47,7 @@ export function FootprintEditorToolbar() {
   };
 
   const handleSave = async () => {
-    const s = useFootprintEditorStore.getState();
-    if (!s.footprint || !s.sourcePath || !s.sourceId) return;
-    // TODO: Tauri save_footprint command
-    alert("Save footprint: " + s.sourceId + " → " + s.sourcePath + "\n(Backend save not yet implemented)");
+    // Tauri save_footprint command will be implemented when Rust backend supports .snxpkg format
   };
 
   return (
@@ -112,14 +109,14 @@ export function FootprintEditorToolbar() {
       <ToolBtn icon={<Trash2 size={15} />} label="Delete (Del)"
         disabled={!selectedItem} onClick={handleDelete} />
       <ToolBtn icon={<Undo2 size={15} />} label="Undo (Ctrl+Z)"
-        disabled={undoStack.length === 0} onClick={() => useFootprintEditorStore.getState().undo()} />
+        disabled={!canUndo} onClick={() => useFootprintEditorStore.getState().undo()} />
       <ToolBtn icon={<Redo2 size={15} />} label="Redo (Ctrl+Y)"
-        disabled={redoStack.length === 0} onClick={() => useFootprintEditorStore.getState().redo()} />
+        disabled={!canRedo} onClick={() => useFootprintEditorStore.getState().redo()} />
 
       <Sep />
 
-      <ToolBtn icon={<Save size={15} />} label="Save Footprint"
-        disabled={!dirty} onClick={handleSave} />
+      <ToolBtn icon={<Save size={15} />} label="Save Footprint (backend pending)"
+        disabled={true} onClick={handleSave} />
 
       <div className="flex-1" />
 

--- a/src/components/FootprintEditorToolbar.tsx
+++ b/src/components/FootprintEditorToolbar.tsx
@@ -1,0 +1,130 @@
+import {
+  MousePointer2, Square, Minus, Circle, Spline, Type,
+  Trash2, Save, Undo2, Redo2, X, CircleDot,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useFootprintEditorStore } from "@/stores/footprintEditor";
+import { LAYER_DISPLAY_NAMES, DEFAULT_LAYER_COLORS } from "@/types/pcb";
+
+function ToolBtn({ icon, label, active, disabled, onClick }: {
+  icon: React.ReactNode; label: string; active?: boolean; disabled?: boolean; onClick?: () => void;
+}) {
+  return (
+    <button title={label} disabled={disabled} onClick={onClick}
+      className={cn("p-1.5 rounded transition-colors",
+        active ? "bg-accent/20 text-accent"
+          : disabled ? "text-text-muted/30 cursor-default"
+          : "text-text-secondary hover:bg-bg-hover hover:text-text-primary")}>
+      {icon}
+    </button>
+  );
+}
+
+function Sep() { return <div className="w-px h-5 bg-border mx-1" />; }
+
+const LAYER_IDS = ["F.Cu", "B.Cu", "F.SilkS", "B.SilkS", "F.Fab", "B.Fab", "F.CrtYd", "B.CrtYd", "F.Paste", "B.Paste", "F.Mask", "B.Mask"];
+const LAYERS = LAYER_IDS.map(id => ({
+  id,
+  label: LAYER_DISPLAY_NAMES[id] || id,
+  color: DEFAULT_LAYER_COLORS[id] || "#666",
+}));
+
+export function FootprintEditorToolbar() {
+  const editMode = useFootprintEditorStore(s => s.editMode);
+  const setEditMode = useFootprintEditorStore(s => s.setEditMode);
+  const selectedItem = useFootprintEditorStore(s => s.selectedItem);
+  const dirty = useFootprintEditorStore(s => s.dirty);
+  const undoStack = useFootprintEditorStore(s => s.undoStack);
+  const redoStack = useFootprintEditorStore(s => s.redoStack);
+  const footprint = useFootprintEditorStore(s => s.footprint);
+  const activeLayer = useFootprintEditorStore(s => s.activeLayer);
+  const setActiveLayer = useFootprintEditorStore(s => s.setActiveLayer);
+
+  const handleDelete = () => {
+    const s = useFootprintEditorStore.getState();
+    if (s.selectedItem?.type === "pad") s.removePad(s.selectedItem.index);
+    else if (s.selectedItem?.type === "graphic") s.removeGraphic(s.selectedItem.index);
+  };
+
+  const handleSave = async () => {
+    const s = useFootprintEditorStore.getState();
+    if (!s.footprint || !s.sourcePath || !s.sourceId) return;
+    // TODO: Tauri save_footprint command
+    alert("Save footprint: " + s.sourceId + " → " + s.sourcePath + "\n(Backend save not yet implemented)");
+  };
+
+  return (
+    <div className="flex items-center gap-0.5 px-3 h-9 bg-bg-secondary border-b border-border shrink-0 select-none">
+      <div className="flex items-center gap-0.5 mr-2">
+        <span className="text-[10px] font-semibold text-success uppercase tracking-wider mr-1">
+          Footprint Editor
+        </span>
+        {footprint && (
+          <span className="text-[10px] text-text-muted font-mono truncate max-w-[200px]">
+            {footprint.id}
+          </span>
+        )}
+        {dirty && <span className="text-[10px] text-warning ml-1">*</span>}
+      </div>
+
+      <Sep />
+
+      <ToolBtn icon={<MousePointer2 size={15} />} label="Select (Esc)"
+        active={editMode === "select"} onClick={() => setEditMode("select")} />
+
+      <Sep />
+
+      {/* Pads */}
+      <ToolBtn icon={<Square size={15} />} label="SMD Pad"
+        active={editMode === "addPadSmd"} onClick={() => setEditMode("addPadSmd")} />
+      <ToolBtn icon={<CircleDot size={15} />} label="Through-Hole Pad"
+        active={editMode === "addPadTh"} onClick={() => setEditMode("addPadTh")} />
+
+      <Sep />
+
+      {/* Graphics */}
+      <ToolBtn icon={<Minus size={15} />} label="Line"
+        active={editMode === "addLine"} onClick={() => setEditMode("addLine")} />
+      <ToolBtn icon={<Square size={15} />} label="Rectangle"
+        active={editMode === "addRect"} onClick={() => setEditMode("addRect")} />
+      <ToolBtn icon={<Circle size={15} />} label="Circle"
+        active={editMode === "addCircle"} onClick={() => setEditMode("addCircle")} />
+      <ToolBtn icon={<Spline size={15} />} label="Arc"
+        active={editMode === "addArc"} onClick={() => setEditMode("addArc")} />
+      <ToolBtn icon={<Type size={15} />} label="Text"
+        active={editMode === "addText"} onClick={() => setEditMode("addText")} />
+
+      <Sep />
+
+      {/* Active layer selector */}
+      <select
+        value={activeLayer}
+        onChange={e => setActiveLayer(e.target.value as any)}
+        className="bg-bg-secondary border border-border-subtle rounded px-1.5 py-0.5 text-[10px] text-text-secondary outline-none"
+      >
+        {LAYERS.map(l => (
+          <option key={l.id} value={l.id}>{l.label}</option>
+        ))}
+      </select>
+
+      <Sep />
+
+      <ToolBtn icon={<Trash2 size={15} />} label="Delete (Del)"
+        disabled={!selectedItem} onClick={handleDelete} />
+      <ToolBtn icon={<Undo2 size={15} />} label="Undo (Ctrl+Z)"
+        disabled={undoStack.length === 0} onClick={() => useFootprintEditorStore.getState().undo()} />
+      <ToolBtn icon={<Redo2 size={15} />} label="Redo (Ctrl+Y)"
+        disabled={redoStack.length === 0} onClick={() => useFootprintEditorStore.getState().redo()} />
+
+      <Sep />
+
+      <ToolBtn icon={<Save size={15} />} label="Save Footprint"
+        disabled={!dirty} onClick={handleSave} />
+
+      <div className="flex-1" />
+
+      <ToolBtn icon={<X size={15} />} label="Close Footprint Editor"
+        onClick={() => useFootprintEditorStore.getState().closeEditor()} />
+    </div>
+  );
+}

--- a/src/components/FootprintEditorToolbar.tsx
+++ b/src/components/FootprintEditorToolbar.tsx
@@ -4,7 +4,10 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useFootprintEditorStore } from "@/stores/footprintEditor";
+import type { FootprintData } from "@/stores/footprintEditor";
 import { LAYER_DISPLAY_NAMES, DEFAULT_LAYER_COLORS } from "@/types/pcb";
+import type { PcbGraphic } from "@/types/pcb";
+import { invoke } from "@tauri-apps/api/core";
 
 function ToolBtn({ icon, label, active, disabled, onClick }: {
   icon: React.ReactNode; label: string; active?: boolean; disabled?: boolean; onClick?: () => void;
@@ -47,7 +50,15 @@ export function FootprintEditorToolbar() {
   };
 
   const handleSave = async () => {
-    // Tauri save_footprint command will be implemented when Rust backend supports .snxpkg format
+    const store = useFootprintEditorStore.getState();
+    if (!store.footprint || !store.sourcePath) return;
+    try {
+      const rustFp = toRustFootprint(store.footprint);
+      await invoke("save_footprint", { filePath: store.sourcePath, footprint: rustFp });
+      useFootprintEditorStore.setState({ dirty: false });
+    } catch (err) {
+      alert(`Failed to save footprint: ${err}`);
+    }
   };
 
   return (
@@ -115,8 +126,8 @@ export function FootprintEditorToolbar() {
 
       <Sep />
 
-      <ToolBtn icon={<Save size={15} />} label="Save Footprint (backend pending)"
-        disabled={true} onClick={handleSave} />
+      <ToolBtn icon={<Save size={15} />} label="Save Footprint"
+        disabled={!dirty} onClick={handleSave} />
 
       <div className="flex-1" />
 
@@ -124,4 +135,50 @@ export function FootprintEditorToolbar() {
         onClick={() => useFootprintEditorStore.getState().closeEditor()} />
     </div>
   );
+}
+
+/** Convert frontend FootprintData to the shape Rust's PcbFootprint expects (snake_case keys) */
+function toRustFootprint(fp: FootprintData) {
+  return {
+    uuid: crypto.randomUUID(),
+    reference: "REF**",
+    value: fp.id,
+    footprint_id: fp.id,
+    position: { x: 0, y: 0 },
+    rotation: 0,
+    layer: "F.Cu",
+    locked: false,
+    pads: fp.pads.map(p => ({
+      uuid: p.uuid,
+      number: p.number,
+      pad_type: p.type,
+      shape: p.shape,
+      position: p.position,
+      size: p.size,
+      drill: p.drill ? { diameter: p.drill.diameter, shape: p.drill.shape ?? null } : null,
+      layers: p.layers,
+      net: null,
+      roundrect_ratio: p.roundrectRatio ?? null,
+    })),
+    graphics: fp.graphics.map(toRustGraphic),
+  };
+}
+
+function toRustGraphic(g: PcbGraphic) {
+  return {
+    graphic_type: g.type,
+    layer: g.layer,
+    width: "width" in g ? g.width : 0.12,
+    start: "start" in g ? g.start : null,
+    end: "end" in g ? g.end : null,
+    center: "center" in g ? g.center : null,
+    mid: "mid" in g ? g.mid : null,
+    radius: "radius" in g ? g.radius : null,
+    points: "points" in g ? g.points : [],
+    text: g.type === "text" ? g.text : null,
+    font_size: g.type === "text" ? g.fontSize : null,
+    position: g.type === "text" ? g.position : null,
+    rotation: g.type === "text" ? g.rotation : null,
+    fill: "fill" in g ? g.fill : null,
+  };
 }

--- a/src/components/FootprintEditorToolbar.tsx
+++ b/src/components/FootprintEditorToolbar.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   MousePointer2, Square, Minus, Circle, Spline, Type,
   Trash2, Save, Undo2, Redo2, X, CircleDot,
@@ -49,15 +50,23 @@ export function FootprintEditorToolbar() {
     else if (s.selectedItem?.type === "graphic") s.removeGraphic(s.selectedItem.index);
   };
 
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
   const handleSave = async () => {
+    if (saving) return;
     const store = useFootprintEditorStore.getState();
     if (!store.footprint || !store.sourcePath) return;
+    setSaving(true);
+    setSaveError(null);
     try {
       const rustFp = toRustFootprint(store.footprint);
       await invoke("save_footprint", { filePath: store.sourcePath, footprint: rustFp });
       useFootprintEditorStore.setState({ dirty: false });
     } catch (err) {
-      alert(`Failed to save footprint: ${err}`);
+      setSaveError(String(err));
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -126,8 +135,9 @@ export function FootprintEditorToolbar() {
 
       <Sep />
 
-      <ToolBtn icon={<Save size={15} />} label="Save Footprint"
-        disabled={!dirty} onClick={handleSave} />
+      <ToolBtn icon={<Save size={15} />} label={saveError ? `Save failed: ${saveError}` : "Save Footprint"}
+        disabled={!dirty || saving} onClick={handleSave} />
+      {saveError && <span className="text-[9px] text-error truncate max-w-[150px]">{saveError}</span>}
 
       <div className="flex-1" />
 
@@ -140,7 +150,7 @@ export function FootprintEditorToolbar() {
 /** Convert frontend FootprintData to the shape Rust's PcbFootprint expects (snake_case keys) */
 function toRustFootprint(fp: FootprintData) {
   return {
-    uuid: crypto.randomUUID(),
+    uuid: (fp as any).uuid || crypto.randomUUID(),
     reference: "REF**",
     value: fp.id,
     footprint_id: fp.id,

--- a/src/components/FootprintPickerDialog.tsx
+++ b/src/components/FootprintPickerDialog.tsx
@@ -1,0 +1,207 @@
+import { useState, useEffect, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface FootprintPickerProps {
+  open: boolean;
+  initialValue: string;
+  onClose: () => void;
+  onSelect: (footprintId: string) => void;
+}
+
+interface FootprintEntry {
+  name: string;
+  library: string;
+  fullId: string; // "Library:Footprint"
+}
+
+export function FootprintPickerDialog({ open, initialValue, onClose, onSelect }: FootprintPickerProps) {
+  const [modelName, setModelName] = useState(initialValue);
+  const [description, setDescription] = useState("");
+  const [libraryMode, setLibraryMode] = useState<"any" | "name" | "path">("any");
+  const [libraryFilter, setLibraryFilter] = useState("");
+  const [footprints, setFootprints] = useState<FootprintEntry[]>([]);
+  const [selectedFp, setSelectedFp] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [foundIn, setFoundIn] = useState("");
+
+  // Load available footprint libraries
+  useEffect(() => {
+    if (!open) return;
+    setModelName(initialValue);
+    setSelectedFp(null);
+    setDescription(initialValue ? "" : "");
+  }, [open, initialValue]);
+
+  // Search footprints when library mode or filter changes
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    loadFootprints().then(fps => {
+      setFootprints(fps);
+      setLoading(false);
+    }).catch(() => { setFootprints([]); setLoading(false); });
+  }, [open, libraryMode, libraryFilter]);
+
+  const loadFootprints = async (): Promise<FootprintEntry[]> => {
+    try {
+      const libs: string[] = await invoke("list_footprint_libraries");
+      const results: FootprintEntry[] = [];
+      const targetLibs = libraryMode === "name" && libraryFilter
+        ? libs.filter(l => l.toLowerCase().includes(libraryFilter.toLowerCase()))
+        : libs;
+
+      for (const lib of targetLibs.slice(0, 20)) {
+        try {
+          const fps: string[] = await invoke("list_footprints_in_library", { libraryName: lib });
+          for (const fp of fps) {
+            results.push({ name: fp, library: lib, fullId: `${lib}:${fp}` });
+          }
+        } catch { /* library may fail */ }
+      }
+      return results;
+    } catch {
+      return [];
+    }
+  };
+
+  const handleBrowse = useCallback(() => {
+    // Trigger search with current model name
+    const match = footprints.find(fp =>
+      fp.name.toLowerCase().includes(modelName.toLowerCase()) ||
+      fp.fullId.toLowerCase().includes(modelName.toLowerCase())
+    );
+    if (match) {
+      setSelectedFp(match.fullId);
+      setFoundIn(match.library);
+      setDescription(match.name);
+    } else {
+      setDescription("Footprint not found");
+      setFoundIn("");
+    }
+  }, [modelName, footprints]);
+
+  const handleSelect = useCallback((fp: FootprintEntry) => {
+    setSelectedFp(fp.fullId);
+    setModelName(fp.fullId);
+    setFoundIn(fp.library);
+    setDescription(fp.name);
+  }, []);
+
+  const handleOk = useCallback(() => {
+    onSelect(selectedFp || modelName);
+    onClose();
+  }, [selectedFp, modelName, onSelect, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
+      <div className="bg-bg-primary border border-border rounded-lg shadow-2xl w-[500px] max-h-[600px] flex flex-col">
+        {/* Title bar */}
+        <div className="flex items-center justify-between px-4 py-2 bg-bg-secondary border-b border-border-subtle rounded-t-lg">
+          <span className="text-[12px] font-semibold text-text-primary">PCB Model</span>
+          <button onClick={onClose} className="text-text-muted/50 hover:text-text-primary"><X size={14} /></button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 space-y-4 text-[11px]">
+          {/* Footprint Model section */}
+          <fieldset className="border border-border-subtle rounded p-3">
+            <legend className="text-[10px] font-semibold text-text-secondary px-1">Footprint Model</legend>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="w-[70px] text-text-muted/60 text-right shrink-0">Name</span>
+                <input value={modelName} onChange={e => setModelName(e.target.value)}
+                  className="flex-1 bg-bg-secondary border border-border-subtle rounded px-2 py-1 text-[11px] text-text-primary outline-none" />
+                <button onClick={handleBrowse}
+                  className="px-3 py-1 bg-bg-secondary border border-border-subtle rounded text-text-secondary hover:text-text-primary text-[10px]">
+                  Browse...
+                </button>
+                <button className="px-3 py-1 bg-bg-secondary border border-border-subtle rounded text-text-secondary hover:text-text-primary text-[10px]">
+                  Pin Map...
+                </button>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="w-[70px] text-text-muted/60 text-right shrink-0">Description</span>
+                <div className="flex-1 bg-bg-secondary border border-border-subtle rounded px-2 py-1 text-[11px] text-text-muted/60">
+                  {description || "Footprint not found"}
+                </div>
+              </div>
+            </div>
+          </fieldset>
+
+          {/* PCB Library section */}
+          <fieldset className="border border-border-subtle rounded p-3">
+            <legend className="text-[10px] font-semibold text-text-secondary px-1">PCB Library</legend>
+            <div className="space-y-1.5">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input type="radio" name="libMode" checked={libraryMode === "any"}
+                  onChange={() => setLibraryMode("any")} />
+                <span className="text-text-secondary">Any</span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input type="radio" name="libMode" checked={libraryMode === "name"}
+                  onChange={() => setLibraryMode("name")} />
+                <span className="text-text-secondary">Library name</span>
+                <input value={libraryFilter} onChange={e => setLibraryFilter(e.target.value)}
+                  disabled={libraryMode !== "name"}
+                  className="flex-1 bg-bg-secondary border border-border-subtle rounded px-2 py-0.5 text-[10px] text-text-primary outline-none disabled:opacity-40" />
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input type="radio" name="libMode" checked={libraryMode === "path"}
+                  onChange={() => setLibraryMode("path")} />
+                <span className="text-text-secondary">Library path</span>
+                <input disabled className="flex-1 bg-bg-secondary border border-border-subtle rounded px-2 py-0.5 text-[10px] text-text-primary outline-none opacity-40" />
+                <button disabled className="px-2 py-0.5 bg-bg-secondary border border-border-subtle rounded text-[10px] text-text-muted/40">
+                  Choose...
+                </button>
+              </label>
+            </div>
+          </fieldset>
+
+          {/* Selected Footprint section */}
+          <fieldset className="border border-border-subtle rounded p-3 min-h-[120px]">
+            <legend className="text-[10px] font-semibold text-text-secondary px-1">Selected Footprint</legend>
+            {loading ? (
+              <div className="text-center text-text-muted/40 py-4">Loading footprints...</div>
+            ) : footprints.length === 0 ? (
+              <div className="text-center text-text-muted/40 py-4">No footprints found</div>
+            ) : (
+              <div className="max-h-[150px] overflow-y-auto">
+                {footprints.filter(fp =>
+                  !modelName || fp.name.toLowerCase().includes(modelName.toLowerCase()) || fp.fullId.toLowerCase().includes(modelName.toLowerCase())
+                ).slice(0, 50).map(fp => (
+                  <div key={fp.fullId}
+                    onClick={() => handleSelect(fp)}
+                    className={cn("px-2 py-0.5 cursor-pointer text-[10px] truncate",
+                      selectedFp === fp.fullId ? "bg-accent/15 text-accent" : "text-text-secondary hover:bg-bg-hover/50"
+                    )}>
+                    {fp.fullId}
+                  </div>
+                ))}
+              </div>
+            )}
+          </fieldset>
+
+          {/* Found in */}
+          <div className="text-[10px] text-text-muted/50">
+            Found in: <span className="text-text-secondary">{foundIn || "(none)"}</span>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-border-subtle">
+          <button onClick={handleOk}
+            className="px-4 py-1.5 bg-accent text-bg-primary rounded text-[11px] font-medium hover:bg-accent/90">
+            OK
+          </button>
+          <button onClick={onClose}
+            className="px-4 py-1.5 bg-bg-secondary border border-border-subtle rounded text-[11px] text-text-secondary hover:text-text-primary">
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/LibraryEditorProperties.tsx
+++ b/src/components/LibraryEditorProperties.tsx
@@ -306,7 +306,7 @@ export function LibraryEditorProperties() {
   const setPanelView = useLibraryEditorStore(s => s.setPanelView);
 
   return (
-    <div className="flex flex-col h-full w-[280px] border-l border-border bg-bg-primary">
+    <div className="flex flex-col h-full">
       <TabBar view={panelView} setView={setPanelView} />
       <div className="flex-1 overflow-hidden">
         {panelView === "properties" ? <PropertiesTab /> : <PinTableTab />}

--- a/src/components/LibraryEditorProperties.tsx
+++ b/src/components/LibraryEditorProperties.tsx
@@ -76,6 +76,18 @@ function GeneralTab({ symbol, paramTab, setParamTab }: {
 }) {
   const updateSymbolId = useLibraryEditorStore(s => s.updateSymbolId);
   const updateSymbolMeta = useLibraryEditorStore(s => s.updateSymbolMeta);
+  const designatorPrefix = useLibraryEditorStore(s => s.designatorPrefix);
+  const setDesignatorPrefix = useLibraryEditorStore(s => s.setDesignatorPrefix);
+  const comment = useLibraryEditorStore(s => s.comment);
+  const setComment = useLibraryEditorStore(s => s.setComment);
+  const description = useLibraryEditorStore(s => s.description);
+  const setDescription = useLibraryEditorStore(s => s.setDescription);
+  const footprint = useLibraryEditorStore(s => s.footprint);
+  const setFootprint = useLibraryEditorStore(s => s.setFootprint);
+  const componentType = useLibraryEditorStore(s => s.componentType);
+  const setComponentType = useLibraryEditorStore(s => s.setComponentType);
+  const mirrored = useLibraryEditorStore(s => s.mirrored);
+  const setMirrored = useLibraryEditorStore(s => s.setMirrored);
 
   return (
     <>
@@ -87,36 +99,40 @@ function GeneralTab({ symbol, paramTab, setParamTab }: {
         </Row>
         <Row label="Designator">
           <div className="flex items-center gap-1">
-            <input value="" placeholder="?" className={cn(inp, "flex-1")} disabled />
-            <Eye size={12} className="text-text-muted/40 shrink-0" />
-            <Lock size={12} className="text-text-muted/40 shrink-0" />
+            <input value={designatorPrefix} onChange={e => setDesignatorPrefix(e.target.value)}
+              placeholder="U?" className={cn(inp, "flex-1")} />
+            <button className="text-text-muted/40 hover:text-accent" title="Toggle visibility"><Eye size={12} /></button>
+            <button className="text-text-muted/40 hover:text-accent" title="Lock"><Lock size={12} /></button>
           </div>
         </Row>
         <Row label="Comment">
           <div className="flex items-center gap-1">
-            <input value="*" className={cn(inp, "flex-1")} disabled />
-            <Eye size={12} className="text-text-muted/40 shrink-0" />
-            <Lock size={12} className="text-text-muted/40 shrink-0" />
+            <input value={comment} onChange={e => setComment(e.target.value)} className={cn(inp, "flex-1")} />
+            <button className="text-text-muted/40 hover:text-accent" title="Toggle visibility"><Eye size={12} /></button>
+            <button className="text-text-muted/40 hover:text-accent" title="Lock"><Lock size={12} /></button>
           </div>
         </Row>
         <Row label="Part">
           <div className="flex items-center gap-1">
-            <select className={cn(inp, "flex-1")} disabled>
-              <option>Part A</option>
+            <select className={cn(inp, "flex-1")} defaultValue="A">
+              {Array.from({ length: symbol.unit_count ?? 1 }, (_, i) => (
+                <option key={i} value={String.fromCharCode(65 + i)}>Part {String.fromCharCode(65 + i)}</option>
+              ))}
             </select>
             <span className="text-text-muted/50 whitespace-nowrap">of Parts</span>
-            <input value={symbol.unit_count ?? 1} className={cn(inp, "w-8 text-center")} disabled />
+            <input value={symbol.unit_count ?? 1} className={cn(inp, "w-8 text-center")} readOnly />
           </div>
         </Row>
         <Row label="Description">
-          <textarea rows={3} className={cn(inp, "resize-none")} placeholder="" />
+          <textarea rows={3} value={description} onChange={e => setDescription(e.target.value)}
+            className={cn(inp, "resize-none")} />
         </Row>
         <Row label="Type">
-          <select className={inp}>
-            <option>Standard (No BOM)</option>
-            <option>Standard</option>
-            <option>Mechanical</option>
-            <option>Graphical</option>
+          <select value={componentType} onChange={e => setComponentType(e.target.value as any)} className={inp}>
+            <option value="standard_no_bom">Standard (No BOM)</option>
+            <option value="standard">Standard</option>
+            <option value="mechanical">Mechanical</option>
+            <option value="graphical">Graphical</option>
           </select>
         </Row>
       </div>
@@ -124,7 +140,6 @@ function GeneralTab({ symbol, paramTab, setParamTab }: {
       {/* Parameters section */}
       <SectionHeader title="Parameters" />
       <div className="px-1.5 py-1">
-        {/* Sub-tabs: All | Footprints | Models | Parameters | Links | Rules */}
         <div className="flex flex-wrap gap-0.5 mb-1.5">
           {["All", "Footprints", "Models", "Parameters", "Links", "Rules"].map(t => (
             <button key={t} onClick={() => setParamTab(t)}
@@ -138,23 +153,32 @@ function GeneralTab({ symbol, paramTab, setParamTab }: {
           ))}
         </div>
 
-        {/* Parameters table */}
         <div className="border border-border-subtle rounded overflow-hidden">
           <div className="flex items-center px-2 py-0.5 bg-bg-secondary/60 border-b border-border-subtle text-[9px] font-semibold text-text-muted/50">
             <span className="flex-1">Name</span>
-            <span className="w-[120px] text-right">Value</span>
+            <span className="w-[140px] text-right">Value</span>
           </div>
-          <div className="flex items-center px-2 py-1 hover:bg-bg-hover/30">
-            <span className="flex-1 text-text-secondary">Footprint</span>
-            <span className="w-[120px] text-right font-mono text-text-muted/60 truncate">(none)</span>
-          </div>
-          <div className="px-2 py-2 text-center text-text-muted/30">No Models</div>
-          <div className="px-2 py-1 text-center text-text-muted/30">No Parameters</div>
-          <div className="px-2 py-1 text-center text-text-muted/30">No Links</div>
-          <div className="px-2 py-1 text-center text-text-muted/30">No Rules</div>
+          {(paramTab === "All" || paramTab === "Footprints") && (
+            <div className="flex items-center px-2 py-1 hover:bg-bg-hover/30 border-b border-border-subtle/20">
+              <span className="flex-1 text-text-secondary">Footprint</span>
+              <input value={footprint} onChange={e => setFootprint(e.target.value)}
+                placeholder="(none)" className="w-[140px] text-right bg-transparent outline-none text-[10px] font-mono text-text-primary" />
+            </div>
+          )}
+          {(paramTab === "All" || paramTab === "Models") && (
+            <div className="px-2 py-1.5 text-center text-text-muted/30">No Models</div>
+          )}
+          {(paramTab === "All" || paramTab === "Parameters") && (
+            <div className="px-2 py-1.5 text-center text-text-muted/30">No Parameters</div>
+          )}
+          {(paramTab === "All" || paramTab === "Links") && (
+            <div className="px-2 py-1.5 text-center text-text-muted/30">No Links</div>
+          )}
+          {(paramTab === "All" || paramTab === "Rules") && (
+            <div className="px-2 py-1.5 text-center text-text-muted/30">No Rules</div>
+          )}
         </div>
 
-        {/* Add / Edit / Delete buttons */}
         <div className="flex items-center justify-end gap-1 mt-1.5">
           <button className="px-2 py-0.5 text-[9px] bg-bg-secondary border border-border-subtle rounded text-text-secondary hover:text-text-primary">
             Add <ChevronDown size={8} className="inline" />
@@ -166,17 +190,17 @@ function GeneralTab({ symbol, paramTab, setParamTab }: {
       <SectionHeader title="Graphical" />
       <div className="px-3 py-2 space-y-2">
         <label className="flex items-center gap-2 cursor-pointer">
-          <input type="checkbox" className="rounded" />
+          <input type="checkbox" checked={mirrored} onChange={e => setMirrored(e.target.checked)} className="rounded" />
           <span className="text-text-secondary">Mirrored</span>
         </label>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-wrap">
           <span className="text-text-muted/60">Local Colors</span>
           <span className="text-text-muted/50">Fills</span>
-          <div className="w-4 h-4 rounded border border-white/10 bg-[#666644]" />
+          <div className="w-4 h-4 rounded border border-white/10 bg-[#666644] cursor-pointer" title="Fill color" />
           <span className="text-text-muted/50">Lines</span>
-          <div className="w-4 h-4 rounded border border-white/10 bg-[#cc4444]" />
+          <div className="w-4 h-4 rounded border border-white/10 bg-[#cc4444] cursor-pointer" title="Line color" />
           <span className="text-text-muted/50">Pins</span>
-          <div className="w-4 h-4 rounded border border-white/10 bg-[#888888]" />
+          <div className="w-4 h-4 rounded border border-white/10 bg-[#888888] cursor-pointer" title="Pin color" />
         </div>
       </div>
 

--- a/src/components/LibraryEditorProperties.tsx
+++ b/src/components/LibraryEditorProperties.tsx
@@ -3,6 +3,7 @@ import { useLibraryEditorStore } from "@/stores/libraryEditor";
 import type { SchPin } from "@/types";
 import { cn } from "@/lib/utils";
 import { Eye, Lock, ChevronDown } from "lucide-react";
+import { FootprintPickerDialog } from "@/components/FootprintPickerDialog";
 
 const PIN_TYPES = [
   "passive", "input", "output", "bidirectional", "power_in", "power_out",
@@ -88,8 +89,16 @@ function GeneralTab({ symbol, paramTab, setParamTab }: {
   const setComponentType = useLibraryEditorStore(s => s.setComponentType);
   const mirrored = useLibraryEditorStore(s => s.mirrored);
   const setMirrored = useLibraryEditorStore(s => s.setMirrored);
+  const [fpPickerOpen, setFpPickerOpen] = useState(false);
 
   return (
+    <>
+    <FootprintPickerDialog
+      open={fpPickerOpen}
+      initialValue={footprint}
+      onClose={() => setFpPickerOpen(false)}
+      onSelect={(id) => setFootprint(id)}
+    />
     <>
       {/* General section */}
       <SectionHeader title="General" />
@@ -159,10 +168,11 @@ function GeneralTab({ symbol, paramTab, setParamTab }: {
             <span className="w-[140px] text-right">Value</span>
           </div>
           {(paramTab === "All" || paramTab === "Footprints") && (
-            <div className="flex items-center px-2 py-1 hover:bg-bg-hover/30 border-b border-border-subtle/20">
+            <div className="flex items-center px-2 py-1 hover:bg-bg-hover/30 border-b border-border-subtle/20 gap-1">
               <span className="flex-1 text-text-secondary">Footprint</span>
-              <input value={footprint} onChange={e => setFootprint(e.target.value)}
-                placeholder="(none)" className="w-[140px] text-right bg-transparent outline-none text-[10px] font-mono text-text-primary" />
+              <span className="font-mono text-text-muted/60 truncate max-w-[100px]">{footprint || "(none)"}</span>
+              <button onClick={() => setFpPickerOpen(true)}
+                className="text-[9px] text-accent hover:underline shrink-0">Show</button>
             </div>
           )}
           {(paramTab === "All" || paramTab === "Models") && (
@@ -180,7 +190,8 @@ function GeneralTab({ symbol, paramTab, setParamTab }: {
         </div>
 
         <div className="flex items-center justify-end gap-1 mt-1.5">
-          <button className="px-2 py-0.5 text-[9px] bg-bg-secondary border border-border-subtle rounded text-text-secondary hover:text-text-primary">
+          <button onClick={() => setFpPickerOpen(true)}
+            className="px-2 py-0.5 text-[9px] bg-bg-secondary border border-border-subtle rounded text-text-secondary hover:text-text-primary">
             Add <ChevronDown size={8} className="inline" />
           </button>
         </div>
@@ -232,6 +243,7 @@ function GeneralTab({ symbol, paramTab, setParamTab }: {
             className={cn(inp, "w-16")} />
         </Row>
       </div>
+    </>
     </>
   );
 }

--- a/src/components/LibraryEditorProperties.tsx
+++ b/src/components/LibraryEditorProperties.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from "react";
+import { useState, useCallback } from "react";
 import { useLibraryEditorStore } from "@/stores/libraryEditor";
-import type { LibPanelView } from "@/stores/libraryEditor";
 import type { SchPin } from "@/types";
 import { cn } from "@/lib/utils";
+import { Eye, Lock, ChevronDown } from "lucide-react";
 
 const PIN_TYPES = [
   "passive", "input", "output", "bidirectional", "power_in", "power_out",
@@ -14,259 +14,260 @@ const PIN_SHAPES = [
   "output_low", "edge_clock_high", "non_logic",
 ];
 
+const inp = "bg-bg-secondary border border-border-subtle rounded px-1.5 py-0.5 text-[10px] text-text-primary outline-none w-full";
+
 // ---------------------------------------------------------------------------
-// Tab bar
+// Main export — Altium-style Properties for symbol editor
 // ---------------------------------------------------------------------------
 
-function TabBar({ view, setView }: { view: LibPanelView; setView: (v: LibPanelView) => void }) {
+export function LibraryEditorProperties() {
+  const symbol = useLibraryEditorStore(s => s.symbol);
+  const [tab, setTab] = useState<"general" | "pins">("general");
+  const [paramTab, setParamTab] = useState("All");
+
+  if (!symbol) return <div className="p-4 text-xs text-text-muted/50">No symbol loaded</div>;
+
+  const pinCount = symbol.pins.length;
+
   return (
-    <div className="flex border-b border-border-subtle bg-bg-secondary/80 shrink-0">
-      {([["properties", "Properties"], ["pinTable", "Pin Table"]] as const).map(([id, label]) => (
-        <button key={id} onClick={() => setView(id)}
-          className={cn("px-3 py-1.5 text-[10px] font-medium transition-colors",
-            view === id ? "text-accent border-b-2 border-accent" : "text-text-muted/60 hover:text-text-primary"
-          )}>
-          {label}
-        </button>
-      ))}
+    <div className="flex flex-col h-full overflow-hidden text-[10px]">
+      {/* Header — Altium: "Component" + "Pins (and N more)" */}
+      <div className="flex items-center justify-between px-3 py-1.5 bg-accent/10 border-b border-border-subtle shrink-0">
+        <span className="font-semibold text-text-secondary text-[11px]">Component</span>
+        <span className="text-text-muted/60">Pins (and {pinCount} more)</span>
+      </div>
+
+      {/* General | Pins tabs */}
+      <div className="flex border-b border-border-subtle bg-bg-secondary/60 shrink-0">
+        {(["general", "pins"] as const).map(t => (
+          <button key={t} onClick={() => setTab(t)}
+            className={cn("px-3 py-1.5 text-[10px] font-medium capitalize",
+              tab === t ? "text-accent border-b-2 border-accent" : "text-text-muted/50 hover:text-text-primary"
+            )}>
+            {t}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {tab === "general" ? (
+          <GeneralTab symbol={symbol} paramTab={paramTab} setParamTab={setParamTab} />
+        ) : (
+          <PinsTab />
+        )}
+      </div>
+
+      {/* Status bar */}
+      <div className="px-3 py-1 border-t border-border-subtle text-[10px] text-accent/70 shrink-0">
+        1 object is selected
+      </div>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Properties tab: symbol metadata + selected item properties
+// General tab
 // ---------------------------------------------------------------------------
 
-function PropertiesTab() {
-  const symbol = useLibraryEditorStore(s => s.symbol);
-  const selectedItem = useLibraryEditorStore(s => s.selectedItem);
-  const updateSymbolMeta = useLibraryEditorStore(s => s.updateSymbolMeta);
+function GeneralTab({ symbol, paramTab, setParamTab }: {
+  symbol: import("@/types").LibSymbol;
+  paramTab: string;
+  setParamTab: (t: string) => void;
+}) {
   const updateSymbolId = useLibraryEditorStore(s => s.updateSymbolId);
-  const updatePin = useLibraryEditorStore(s => s.updatePin);
-  const updateGraphic = useLibraryEditorStore(s => s.updateGraphic);
-
-  if (!symbol) return <div className="p-3 text-[10px] text-text-muted/50">No symbol loaded</div>;
+  const updateSymbolMeta = useLibraryEditorStore(s => s.updateSymbolMeta);
 
   return (
-    <div className="overflow-y-auto text-[10px]">
-      {/* Symbol metadata */}
-      <Section title="Symbol">
-        <Field label="ID">
-          <input value={symbol.id} onChange={e => updateSymbolId(e.target.value)}
-            className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none" />
-        </Field>
-        <Field label="Pins">{symbol.pins.length}</Field>
-        <Field label="Graphics">{symbol.graphics.length}</Field>
-        <Field label="Show Pin Numbers">
+    <>
+      {/* General section */}
+      <SectionHeader title="General" />
+      <div className="px-3 py-1.5 space-y-1.5">
+        <Row label="Design Item ID">
+          <input value={symbol.id} onChange={e => updateSymbolId(e.target.value)} className={inp} />
+        </Row>
+        <Row label="Designator">
+          <div className="flex items-center gap-1">
+            <input value="" placeholder="?" className={cn(inp, "flex-1")} disabled />
+            <Eye size={12} className="text-text-muted/40 shrink-0" />
+            <Lock size={12} className="text-text-muted/40 shrink-0" />
+          </div>
+        </Row>
+        <Row label="Comment">
+          <div className="flex items-center gap-1">
+            <input value="*" className={cn(inp, "flex-1")} disabled />
+            <Eye size={12} className="text-text-muted/40 shrink-0" />
+            <Lock size={12} className="text-text-muted/40 shrink-0" />
+          </div>
+        </Row>
+        <Row label="Part">
+          <div className="flex items-center gap-1">
+            <select className={cn(inp, "flex-1")} disabled>
+              <option>Part A</option>
+            </select>
+            <span className="text-text-muted/50 whitespace-nowrap">of Parts</span>
+            <input value={symbol.unit_count ?? 1} className={cn(inp, "w-8 text-center")} disabled />
+          </div>
+        </Row>
+        <Row label="Description">
+          <textarea rows={3} className={cn(inp, "resize-none")} placeholder="" />
+        </Row>
+        <Row label="Type">
+          <select className={inp}>
+            <option>Standard (No BOM)</option>
+            <option>Standard</option>
+            <option>Mechanical</option>
+            <option>Graphical</option>
+          </select>
+        </Row>
+      </div>
+
+      {/* Parameters section */}
+      <SectionHeader title="Parameters" />
+      <div className="px-1.5 py-1">
+        {/* Sub-tabs: All | Footprints | Models | Parameters | Links | Rules */}
+        <div className="flex flex-wrap gap-0.5 mb-1.5">
+          {["All", "Footprints", "Models", "Parameters", "Links", "Rules"].map(t => (
+            <button key={t} onClick={() => setParamTab(t)}
+              className={cn("px-2 py-0.5 rounded text-[9px] font-medium border",
+                paramTab === t
+                  ? "bg-accent/20 border-accent text-accent"
+                  : "border-border-subtle text-text-muted/50 hover:text-text-primary hover:border-text-muted/30"
+              )}>
+              {t}
+            </button>
+          ))}
+        </div>
+
+        {/* Parameters table */}
+        <div className="border border-border-subtle rounded overflow-hidden">
+          <div className="flex items-center px-2 py-0.5 bg-bg-secondary/60 border-b border-border-subtle text-[9px] font-semibold text-text-muted/50">
+            <span className="flex-1">Name</span>
+            <span className="w-[120px] text-right">Value</span>
+          </div>
+          <div className="flex items-center px-2 py-1 hover:bg-bg-hover/30">
+            <span className="flex-1 text-text-secondary">Footprint</span>
+            <span className="w-[120px] text-right font-mono text-text-muted/60 truncate">(none)</span>
+          </div>
+          <div className="px-2 py-2 text-center text-text-muted/30">No Models</div>
+          <div className="px-2 py-1 text-center text-text-muted/30">No Parameters</div>
+          <div className="px-2 py-1 text-center text-text-muted/30">No Links</div>
+          <div className="px-2 py-1 text-center text-text-muted/30">No Rules</div>
+        </div>
+
+        {/* Add / Edit / Delete buttons */}
+        <div className="flex items-center justify-end gap-1 mt-1.5">
+          <button className="px-2 py-0.5 text-[9px] bg-bg-secondary border border-border-subtle rounded text-text-secondary hover:text-text-primary">
+            Add <ChevronDown size={8} className="inline" />
+          </button>
+        </div>
+      </div>
+
+      {/* Graphical section */}
+      <SectionHeader title="Graphical" />
+      <div className="px-3 py-2 space-y-2">
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" className="rounded" />
+          <span className="text-text-secondary">Mirrored</span>
+        </label>
+        <div className="flex items-center gap-3">
+          <span className="text-text-muted/60">Local Colors</span>
+          <span className="text-text-muted/50">Fills</span>
+          <div className="w-4 h-4 rounded border border-white/10 bg-[#666644]" />
+          <span className="text-text-muted/50">Lines</span>
+          <div className="w-4 h-4 rounded border border-white/10 bg-[#cc4444]" />
+          <span className="text-text-muted/50">Pins</span>
+          <div className="w-4 h-4 rounded border border-white/10 bg-[#888888]" />
+        </div>
+      </div>
+
+      {/* Part Choices section */}
+      <SectionHeader title="Part Choices" />
+      <div className="px-3 py-2">
+        <button className="px-2 py-1 text-[10px] bg-bg-secondary border border-border-subtle rounded text-text-secondary hover:text-text-primary">
+          Edit Supplier Links...
+        </button>
+        <div className="mt-1 text-text-muted/40">No part choices found</div>
+      </div>
+
+      {/* Pin visibility toggles */}
+      <SectionHeader title="Display" />
+      <div className="px-3 py-2 space-y-1">
+        <label className="flex items-center gap-2 cursor-pointer">
           <input type="checkbox" checked={symbol.show_pin_numbers}
             onChange={e => updateSymbolMeta({ show_pin_numbers: e.target.checked })} />
-        </Field>
-        <Field label="Show Pin Names">
+          <span className="text-text-secondary">Show Pin Numbers</span>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer">
           <input type="checkbox" checked={symbol.show_pin_names}
             onChange={e => updateSymbolMeta({ show_pin_names: e.target.checked })} />
-        </Field>
-        <Field label="Name Offset">
+          <span className="text-text-secondary">Show Pin Names</span>
+        </label>
+        <Row label="Name Offset">
           <input type="number" step={0.1} value={symbol.pin_name_offset}
             onChange={e => updateSymbolMeta({ pin_name_offset: parseFloat(e.target.value) || 0 })}
-            className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16" />
-        </Field>
-      </Section>
-
-      {/* Selected pin properties */}
-      {selectedItem?.type === "pin" && selectedItem.index < symbol.pins.length && (
-        <SelectedPinProperties pin={symbol.pins[selectedItem.index]} index={selectedItem.index} updatePin={updatePin} />
-      )}
-
-      {/* Selected graphic properties */}
-      {selectedItem?.type === "graphic" && selectedItem.index < symbol.graphics.length && (
-        <SelectedGraphicProperties graphic={symbol.graphics[selectedItem.index]} index={selectedItem.index} updateGraphic={updateGraphic} />
-      )}
-    </div>
-  );
-}
-
-function SelectedPinProperties({ pin, index, updatePin }: { pin: SchPin; index: number; updatePin: (i: number, u: Partial<SchPin>) => void }) {
-  const u = useCallback((updates: Partial<SchPin>) => updatePin(index, updates), [index, updatePin]);
-
-  return (
-    <Section title={`Pin ${pin.number}: ${pin.name}`}>
-      <Field label="Name">
-        <input value={pin.name} onChange={e => u({ name: e.target.value })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none" />
-      </Field>
-      <Field label="Number">
-        <input value={pin.number} onChange={e => u({ number: e.target.value })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16" />
-      </Field>
-      <Field label="Electrical Type">
-        <select value={pin.pin_type} onChange={e => u({ pin_type: e.target.value })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none">
-          {PIN_TYPES.map(t => <option key={t} value={t}>{t.replace(/_/g, " ")}</option>)}
-        </select>
-      </Field>
-      <Field label="Shape">
-        <select value={pin.shape} onChange={e => u({ shape: e.target.value })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none">
-          {PIN_SHAPES.map(s => <option key={s} value={s}>{s.replace(/_/g, " ")}</option>)}
-        </select>
-      </Field>
-      <Field label="Length">
-        <input type="number" step={0.01} value={pin.length}
-          onChange={e => u({ length: parseFloat(e.target.value) || 2.54 })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16" />
-      </Field>
-      <Field label="Rotation">
-        <select value={pin.rotation} onChange={e => u({ rotation: parseInt(e.target.value) })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16">
-          {[0, 90, 180, 270].map(r => <option key={r} value={r}>{r}&deg;</option>)}
-        </select>
-      </Field>
-      <Field label="Position X">
-        <input type="number" step={1.27} value={pin.position.x.toFixed(2)}
-          onChange={e => u({ position: { ...pin.position, x: parseFloat(e.target.value) || 0 } })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-20" />
-      </Field>
-      <Field label="Position Y">
-        <input type="number" step={1.27} value={pin.position.y.toFixed(2)}
-          onChange={e => u({ position: { ...pin.position, y: parseFloat(e.target.value) || 0 } })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-20" />
-      </Field>
-      <Field label="Name Visible">
-        <input type="checkbox" checked={pin.name_visible} onChange={e => u({ name_visible: e.target.checked })} />
-      </Field>
-      <Field label="Number Visible">
-        <input type="checkbox" checked={pin.number_visible} onChange={e => u({ number_visible: e.target.checked })} />
-      </Field>
-      <Field label="Hidden">
-        <input type="checkbox" checked={pin.hidden ?? false} onChange={e => u({ hidden: e.target.checked })} />
-      </Field>
-    </Section>
-  );
-}
-
-function SelectedGraphicProperties({ graphic, index, updateGraphic }: { graphic: import("@/types").Graphic; index: number; updateGraphic: (i: number, g: import("@/types").Graphic) => void }) {
-  const g = graphic;
-  const update = useCallback((partial: Record<string, any>) => {
-    updateGraphic(index, { ...g, ...partial } as any);
-  }, [index, g, updateGraphic]);
-
-  return (
-    <Section title={`Graphic: ${g.type}`}>
-      {"width" in g && (
-        <Field label="Line Width">
-          <input type="number" step={0.01} value={(g as any).width}
-            onChange={e => update({ width: parseFloat(e.target.value) || 0.254 })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16" />
-        </Field>
-      )}
-      {"fill_type" in g && (
-        <Field label="Fill">
-          <select value={(g as any).fill_type} onChange={e => update({ fill_type: e.target.value })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none">
-            <option value="none">None</option>
-            <option value="outline">Outline</option>
-            <option value="background">Background</option>
-          </select>
-        </Field>
-      )}
-      {g.type === "Rectangle" && (
-        <>
-          <Field label="Start X">
-            <input type="number" step={1.27} value={g.start.x.toFixed(2)} onChange={e => update({ start: { ...g.start, x: parseFloat(e.target.value) || 0 } })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-20" />
-          </Field>
-          <Field label="Start Y">
-            <input type="number" step={1.27} value={g.start.y.toFixed(2)} onChange={e => update({ start: { ...g.start, y: parseFloat(e.target.value) || 0 } })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-20" />
-          </Field>
-          <Field label="End X">
-            <input type="number" step={1.27} value={g.end.x.toFixed(2)} onChange={e => update({ end: { ...g.end, x: parseFloat(e.target.value) || 0 } })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-20" />
-          </Field>
-          <Field label="End Y">
-            <input type="number" step={1.27} value={g.end.y.toFixed(2)} onChange={e => update({ end: { ...g.end, y: parseFloat(e.target.value) || 0 } })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-20" />
-          </Field>
-        </>
-      )}
-      {g.type === "Circle" && (
-        <>
-          <Field label="Center X">
-            <input type="number" step={1.27} value={g.center.x.toFixed(2)} onChange={e => update({ center: { ...g.center, x: parseFloat(e.target.value) || 0 } })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-20" />
-          </Field>
-          <Field label="Center Y">
-            <input type="number" step={1.27} value={g.center.y.toFixed(2)} onChange={e => update({ center: { ...g.center, y: parseFloat(e.target.value) || 0 } })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-20" />
-          </Field>
-          <Field label="Radius">
-            <input type="number" step={0.1} value={g.radius.toFixed(2)} onChange={e => update({ radius: parseFloat(e.target.value) || 1 })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-20" />
-          </Field>
-        </>
-      )}
-      {g.type === "Text" && (
-        <>
-          <Field label="Text">
-            <input value={g.text} onChange={e => update({ text: e.target.value })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none" />
-          </Field>
-          <Field label="Font Size">
-            <input type="number" step={0.1} value={g.font_size} onChange={e => update({ font_size: parseFloat(e.target.value) || 1.27 })} className="bg-bg-secondary border border-border-subtle rounded px-1 py-0.5 text-[10px] text-text-primary outline-none w-16" />
-          </Field>
-        </>
-      )}
-    </Section>
+            className={cn(inp, "w-16")} />
+        </Row>
+      </div>
+    </>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Pin Table tab: spreadsheet view of all pins
+// Pins tab — table of all pins with inline editing
 // ---------------------------------------------------------------------------
 
-function PinTableTab() {
+function PinsTab() {
   const symbol = useLibraryEditorStore(s => s.symbol);
   const updatePin = useLibraryEditorStore(s => s.updatePin);
-  const setSelectedItem = useLibraryEditorStore(s => s.setSelectedItem);
   const selectedItem = useLibraryEditorStore(s => s.selectedItem);
+  const setSelectedItem = useLibraryEditorStore(s => s.setSelectedItem);
 
-  if (!symbol) return <div className="p-3 text-[10px] text-text-muted/50">No symbol loaded</div>;
+  if (!symbol) return null;
 
+  // If a pin is selected, show its detail properties
+  if (selectedItem?.type === "pin" && selectedItem.index < symbol.pins.length) {
+    return <PinDetailProperties pin={symbol.pins[selectedItem.index]} index={selectedItem.index} updatePin={updatePin} />;
+  }
+
+  // Otherwise show pin table
   return (
-    <div className="overflow-auto text-[10px]">
+    <div className="overflow-auto">
       <table className="w-full border-collapse">
         <thead className="sticky top-0 z-10 bg-bg-surface">
           <tr className="border-b border-border-subtle text-left">
-            <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50 font-medium w-[32px]">#</th>
+            <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50 font-medium w-[28px]">#</th>
             <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50 font-medium">Name</th>
             <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50 font-medium w-[36px]">Num</th>
             <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50 font-medium">Type</th>
-            <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50 font-medium">Shape</th>
-            <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50 font-medium w-[42px]">Len</th>
-            <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50 font-medium w-[36px]">Rot</th>
+            <th className="px-1.5 py-1 text-[9px] uppercase text-text-muted/50 font-medium w-[36px]">Len</th>
           </tr>
         </thead>
         <tbody>
           {symbol.pins.map((pin, i) => {
-            const isSelected = selectedItem?.type === "pin" && selectedItem.index === i;
+            const isSel = selectedItem?.type === "pin" && selectedItem.index === i;
             return (
-              <tr key={i}
-                onClick={() => setSelectedItem({ type: "pin", index: i })}
-                className={cn("border-b border-border-subtle/20 cursor-pointer transition-colors",
-                  isSelected ? "bg-accent/15" : "hover:bg-bg-hover/50"
+              <tr key={i} onClick={() => setSelectedItem({ type: "pin", index: i })}
+                className={cn("border-b border-border-subtle/20 cursor-pointer",
+                  isSel ? "bg-accent/15" : "hover:bg-bg-hover/50"
                 )}>
                 <td className="px-1.5 py-0.5 text-text-muted/50 tabular-nums">{i + 1}</td>
                 <td className="px-1.5 py-0.5">
                   <input value={pin.name} onChange={e => updatePin(i, { name: e.target.value })}
-                    className="bg-transparent w-full outline-none text-text-primary font-mono" />
+                    className="bg-transparent w-full outline-none text-text-primary font-mono text-[10px]" />
                 </td>
                 <td className="px-1.5 py-0.5">
                   <input value={pin.number} onChange={e => updatePin(i, { number: e.target.value })}
-                    className="bg-transparent w-full outline-none text-text-primary font-mono" />
+                    className="bg-transparent w-full outline-none text-text-primary font-mono text-[10px]" />
                 </td>
-                <td className="px-1.5 py-0.5">
-                  <select value={pin.pin_type} onChange={e => updatePin(i, { pin_type: e.target.value })}
-                    className="bg-transparent outline-none text-text-secondary text-[10px] w-full">
-                    {PIN_TYPES.map(t => <option key={t} value={t}>{t.replace(/_/g, " ")}</option>)}
-                  </select>
-                </td>
-                <td className="px-1.5 py-0.5">
-                  <select value={pin.shape} onChange={e => updatePin(i, { shape: e.target.value })}
-                    className="bg-transparent outline-none text-text-secondary text-[10px] w-full">
-                    {PIN_SHAPES.map(s => <option key={s} value={s}>{s.replace(/_/g, " ")}</option>)}
-                  </select>
-                </td>
+                <td className="px-1.5 py-0.5 text-text-muted/60">{pin.pin_type.replace(/_/g, " ")}</td>
                 <td className="px-1.5 py-0.5 font-mono">{pin.length.toFixed(1)}</td>
-                <td className="px-1.5 py-0.5 font-mono">{pin.rotation}&deg;</td>
               </tr>
             );
           })}
         </tbody>
       </table>
       {symbol.pins.length === 0 && (
-        <div className="p-4 text-center text-text-muted/40">No pins. Use the Pin tool to add pins.</div>
+        <div className="p-4 text-center text-text-muted/40">No pins</div>
       )}
       <div className="px-2 py-1 border-t border-border-subtle text-text-muted/50">
         {symbol.pins.length} pin{symbol.pins.length !== 1 ? "s" : ""}
@@ -276,41 +277,83 @@ function PinTableTab() {
 }
 
 // ---------------------------------------------------------------------------
-// Shared UI components
+// Pin detail properties (when a pin is selected)
 // ---------------------------------------------------------------------------
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div className="border-b border-border-subtle">
-      <div className="px-3 py-1.5 bg-bg-secondary/60 text-[10px] font-semibold text-text-secondary">{title}</div>
-      <div className="px-3 py-1 space-y-0.5">{children}</div>
-    </div>
-  );
-}
-
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="flex items-center gap-2 py-0.5">
-      <span className="w-24 shrink-0 text-text-muted/60 text-[10px]">{label}</span>
-      <div className="flex-1 text-[10px] text-text-primary">{children}</div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Main export
-// ---------------------------------------------------------------------------
-
-export function LibraryEditorProperties() {
-  const panelView = useLibraryEditorStore(s => s.panelView);
-  const setPanelView = useLibraryEditorStore(s => s.setPanelView);
+function PinDetailProperties({ pin, index, updatePin }: { pin: SchPin; index: number; updatePin: (i: number, u: Partial<SchPin>) => void }) {
+  const u = useCallback((updates: Partial<SchPin>) => updatePin(index, updates), [index, updatePin]);
 
   return (
-    <div className="flex flex-col h-full">
-      <TabBar view={panelView} setView={setPanelView} />
-      <div className="flex-1 overflow-hidden">
-        {panelView === "properties" ? <PropertiesTab /> : <PinTableTab />}
+    <div className="overflow-y-auto">
+      <SectionHeader title={`Pin ${pin.number}: ${pin.name}`} />
+      <div className="px-3 py-1.5 space-y-1">
+        <Row label="Name">
+          <input value={pin.name} onChange={e => u({ name: e.target.value })} className={inp} />
+        </Row>
+        <Row label="Designator">
+          <input value={pin.number} onChange={e => u({ number: e.target.value })} className={cn(inp, "w-16")} />
+        </Row>
+        <Row label="Electrical Type">
+          <select value={pin.pin_type} onChange={e => u({ pin_type: e.target.value })} className={inp}>
+            {PIN_TYPES.map(t => <option key={t} value={t}>{t.replace(/_/g, " ")}</option>)}
+          </select>
+        </Row>
+        <Row label="Pin Shape">
+          <select value={pin.shape} onChange={e => u({ shape: e.target.value })} className={inp}>
+            {PIN_SHAPES.map(s => <option key={s} value={s}>{s.replace(/_/g, " ")}</option>)}
+          </select>
+        </Row>
+        <Row label="Length">
+          <input type="number" step={0.01} value={pin.length}
+            onChange={e => u({ length: parseFloat(e.target.value) || 2.54 })} className={cn(inp, "w-16")} />
+        </Row>
+        <Row label="Orientation">
+          <select value={pin.rotation} onChange={e => u({ rotation: parseInt(e.target.value) })} className={cn(inp, "w-20")}>
+            {[0, 90, 180, 270].map(r => <option key={r} value={r}>{r}&deg;</option>)}
+          </select>
+        </Row>
+        <Row label="X">
+          <input type="number" step={1.27} value={pin.position.x.toFixed(2)}
+            onChange={e => u({ position: { ...pin.position, x: parseFloat(e.target.value) || 0 } })} className={cn(inp, "w-20")} />
+        </Row>
+        <Row label="Y">
+          <input type="number" step={1.27} value={pin.position.y.toFixed(2)}
+            onChange={e => u({ position: { ...pin.position, y: parseFloat(e.target.value) || 0 } })} className={cn(inp, "w-20")} />
+        </Row>
+        <label className="flex items-center gap-2 cursor-pointer py-0.5">
+          <input type="checkbox" checked={pin.name_visible} onChange={e => u({ name_visible: e.target.checked })} />
+          <span className="text-text-secondary">Name Visible</span>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer py-0.5">
+          <input type="checkbox" checked={pin.number_visible} onChange={e => u({ number_visible: e.target.checked })} />
+          <span className="text-text-secondary">Number Visible</span>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer py-0.5">
+          <input type="checkbox" checked={pin.hidden ?? false} onChange={e => u({ hidden: e.target.checked })} />
+          <span className="text-text-secondary">Hidden</span>
+        </label>
       </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared UI
+// ---------------------------------------------------------------------------
+
+function SectionHeader({ title }: { title: string }) {
+  return (
+    <div className="px-3 py-1.5 bg-bg-secondary/80 border-y border-border-subtle text-[10px] font-semibold text-text-secondary">
+      {title}
+    </div>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-start gap-2">
+      <span className="w-[80px] shrink-0 text-text-muted/60 pt-0.5 text-right">{label}</span>
+      <div className="flex-1">{children}</div>
     </div>
   );
 }

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -419,7 +419,7 @@ export function MenuBar({ onOpenProject, onSave, onOpenComponentSearch, onExport
       }};
       if (item.label === "Length Tuning") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("lengthTune")); } };
       if (item.label === "Layer Stack Manager...") return { ...item, action: () => {} };
-      void onBgaFanout;
+      if (item.label === "BGA Fanout..." && !onBgaFanout) return item; // suppress unused warning
 
       return item;
     }),

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { useSchematicStore } from "@/stores/schematic";
 import { useEditorStore } from "@/stores/editor";
+import { toggleCrossSelect } from "@/lib/crossProbe";
 
 interface MenuBarProps {
   onOpenProject?: () => void;
@@ -21,6 +22,8 @@ interface MenuBarProps {
   onErcMatrix?: () => void;
   onConstraints?: () => void;
   onViaStitching?: () => void;
+  onBgaFanout?: () => void;
+  isPcbView?: boolean;
 }
 
 interface MenuItem {
@@ -201,12 +204,73 @@ const menus: MenuGroup[] = [
   },
 ];
 
-export function MenuBar({ onOpenProject, onSave, onOpenComponentSearch, onExportPdf, onExportBom, onExportNetlist, onOpenOutputJobs, onAnnotate, onPreferences, onFindSimilar, onParameterManager, onPrint, onRunDrc, onBackAnnotate, onErcMatrix, onConstraints, onViaStitching }: MenuBarProps) {
+// PCB-specific menu overrides for Place, Design, Tools
+const pcbPlaceMenu: MenuGroup = {
+  label: "Place",
+  items: [
+    { label: "Route Track", shortcut: "X" },
+    { label: "Differential Pair Route" },
+    { label: "Multi-Track Route" },
+    { separator: true, label: "" },
+    { label: "Via" },
+    { label: "Footprint" },
+    { separator: true, label: "" },
+    { label: "Zone" },
+    { label: "Keepout" },
+    { label: "Board Outline" },
+    { separator: true, label: "" },
+    { label: "Text" },
+    { label: "Line" },
+    { label: "Dimension" },
+  ],
+};
+
+const pcbDesignMenu: MenuGroup = {
+  label: "Design",
+  items: [
+    { label: "Design Rules...", disabled: true },
+    { label: "Board Setup...", disabled: true },
+    { label: "Layer Stack Manager..." },
+    { separator: true, label: "" },
+    { label: "Import Changes From Schematic...", disabled: true },
+    { label: "Back Annotate to Schematic...", disabled: true },
+  ],
+};
+
+const pcbToolsMenu: MenuGroup = {
+  label: "Tools",
+  items: [
+    { label: "Design Rule Check..." },
+    { separator: true, label: "" },
+    { label: "Fill All Zones" },
+    { label: "Remove Dead Copper", disabled: true },
+    { separator: true, label: "" },
+    { label: "Via Stitching..." },
+    { label: "BGA Fanout..." },
+    { label: "Generate Teardrops" },
+    { label: "Length Tuning" },
+    { separator: true, label: "" },
+    { label: "Cross Select Mode", shortcut: "Shift+Ctrl+X" },
+    { separator: true, label: "" },
+    { label: "Preferences..." },
+  ],
+};
+
+export function MenuBar({ onOpenProject, onSave, onOpenComponentSearch, onExportPdf, onExportBom, onExportNetlist, onOpenOutputJobs, onAnnotate, onPreferences, onFindSimilar, onParameterManager, onPrint, onRunDrc, onBackAnnotate, onErcMatrix, onConstraints, onViaStitching, onBgaFanout, isPcbView }: MenuBarProps) {
   const [openMenu, setOpenMenu] = useState<number | null>(null);
   const menuBarRef = useRef<HTMLDivElement>(null);
 
+  // Swap Place/Design/Tools menus when in PCB view
+  const baseMenus = isPcbView
+    ? menus.map((m) =>
+        m.label === "Place" ? pcbPlaceMenu
+        : m.label === "Design" ? pcbDesignMenu
+        : m.label === "Tools" ? pcbToolsMenu
+        : m)
+    : menus;
+
   // Wire up actions
-  const actionMenus = menus.map((menu) => ({
+  const actionMenus = baseMenus.map((menu) => ({
     ...menu,
     items: menu.items.map((item) => {
       if (item.id === "file-open") return { ...item, action: onOpenProject };
@@ -311,15 +375,51 @@ export function MenuBar({ onOpenProject, onSave, onOpenComponentSearch, onExport
       if (item.label === "Import Changes From PCB...") return { ...item, disabled: false, action: onBackAnnotate };
       if (item.label === "Document Options...") return { ...item, disabled: false, action: onConstraints };
       // Tools menu
-      if (item.label === "Cross Select Mode") return { ...item, disabled: false, action: () => {} };
+      if (item.label === "Cross Select Mode") return { ...item, disabled: false, action: () => toggleCrossSelect() };
       if (item.label === "Component Cross Reference...") return { ...item, disabled: false, action: () => {} };
       if (item.label === "Number Schematic Sheets...") return { ...item, disabled: false, action: () => {} };
       if (item.label === "Cross Reference...") return { ...item, disabled: false, action: () => {} };
       if (item.label === "Signal (AI)") return { ...item, action: () => {
         // Open Signal panel — handled via layout store from App
       }};
-      // Not used from menu directly, but available via toolbar
-      void onViaStitching;
+      // PCB-specific Place menu actions
+      if (item.label === "Route Track" && isPcbView) return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("routeTrack")); } };
+      if (item.label === "Differential Pair Route") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("routeDiffPair")); } };
+      if (item.label === "Multi-Track Route") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("routeMultiTrack")); } };
+      if (item.label === "Via" && isPcbView) return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("placeVia")); } };
+      if (item.label === "Footprint" && isPcbView) return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("placeFootprint")); } };
+      if (item.label === "Zone") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("placeZone")); } };
+      if (item.label === "Keepout") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("placeKeepout")); } };
+      if (item.label === "Board Outline") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("drawBoardOutline")); } };
+      if (item.label === "Text" && isPcbView) return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("placeText")); } };
+      if (item.label === "Dimension") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("placeDimension")); } };
+      // PCB-specific Tools menu
+      if (item.label === "Fill All Zones") return { ...item, action: () => {
+        Promise.all([import("@/lib/pcbCopperPour"), import("@/stores/pcb")]).then(([cpMod, pcbMod]) => {
+          const store = pcbMod.usePcbStore.getState();
+          if (!store.data) return;
+          store.pushUndo();
+          const nd = structuredClone(store.data);
+          cpMod.fillZones(nd);
+          pcbMod.usePcbStore.setState({ data: nd, dirty: true });
+        });
+      }};
+      if (item.label === "Via Stitching...") return { ...item, action: onViaStitching };
+      if (item.label === "BGA Fanout...") return { ...item, action: onBgaFanout };
+      if (item.label === "Generate Teardrops" && isPcbView) return { ...item, action: () => {
+        Promise.all([import("@/lib/pcbRouter"), import("@/stores/pcb")]).then(([rtMod, pcbMod]) => {
+          const store = pcbMod.usePcbStore.getState();
+          if (!store.data) return;
+          store.pushUndo();
+          const nd = structuredClone(store.data);
+          const newSegs = rtMod.generateTeardrops(nd, 0.5, 0.5);
+          nd.segments = [...nd.segments, ...newSegs];
+          pcbMod.usePcbStore.setState({ data: nd, dirty: true });
+        });
+      }};
+      if (item.label === "Length Tuning") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("lengthTune")); } };
+      if (item.label === "Layer Stack Manager...") return { ...item, action: () => {} };
+      void onBgaFanout;
 
       return item;
     }),

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -19,6 +19,8 @@ interface MenuBarProps {
   onRunDrc?: () => void;
   onBackAnnotate?: () => void;
   onErcMatrix?: () => void;
+  onConstraints?: () => void;
+  onViaStitching?: () => void;
 }
 
 interface MenuItem {
@@ -199,7 +201,7 @@ const menus: MenuGroup[] = [
   },
 ];
 
-export function MenuBar({ onOpenProject, onSave, onOpenComponentSearch, onExportPdf, onExportBom, onExportNetlist, onOpenOutputJobs, onAnnotate, onPreferences, onFindSimilar, onParameterManager, onPrint, onRunDrc, onBackAnnotate, onErcMatrix }: MenuBarProps) {
+export function MenuBar({ onOpenProject, onSave, onOpenComponentSearch, onExportPdf, onExportBom, onExportNetlist, onOpenOutputJobs, onAnnotate, onPreferences, onFindSimilar, onParameterManager, onPrint, onRunDrc, onBackAnnotate, onErcMatrix, onConstraints, onViaStitching }: MenuBarProps) {
   const [openMenu, setOpenMenu] = useState<number | null>(null);
   const menuBarRef = useRef<HTMLDivElement>(null);
 
@@ -291,6 +293,33 @@ export function MenuBar({ onOpenProject, onSave, onOpenComponentSearch, onExport
       }};
       if (item.label === "Align to Grid") return { ...item, disabled: false, action: () => useSchematicStore.getState().alignSelectionToGrid() };
       if (item.label === "Smart Paste...") return { ...item, disabled: false, action: () => useSchematicStore.getState().smartPaste({ x: 2.54, y: 2.54 }) };
+      // Place menu — remaining items
+      if (item.label === "Text Frame") return { ...item, disabled: false, action: () => useSchematicStore.getState().setEditMode("placeTextFrame" as any) };
+      if (item.label === "Note") return { ...item, disabled: false, action: () => useSchematicStore.getState().setEditMode("placeNote" as any) };
+      if (item.label === "Image...") return { ...item, disabled: false, action: () => useSchematicStore.getState().setEditMode("placeImage" as any) };
+      if (item.label === "Sheet Entry") return { ...item, disabled: false, action: () => useSchematicStore.getState().setEditMode("placeSheetEntry" as any) };
+      if (item.label === "Directive") return { ...item, disabled: false, action: () => useSchematicStore.getState().setEditMode("placeParameterSet" as any) };
+      if (item.label === "Junction") return { ...item, disabled: false, action: () => useSchematicStore.getState().setEditMode("placeJunction" as any) };
+      // View menu
+      if (item.label === "Fit All Objects") return { ...item, disabled: false, action: () => window.dispatchEvent(new KeyboardEvent("keydown", { key: "Home" })) };
+      if (item.label === "Toggle Net Color Override") return { ...item, disabled: false, action: () => {} };
+      if (item.label === "Navigator") return { ...item, disabled: false, action: () => {
+        // Handled from App.tsx via layout store
+      }};
+      // Design menu
+      if (item.label === "Update PCB Document...") return { ...item, disabled: false, action: () => {} };
+      if (item.label === "Import Changes From PCB...") return { ...item, disabled: false, action: onBackAnnotate };
+      if (item.label === "Document Options...") return { ...item, disabled: false, action: onConstraints };
+      // Tools menu
+      if (item.label === "Cross Select Mode") return { ...item, disabled: false, action: () => {} };
+      if (item.label === "Component Cross Reference...") return { ...item, disabled: false, action: () => {} };
+      if (item.label === "Number Schematic Sheets...") return { ...item, disabled: false, action: () => {} };
+      if (item.label === "Cross Reference...") return { ...item, disabled: false, action: () => {} };
+      if (item.label === "Signal (AI)") return { ...item, action: () => {
+        // Open Signal panel — handled via layout store from App
+      }};
+      // Not used from menu directly, but available via toolbar
+      void onViaStitching;
 
       return item;
     }),

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -16,6 +16,9 @@ interface MenuBarProps {
   onFindSimilar?: () => void;
   onParameterManager?: () => void;
   onPrint?: () => void;
+  onRunDrc?: () => void;
+  onBackAnnotate?: () => void;
+  onErcMatrix?: () => void;
 }
 
 interface MenuItem {
@@ -196,7 +199,7 @@ const menus: MenuGroup[] = [
   },
 ];
 
-export function MenuBar({ onOpenProject, onSave, onOpenComponentSearch, onExportPdf, onExportBom, onExportNetlist, onOpenOutputJobs, onAnnotate, onPreferences, onFindSimilar, onParameterManager, onPrint }: MenuBarProps) {
+export function MenuBar({ onOpenProject, onSave, onOpenComponentSearch, onExportPdf, onExportBom, onExportNetlist, onOpenOutputJobs, onAnnotate, onPreferences, onFindSimilar, onParameterManager, onPrint, onRunDrc, onBackAnnotate, onErcMatrix }: MenuBarProps) {
   const [openMenu, setOpenMenu] = useState<number | null>(null);
   const menuBarRef = useRef<HTMLDivElement>(null);
 
@@ -260,9 +263,9 @@ export function MenuBar({ onOpenProject, onSave, onOpenComponentSearch, onExport
       }};
       if (item.label === "Export as PDF...") return { ...item, disabled: false, action: onExportPdf };
       if (item.label === "Print...") return { ...item, disabled: false, action: onPrint };
-      if (item.label === "Electrical Rules Check...") return { ...item, disabled: false, action: () => {
-        /* ERC runs from Messages panel */
-      }};
+      if (item.label === "Electrical Rules Check...") return { ...item, disabled: false, action: onErcMatrix || (() => {}) };
+      if (item.label === "Design Rule Check...") return { ...item, disabled: false, action: onRunDrc };
+      if (item.label === "Back Annotate...") return { ...item, disabled: false, action: onBackAnnotate };
       // Design / Tools
       if (item.label === "Annotate Schematics..." && menu.label === "Design") return { ...item, disabled: false, action: onAnnotate };
       if (item.label === "Annotate Schematics..." && menu.label === "Tools") return { ...item, disabled: false, action: onAnnotate };

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -2,7 +2,10 @@ import { useState, useRef, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { useSchematicStore } from "@/stores/schematic";
 import { useEditorStore } from "@/stores/editor";
+import { usePcbStore } from "@/stores/pcb";
 import { toggleCrossSelect } from "@/lib/crossProbe";
+import { fillZones } from "@/lib/pcbCopperPour";
+import { generateTeardrops } from "@/lib/pcbRouter";
 
 interface MenuBarProps {
   onOpenProject?: () => void;
@@ -383,43 +386,38 @@ export function MenuBar({ onOpenProject, onSave, onOpenComponentSearch, onExport
         // Open Signal panel — handled via layout store from App
       }};
       // PCB-specific Place menu actions
-      if (item.label === "Route Track" && isPcbView) return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("routeTrack")); } };
-      if (item.label === "Differential Pair Route") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("routeDiffPair")); } };
-      if (item.label === "Multi-Track Route") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("routeMultiTrack")); } };
-      if (item.label === "Via" && isPcbView) return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("placeVia")); } };
-      if (item.label === "Footprint" && isPcbView) return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("placeFootprint")); } };
-      if (item.label === "Zone") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("placeZone")); } };
-      if (item.label === "Keepout") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("placeKeepout")); } };
-      if (item.label === "Board Outline") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("drawBoardOutline")); } };
-      if (item.label === "Text" && isPcbView) return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("placeText")); } };
-      if (item.label === "Dimension") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("placeDimension")); } };
+      if (item.label === "Route Track" && isPcbView) return { ...item, action: () => usePcbStore.getState().setEditMode("routeTrack") };
+      if (item.label === "Differential Pair Route") return { ...item, action: () => usePcbStore.getState().setEditMode("routeDiffPair") };
+      if (item.label === "Multi-Track Route") return { ...item, action: () => usePcbStore.getState().setEditMode("routeMultiTrack") };
+      if (item.label === "Via" && isPcbView) return { ...item, action: () => usePcbStore.getState().setEditMode("placeVia") };
+      if (item.label === "Footprint" && isPcbView) return { ...item, action: () => usePcbStore.getState().setEditMode("placeFootprint") };
+      if (item.label === "Zone") return { ...item, action: () => usePcbStore.getState().setEditMode("placeZone") };
+      if (item.label === "Keepout") return { ...item, action: () => usePcbStore.getState().setEditMode("placeKeepout") };
+      if (item.label === "Board Outline") return { ...item, action: () => usePcbStore.getState().setEditMode("drawBoardOutline") };
+      if (item.label === "Text" && isPcbView) return { ...item, action: () => usePcbStore.getState().setEditMode("placeText") };
+      if (item.label === "Dimension") return { ...item, action: () => usePcbStore.getState().setEditMode("placeDimension") };
       // PCB-specific Tools menu
       if (item.label === "Fill All Zones") return { ...item, action: () => {
-        Promise.all([import("@/lib/pcbCopperPour"), import("@/stores/pcb")]).then(([cpMod, pcbMod]) => {
-          const store = pcbMod.usePcbStore.getState();
-          if (!store.data) return;
-          store.pushUndo();
-          const nd = structuredClone(store.data);
-          cpMod.fillZones(nd);
-          pcbMod.usePcbStore.setState({ data: nd, dirty: true });
-        });
+        const store = usePcbStore.getState();
+        if (!store.data) return;
+        store.pushUndo();
+        const nd = structuredClone(store.data);
+        fillZones(nd);
+        usePcbStore.setState({ data: nd, dirty: true });
       }};
       if (item.label === "Via Stitching...") return { ...item, action: onViaStitching };
       if (item.label === "BGA Fanout...") return { ...item, action: onBgaFanout };
       if (item.label === "Generate Teardrops" && isPcbView) return { ...item, action: () => {
-        Promise.all([import("@/lib/pcbRouter"), import("@/stores/pcb")]).then(([rtMod, pcbMod]) => {
-          const store = pcbMod.usePcbStore.getState();
-          if (!store.data) return;
-          store.pushUndo();
-          const nd = structuredClone(store.data);
-          const newSegs = rtMod.generateTeardrops(nd, 0.5, 0.5);
-          nd.segments = [...nd.segments, ...newSegs];
-          pcbMod.usePcbStore.setState({ data: nd, dirty: true });
-        });
+        const store = usePcbStore.getState();
+        if (!store.data) return;
+        store.pushUndo();
+        const nd = structuredClone(store.data);
+        const newSegs = generateTeardrops(nd, 0.5, 0.5);
+        nd.segments = [...nd.segments, ...newSegs];
+        usePcbStore.setState({ data: nd, dirty: true });
       }};
-      if (item.label === "Length Tuning") return { ...item, action: () => { import("@/stores/pcb").then(m => m.usePcbStore.getState().setEditMode("lengthTune")); } };
+      if (item.label === "Length Tuning") return { ...item, action: () => usePcbStore.getState().setEditMode("lengthTune") };
       if (item.label === "Layer Stack Manager...") return { ...item, action: () => {} };
-      if (item.label === "BGA Fanout..." && !onBgaFanout) return item; // suppress unused warning
 
       return item;
     }),

--- a/src/components/PcbToolbar.tsx
+++ b/src/components/PcbToolbar.tsx
@@ -5,6 +5,7 @@ import {
   AlignStartVertical, AlignEndVertical, AlignCenterVertical,
   AlignStartHorizontal, AlignEndHorizontal, AlignCenterHorizontal,
   ArrowLeftRight, ArrowUpDown, Droplets,
+  GitBranch, Waves, Cable,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePcbStore } from "@/stores/pcb";
@@ -53,6 +54,9 @@ export function PcbToolbar() {
       {/* Routing */}
       <ToolBtn icon={<Minus size={15} />} label="Route Track (X)" active={editMode === "routeTrack"} onClick={() => setMode("routeTrack")} />
       <ToolBtn icon={<Circle size={15} />} label="Place Via" active={editMode === "placeVia"} onClick={() => setMode("placeVia")} />
+      <ToolBtn icon={<GitBranch size={15} />} label="Diff Pair Route" active={editMode === "routeDiffPair"} onClick={() => setMode("routeDiffPair")} />
+      <ToolBtn icon={<Cable size={15} />} label="Multi-Track Route" active={editMode === "routeMultiTrack"} onClick={() => setMode("routeMultiTrack")} />
+      <ToolBtn icon={<Waves size={15} />} label="Length Tuning" active={editMode === "lengthTune"} onClick={() => setMode("lengthTune")} />
       <select value={store.getState().routeMode}
         onChange={(e) => store.setState({ routeMode: e.target.value as "ignore" | "walkaround" | "push" | "hug_push" })}
         title="Route Mode"

--- a/src/components/PcbToolbar.tsx
+++ b/src/components/PcbToolbar.tsx
@@ -2,11 +2,16 @@ import {
   MousePointer2, Minus, Circle, Square, Type, Ruler,
   Layers, FlipVertical, Palette, RotateCw,
   Undo2, Redo2, Trash2,
+  AlignStartVertical, AlignEndVertical, AlignCenterVertical,
+  AlignStartHorizontal, AlignEndHorizontal, AlignCenterHorizontal,
+  ArrowLeftRight, ArrowUpDown, Droplets,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePcbStore } from "@/stores/pcb";
 import { DEFAULT_LAYER_COLORS, LAYER_DISPLAY_NAMES } from "@/types/pcb";
 import type { PcbEditMode } from "@/stores/pcb";
+import { alignFootprints, distributeFootprints } from "@/lib/pcbPlacement";
+import { generateTeardrops } from "@/lib/pcbRouter";
 
 function ToolBtn({ icon, label, active, disabled, onClick }: {
   icon: React.ReactNode; label: string; active?: boolean; disabled?: boolean; onClick?: () => void;
@@ -48,6 +53,25 @@ export function PcbToolbar() {
       {/* Routing */}
       <ToolBtn icon={<Minus size={15} />} label="Route Track (X)" active={editMode === "routeTrack"} onClick={() => setMode("routeTrack")} />
       <ToolBtn icon={<Circle size={15} />} label="Place Via" active={editMode === "placeVia"} onClick={() => setMode("placeVia")} />
+      <select value={store.getState().routeMode}
+        onChange={(e) => store.setState({ routeMode: e.target.value as "ignore" | "walkaround" | "push" | "hug_push" })}
+        title="Route Mode"
+        className="bg-transparent border border-border-subtle rounded px-1 py-0.5 text-[9px] text-text-secondary outline-none focus:border-accent max-w-[85px]">
+        <option value="ignore">Ignore</option>
+        <option value="walkaround">Walk</option>
+        <option value="push">Push</option>
+        <option value="hug_push">Hug</option>
+      </select>
+      <select value={store.getState().routeCornerMode}
+        onChange={(e) => store.setState({ routeCornerMode: e.target.value as "45" | "90" | "arc45" | "arc90" | "any" })}
+        title="Corner Style"
+        className="bg-transparent border border-border-subtle rounded px-1 py-0.5 text-[9px] text-text-secondary outline-none focus:border-accent max-w-[65px]">
+        <option value="45">45°</option>
+        <option value="90">90°</option>
+        <option value="arc45">Arc 45</option>
+        <option value="arc90">Arc 90</option>
+        <option value="any">Any</option>
+      </select>
       <Sep />
 
       {/* Drawing */}
@@ -64,6 +88,30 @@ export function PcbToolbar() {
         onClick={() => store.getState().toggleBoardFlip()} />
       <ToolBtn icon={<Palette size={15} />} label="Net Colors (F5)" active={netColorEnabled}
         onClick={() => store.getState().toggleNetColors()} />
+      <Sep />
+
+      {/* Alignment */}
+      <ToolBtn icon={<AlignStartVertical size={15} />} label="Align Left" onClick={() => alignFootprints("left")} />
+      <ToolBtn icon={<AlignEndVertical size={15} />} label="Align Right" onClick={() => alignFootprints("right")} />
+      <ToolBtn icon={<AlignCenterVertical size={15} />} label="Align Center H" onClick={() => alignFootprints("centerH")} />
+      <ToolBtn icon={<AlignStartHorizontal size={15} />} label="Align Top" onClick={() => alignFootprints("top")} />
+      <ToolBtn icon={<AlignEndHorizontal size={15} />} label="Align Bottom" onClick={() => alignFootprints("bottom")} />
+      <ToolBtn icon={<AlignCenterHorizontal size={15} />} label="Align Center V" onClick={() => alignFootprints("centerV")} />
+      <ToolBtn icon={<ArrowLeftRight size={15} />} label="Distribute Horizontally" onClick={() => distributeFootprints("horizontal")} />
+      <ToolBtn icon={<ArrowUpDown size={15} />} label="Distribute Vertically" onClick={() => distributeFootprints("vertical")} />
+      <Sep />
+
+      {/* Teardrops */}
+      <ToolBtn icon={<Droplets size={15} />} label="Generate Teardrops"
+        onClick={() => {
+          const s = store.getState();
+          if (!s.data) return;
+          s.pushUndo();
+          const nd = structuredClone(s.data);
+          const newSegs = generateTeardrops(nd, 0.5, 0.5);
+          nd.segments = [...nd.segments, ...newSegs];
+          usePcbStore.setState({ data: nd, dirty: true });
+        }} />
       <Sep />
 
       {/* Actions */}

--- a/src/components/PcbToolbar.tsx
+++ b/src/components/PcbToolbar.tsx
@@ -38,6 +38,8 @@ export function PcbToolbar() {
   const singleLayerMode = usePcbStore((s) => s.singleLayerMode);
   const boardFlipped = usePcbStore((s) => s.boardFlipped);
   const netColorEnabled = usePcbStore((s) => s.netColorEnabled);
+  const routeMode = usePcbStore((s) => s.routeMode);
+  const routeCornerMode = usePcbStore((s) => s.routeCornerMode);
   const store = usePcbStore;
 
   const setMode = (mode: PcbEditMode) => store.getState().setEditMode(mode);
@@ -57,7 +59,7 @@ export function PcbToolbar() {
       <ToolBtn icon={<GitBranch size={15} />} label="Diff Pair Route" active={editMode === "routeDiffPair"} onClick={() => setMode("routeDiffPair")} />
       <ToolBtn icon={<Cable size={15} />} label="Multi-Track Route" active={editMode === "routeMultiTrack"} onClick={() => setMode("routeMultiTrack")} />
       <ToolBtn icon={<Waves size={15} />} label="Length Tuning" active={editMode === "lengthTune"} onClick={() => setMode("lengthTune")} />
-      <select value={store.getState().routeMode}
+      <select value={routeMode}
         onChange={(e) => store.setState({ routeMode: e.target.value as "ignore" | "walkaround" | "push" | "hug_push" })}
         title="Route Mode"
         className="bg-transparent border border-border-subtle rounded px-1 py-0.5 text-[9px] text-text-secondary outline-none focus:border-accent max-w-[85px]">
@@ -66,7 +68,7 @@ export function PcbToolbar() {
         <option value="push">Push</option>
         <option value="hug_push">Hug</option>
       </select>
-      <select value={store.getState().routeCornerMode}
+      <select value={routeCornerMode}
         onChange={(e) => store.setState({ routeCornerMode: e.target.value as "45" | "90" | "arc45" | "arc90" | "any" })}
         title="Corner Style"
         className="bg-transparent border border-border-subtle rounded px-1 py-0.5 text-[9px] text-text-secondary outline-none focus:border-accent max-w-[65px]">

--- a/src/components/ViaStitchingDialog.tsx
+++ b/src/components/ViaStitchingDialog.tsx
@@ -67,7 +67,7 @@ export function ViaStitchingDialog({ open, onClose }: Props) {
   };
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50" role="dialog" aria-modal="true" aria-label="Via Stitching">
       <div className="bg-bg-secondary border border-border-subtle rounded-lg shadow-2xl w-[360px]">
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border-subtle">
           <span className="text-xs font-semibold">Via Stitching</span>

--- a/src/components/ViaStitchingDialog.tsx
+++ b/src/components/ViaStitchingDialog.tsx
@@ -25,6 +25,9 @@ export function ViaStitchingDialog({ open, onClose }: Props) {
   const handleApply = () => {
     if (!pcbData) return;
 
+    if (spacing <= 0 || diameter <= 0 || drill <= 0) return;
+    if (drill >= diameter) { alert("Drill must be smaller than diameter"); return; }
+
     const options = {
       net: netNumber,
       diameter,

--- a/src/components/ViaStitchingDialog.tsx
+++ b/src/components/ViaStitchingDialog.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import { usePcbStore } from "@/stores/pcb";
+import { placeViaGrid, placeViaFence, applyViaStitching } from "@/lib/pcbViaStitching";
+import type { PcbLayerId } from "@/types/pcb";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ViaStitchingDialog({ open, onClose }: Props) {
+  const [mode, setMode] = useState<"grid" | "fence">("grid");
+  const [spacing, setSpacing] = useState(2.0);
+  const [diameter, setDiameter] = useState(0.6);
+  const [drill, setDrill] = useState(0.3);
+  const [netNumber, setNetNumber] = useState(0);
+
+  const pcbData = usePcbStore((s) => s.data);
+  const selectedIds = usePcbStore((s) => s.selectedIds);
+
+  if (!open) return null;
+
+  const handleApply = () => {
+    if (!pcbData) return;
+
+    const options = {
+      net: netNumber,
+      diameter,
+      drill,
+      spacing,
+      layers: ["F.Cu", "B.Cu"] as [PcbLayerId, PcbLayerId],
+    };
+
+    if (mode === "grid") {
+      // Use board outline bounding box or selected zone
+      const zone = pcbData.zones.find((z) => selectedIds.has(z.uuid));
+      let tl = { x: -10, y: -10 }, br = { x: 10, y: 10 };
+      if (zone && zone.outline.length > 0) {
+        const xs = zone.outline.map((p) => p.x);
+        const ys = zone.outline.map((p) => p.y);
+        tl = { x: Math.min(...xs), y: Math.min(...ys) };
+        br = { x: Math.max(...xs), y: Math.max(...ys) };
+      } else if (pcbData.board.outline.length > 0) {
+        const xs = pcbData.board.outline.map((p: { x: number; y: number }) => p.x);
+        const ys = pcbData.board.outline.map((p: { x: number; y: number }) => p.y);
+        tl = { x: Math.min(...xs), y: Math.min(...ys) };
+        br = { x: Math.max(...xs), y: Math.max(...ys) };
+      }
+      const vias = placeViaGrid(tl, br, options);
+      applyViaStitching(vias);
+    } else {
+      const zone = pcbData.zones.find((z) => selectedIds.has(z.uuid));
+      if (!zone || zone.outline.length < 3) {
+        alert("Select a zone for fence stitching");
+        return;
+      }
+      const vias = placeViaFence(zone.outline, options);
+      applyViaStitching(vias);
+    }
+
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
+      <div className="bg-bg-secondary border border-border-subtle rounded-lg shadow-2xl w-[360px]">
+        <div className="flex items-center justify-between px-4 py-2.5 border-b border-border-subtle">
+          <span className="text-xs font-semibold">Via Stitching</span>
+          <button onClick={onClose} className="p-0.5 hover:bg-bg-hover rounded"><X size={14} /></button>
+        </div>
+
+        <div className="p-4 space-y-3">
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] text-text-muted w-16">Mode</span>
+            <select value={mode} onChange={(e) => setMode(e.target.value as "grid" | "fence")}
+              className="flex-1 bg-bg-surface border border-border-subtle rounded px-2 py-0.5 text-[10px] outline-none">
+              <option value="grid">Grid (fill area)</option>
+              <option value="fence">Fence (perimeter)</option>
+            </select>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] text-text-muted w-16">Spacing</span>
+            <input type="number" step="0.1" min="0.5" value={spacing}
+              onChange={(e) => setSpacing(Number(e.target.value))}
+              className="flex-1 bg-bg-surface border border-border-subtle rounded px-2 py-0.5 text-[10px] outline-none" />
+            <span className="text-[9px] text-text-muted">mm</span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] text-text-muted w-16">Diameter</span>
+            <input type="number" step="0.05" min="0.2" value={diameter}
+              onChange={(e) => setDiameter(Number(e.target.value))}
+              className="flex-1 bg-bg-surface border border-border-subtle rounded px-2 py-0.5 text-[10px] outline-none" />
+            <span className="text-[9px] text-text-muted">mm</span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] text-text-muted w-16">Drill</span>
+            <input type="number" step="0.05" min="0.1" value={drill}
+              onChange={(e) => setDrill(Number(e.target.value))}
+              className="flex-1 bg-bg-surface border border-border-subtle rounded px-2 py-0.5 text-[10px] outline-none" />
+            <span className="text-[9px] text-text-muted">mm</span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] text-text-muted w-16">Net</span>
+            <input type="number" min="0" value={netNumber}
+              onChange={(e) => setNetNumber(Number(e.target.value))}
+              className="flex-1 bg-bg-surface border border-border-subtle rounded px-2 py-0.5 text-[10px] outline-none" />
+            <span className="text-[9px] text-text-muted">(0 = GND)</span>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 px-4 py-2.5 border-t border-border-subtle">
+          <button onClick={onClose}
+            className="px-3 py-1 text-[10px] text-text-secondary hover:bg-bg-hover rounded">
+            Cancel
+          </button>
+          <button onClick={handleApply}
+            disabled={!pcbData}
+            className={cn("px-3 py-1 text-[10px] rounded",
+              pcbData ? "bg-accent text-white hover:bg-accent/80" : "bg-bg-hover text-text-muted cursor-default")}>
+            Place Vias
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/panelRegistry.ts
+++ b/src/lib/panelRegistry.ts
@@ -16,9 +16,10 @@ import { VariantPanel } from "@/panels/VariantPanel";
 import { BoardCrossSectionPanel } from "@/panels/BoardCrossSectionPanel";
 import { LibraryPanel } from "@/panels/LibraryPanel";
 import { SchLibraryPanel } from "@/panels/SchLibraryPanel";
+import { PcbLibraryPanel } from "@/panels/PcbLibraryPanel";
 
 export type PanelId =
-  | "projects" | "components" | "navigator" | "libraryMgmt" | "schLibrary"
+  | "projects" | "components" | "navigator" | "libraryMgmt" | "schLibrary" | "pcbLibrary"
   | "properties" | "filter" | "list"
   | "messages" | "output-jobs" | "signal"
   | "inspector" | "drc" | "layerStack" | "snippets" | "variants" | "boardCrossSection";
@@ -44,6 +45,7 @@ export const PANEL_DEFS: PanelDef[] = [
 
   // Library editor panels
   { id: "schLibrary", title: "SCH Library", defaultDock: "left", context: "both" },
+  { id: "pcbLibrary", title: "PCB Library", defaultDock: "left", context: "both" },
 
   // Schematic-only panels
   { id: "filter", title: "SCH Filter", defaultDock: "right", context: "schematic" },
@@ -70,6 +72,7 @@ export const PANEL_COMPONENTS: Record<PanelId, React.FC> = {
   navigator: NavigatorPanel,
   libraryMgmt: LibraryPanel,
   schLibrary: SchLibraryPanel,
+  pcbLibrary: PcbLibraryPanel,
   properties: PropertiesPanel,
   filter: FilterPanel,
   list: ListPanel,

--- a/src/lib/panelRegistry.ts
+++ b/src/lib/panelRegistry.ts
@@ -15,9 +15,10 @@ import { SnippetsPanel } from "@/panels/SnippetsPanel";
 import { VariantPanel } from "@/panels/VariantPanel";
 import { BoardCrossSectionPanel } from "@/panels/BoardCrossSectionPanel";
 import { LibraryPanel } from "@/panels/LibraryPanel";
+import { SchLibraryPanel } from "@/panels/SchLibraryPanel";
 
 export type PanelId =
-  | "projects" | "components" | "navigator" | "libraryMgmt"
+  | "projects" | "components" | "navigator" | "libraryMgmt" | "schLibrary"
   | "properties" | "filter" | "list"
   | "messages" | "output-jobs" | "signal"
   | "inspector" | "drc" | "layerStack" | "snippets" | "variants" | "boardCrossSection";
@@ -40,6 +41,9 @@ export const PANEL_DEFS: PanelDef[] = [
   { id: "properties", title: "Properties", defaultDock: "right", context: "both" },
   { id: "messages", title: "Messages", defaultDock: "bottom", context: "both" },
   { id: "signal", title: "Signal", defaultDock: "bottom", context: "both" },
+
+  // Library editor panels
+  { id: "schLibrary", title: "SCH Library", defaultDock: "left", context: "both" },
 
   // Schematic-only panels
   { id: "filter", title: "SCH Filter", defaultDock: "right", context: "schematic" },
@@ -65,6 +69,7 @@ export const PANEL_COMPONENTS: Record<PanelId, React.FC> = {
   components: ComponentPanel,
   navigator: NavigatorPanel,
   libraryMgmt: LibraryPanel,
+  schLibrary: SchLibraryPanel,
   properties: PropertiesPanel,
   filter: FilterPanel,
   list: ListPanel,

--- a/src/lib/panelRegistry.ts
+++ b/src/lib/panelRegistry.ts
@@ -17,9 +17,11 @@ import { BoardCrossSectionPanel } from "@/panels/BoardCrossSectionPanel";
 import { LibraryPanel } from "@/panels/LibraryPanel";
 import { SchLibraryPanel } from "@/panels/SchLibraryPanel";
 import { PcbLibraryPanel } from "@/panels/PcbLibraryPanel";
+import { NetClassPanel } from "@/panels/NetClassPanel";
+import { NetInspectorPanel } from "@/panels/NetInspectorPanel";
 
 export type PanelId =
-  | "projects" | "components" | "navigator" | "libraryMgmt" | "schLibrary" | "pcbLibrary"
+  | "projects" | "components" | "navigator" | "libraryMgmt" | "schLibrary" | "pcbLibrary" | "netClasses" | "netInspector"
   | "properties" | "filter" | "list"
   | "messages" | "output-jobs" | "signal"
   | "inspector" | "drc" | "layerStack" | "snippets" | "variants" | "boardCrossSection";
@@ -46,6 +48,8 @@ export const PANEL_DEFS: PanelDef[] = [
   // Library editor panels
   { id: "schLibrary", title: "SCH Library", defaultDock: "left", context: "both" },
   { id: "pcbLibrary", title: "PCB Library", defaultDock: "left", context: "both" },
+  { id: "netClasses", title: "Net Classes", defaultDock: "left", context: "both" },
+  { id: "netInspector", title: "Net Inspector", defaultDock: "right", context: "pcb" },
 
   // Schematic-only panels
   { id: "filter", title: "SCH Filter", defaultDock: "right", context: "schematic" },
@@ -73,6 +77,8 @@ export const PANEL_COMPONENTS: Record<PanelId, React.FC> = {
   libraryMgmt: LibraryPanel,
   schLibrary: SchLibraryPanel,
   pcbLibrary: PcbLibraryPanel,
+  netClasses: NetClassPanel,
+  netInspector: NetInspectorPanel,
   properties: PropertiesPanel,
   filter: FilterPanel,
   list: ListPanel,

--- a/src/lib/pcbGerberExport.ts
+++ b/src/lib/pcbGerberExport.ts
@@ -11,6 +11,7 @@ import type {
   PcbGraphic,
   PcbPoint,
 } from "@/types/pcb";
+import { generateX2Header } from "./pcbGerberX2";
 
 // --- Coordinate Helpers ---
 
@@ -192,6 +193,10 @@ export function generateGerber(data: PcbData, layer: PcbLayerId): string {
   for (const g of boardGraphics) {
     apertures.getOrCreate("C", [graphicWidth(g)]);
   }
+
+  // --- Gerber X2 Extended Attributes ---
+  const x2Header = generateX2Header(data, layer);
+  if (x2Header) lines.push(x2Header);
 
   // --- Header ---
 

--- a/src/panels/ComponentPanel.tsx
+++ b/src/panels/ComponentPanel.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { useSchematicStore } from "@/stores/schematic";
 import { useLibraryEditorStore } from "@/stores/libraryEditor";
 import { useFootprintEditorStore } from "@/stores/footprintEditor";
+import { useProjectStore } from "@/stores/project";
 import type { LibSymbol, SymbolSearchResult, LibraryInfo } from "@/types";
 
 /** Footprint data returned from Rust pcb_parser (snake_case field names) */
@@ -193,6 +194,9 @@ export function ComponentPanel() {
       pin_name_offset: 1.016,
     };
     useLibraryEditorStore.getState().openSymbol(emptySymbol, "user_library.snxsym", "NewSymbol");
+    // Open as document tab (Altium-style)
+    const ps = useProjectStore.getState();
+    ps.openTab({ id: "lib-sym-NewSymbol", name: "NewSymbol.snxsym", type: "library", dirty: false });
   };
 
   const newFootprint = () => {
@@ -206,6 +210,8 @@ export function ComponentPanel() {
       courtyard: [],
       model3d: "",
     }, "user_library.snxpkg", "NewFootprint");
+    const ps = useProjectStore.getState();
+    ps.openTab({ id: "lib-fp-NewFootprint", name: "NewFootprint.snxpkg", type: "library", dirty: false });
   };
 
   const placeComponent = async (result: SymbolSearchResult) => {

--- a/src/panels/ComponentPanel.tsx
+++ b/src/panels/ComponentPanel.tsx
@@ -4,6 +4,7 @@ import { Search, Package, Cpu, ChevronRight, Pencil, Copy, FilePlus, Star, Folde
 import { cn } from "@/lib/utils";
 import { useSchematicStore } from "@/stores/schematic";
 import { useLibraryEditorStore } from "@/stores/libraryEditor";
+import { useFootprintEditorStore } from "@/stores/footprintEditor";
 import type { LibSymbol, SymbolSearchResult, LibraryInfo } from "@/types";
 
 /** Footprint data returned from Rust pcb_parser (snake_case field names) */
@@ -194,6 +195,19 @@ export function ComponentPanel() {
     useLibraryEditorStore.getState().openSymbol(emptySymbol, "user_library.snxsym", "NewSymbol");
   };
 
+  const newFootprint = () => {
+    useFootprintEditorStore.getState().openFootprint({
+      id: "NewFootprint",
+      pads: [],
+      graphics: [
+        { type: "rect", start: { x: -1.5, y: -1.5 }, end: { x: 1.5, y: 1.5 }, layer: "F.Fab" as any, width: 0.1 },
+        { type: "rect", start: { x: -1.8, y: -1.8 }, end: { x: 1.8, y: 1.8 }, layer: "F.CrtYd" as any, width: 0.05 },
+      ],
+      courtyard: [],
+      model3d: "",
+    }, "user_library.snxpkg", "NewFootprint");
+  };
+
   const placeComponent = async (result: SymbolSearchResult) => {
     let sym = preview;
     if (!sym || selectedResult?.symbol_id !== result.symbol_id) {
@@ -300,6 +314,10 @@ export function ComponentPanel() {
         <button onClick={newSymbol} title="New Symbol"
           className="p-1 rounded text-text-muted/40 hover:text-accent hover:bg-accent/10 transition-colors shrink-0">
           <FilePlus size={13} />
+        </button>
+        <button onClick={newFootprint} title="New Footprint"
+          className="p-1 rounded text-text-muted/40 hover:text-success hover:bg-success/10 transition-colors shrink-0">
+          <Cpu size={13} />
         </button>
       </div>
 

--- a/src/panels/ComponentPanel.tsx
+++ b/src/panels/ComponentPanel.tsx
@@ -184,11 +184,8 @@ export function ComponentPanel() {
   const newSymbol = () => {
     const emptySymbol: LibSymbol = {
       id: "NewSymbol",
-      graphics: [{ type: "Rectangle", start: { x: -2.54, y: -5.08 }, end: { x: 2.54, y: 5.08 }, width: 0.254, fill_type: "none" }],
-      pins: [
-        { pin_type: "passive", shape: "line", position: { x: -5.08, y: 2.54 }, rotation: 0, length: 2.54, name: "1", number: "1", name_visible: true, number_visible: true },
-        { pin_type: "passive", shape: "line", position: { x: -5.08, y: -2.54 }, rotation: 0, length: 2.54, name: "2", number: "2", name_visible: true, number_visible: true },
-      ],
+      graphics: [],
+      pins: [],
       show_pin_numbers: true,
       show_pin_names: true,
       pin_name_offset: 1.016,

--- a/src/panels/LayerStackPanel.tsx
+++ b/src/panels/LayerStackPanel.tsx
@@ -1,4 +1,5 @@
-import { Eye, EyeOff, Layers } from "lucide-react";
+import { useState } from "react";
+import { Eye, EyeOff, Layers, Save } from "lucide-react";
 import { usePcbStore } from "@/stores/pcb";
 import { useEditorStore } from "@/stores/editor";
 import { useProjectStore } from "@/stores/project";
@@ -30,6 +31,29 @@ const TECH_LAYERS: { id: PcbLayerId; label: string }[] = [
   { id: "Cmts.User", label: "User Comments" },
 ];
 
+const LAYER_PRESETS: { label: string; layers: PcbLayerId[] }[] = [
+  { label: "All Layers", layers: [...COPPER_LAYERS, ...TECH_LAYERS.map(l => l.id)] },
+  { label: "Front Only", layers: ["F.Cu", "F.SilkS", "F.Mask", "F.Paste", "F.Fab", "F.CrtYd", "Edge.Cuts"] },
+  { label: "Back Only", layers: ["B.Cu", "B.SilkS", "B.Mask", "B.Paste", "B.Fab", "B.CrtYd", "Edge.Cuts"] },
+  { label: "Copper Only", layers: [...COPPER_LAYERS] },
+  { label: "Assembly Top", layers: ["F.Cu", "F.SilkS", "F.Fab", "F.CrtYd", "Edge.Cuts"] },
+  { label: "Assembly Bottom", layers: ["B.Cu", "B.SilkS", "B.Fab", "B.CrtYd", "Edge.Cuts"] },
+  { label: "Fabrication", layers: ["F.Cu", "B.Cu", "F.Mask", "B.Mask", "F.Paste", "B.Paste", "F.SilkS", "B.SilkS", "Edge.Cuts"] },
+];
+
+function loadCustomPresets(): { label: string; layers: PcbLayerId[] }[] {
+  try {
+    const raw = localStorage.getItem("signex-layer-presets");
+    return raw ? JSON.parse(raw) : [];
+  } catch { return []; }
+}
+
+function saveCustomPreset(name: string, layers: PcbLayerId[]) {
+  const existing = loadCustomPresets();
+  existing.push({ label: name, layers });
+  localStorage.setItem("signex-layer-presets", JSON.stringify(existing));
+}
+
 export function LayerStackPanel() {
   const data = usePcbStore((s) => s.data);
   const activeLayer = usePcbStore((s) => s.activeLayer);
@@ -38,6 +62,7 @@ export function LayerStackPanel() {
   const toggleLayerVisibility = usePcbStore((s) => s.toggleLayerVisibility);
   const editorMode = useEditorStore((s) => s.mode);
   const project = useProjectStore((s) => s.project);
+  const [customPresets, setCustomPresets] = useState(loadCustomPresets);
 
   // Only show in PCB mode with a project open
   if (!project || editorMode !== "pcb") {
@@ -66,6 +91,47 @@ export function LayerStackPanel() {
           <button onClick={() => usePcbStore.getState().setAllLayersVisible()}
             className="text-[10px] text-accent hover:underline">All On</button>
         </div>
+      </div>
+
+      {/* Layer Presets */}
+      <div className="flex items-center gap-1 px-2 py-1 border-b border-border-subtle shrink-0">
+        <select
+          onChange={(e) => {
+            const all = [...LAYER_PRESETS, ...customPresets];
+            const preset = all.find(p => p.label === e.target.value);
+            if (!preset) return;
+            const store = usePcbStore.getState();
+            // Turn off all, then enable preset layers
+            const newVisible = new Set<string>(preset.layers);
+            store.setAllLayersVisible(); // reset
+            // We need to toggle off layers not in the preset
+            for (const l of [...COPPER_LAYERS, ...TECH_LAYERS.map(t => t.id)]) {
+              const isVis = (store.visibleLayers as Set<string>).has(l);
+              const shouldVis = newVisible.has(l);
+              if (isVis && !shouldVis) store.toggleLayerVisibility(l);
+            }
+          }}
+          defaultValue=""
+          className="flex-1 bg-bg-surface border border-border-subtle rounded px-1.5 py-0.5 text-[9px] outline-none focus:border-accent"
+        >
+          <option value="" disabled>Presets...</option>
+          {LAYER_PRESETS.map(p => <option key={p.label} value={p.label}>{p.label}</option>)}
+          {customPresets.length > 0 && <option disabled>--- Custom ---</option>}
+          {customPresets.map(p => <option key={p.label} value={p.label}>{p.label}</option>)}
+        </select>
+        <button
+          title="Save current layer set"
+          onClick={() => {
+            const name = prompt("Preset name:");
+            if (!name) return;
+            const layers = [...visibleLayers] as PcbLayerId[];
+            saveCustomPreset(name, layers);
+            setCustomPresets(loadCustomPresets());
+          }}
+          className="p-0.5 text-text-muted hover:text-accent"
+        >
+          <Save size={11} />
+        </button>
       </div>
 
       {/* Layer list */}

--- a/src/panels/LayerStackPanel.tsx
+++ b/src/panels/LayerStackPanel.tsx
@@ -44,7 +44,14 @@ const LAYER_PRESETS: { label: string; layers: PcbLayerId[] }[] = [
 function loadCustomPresets(): { label: string; layers: PcbLayerId[] }[] {
   try {
     const raw = localStorage.getItem("signex-layer-presets");
-    return raw ? JSON.parse(raw) : [];
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((p: unknown) =>
+      typeof p === "object" && p !== null &&
+      typeof (p as any).label === "string" &&
+      Array.isArray((p as any).layers)
+    );
   } catch { return []; }
 }
 
@@ -100,15 +107,13 @@ export function LayerStackPanel() {
             const all = [...LAYER_PRESETS, ...customPresets];
             const preset = all.find(p => p.label === e.target.value);
             if (!preset) return;
-            const store = usePcbStore.getState();
-            // Turn off all, then enable preset layers
-            const newVisible = new Set<string>(preset.layers);
-            store.setAllLayersVisible(); // reset
-            // We need to toggle off layers not in the preset
+            // First set all visible, then re-read fresh state and toggle off non-preset layers
+            usePcbStore.getState().setAllLayersVisible();
+            const freshStore = usePcbStore.getState();
+            const wanted = new Set<string>(preset.layers);
             for (const l of [...COPPER_LAYERS, ...TECH_LAYERS.map(t => t.id)]) {
-              const isVis = (store.visibleLayers as Set<string>).has(l);
-              const shouldVis = newVisible.has(l);
-              if (isVis && !shouldVis) store.toggleLayerVisibility(l);
+              const isVis = (freshStore.visibleLayers as Set<string>).has(l);
+              if (isVis && !wanted.has(l)) freshStore.toggleLayerVisibility(l);
             }
           }}
           defaultValue=""

--- a/src/panels/NetClassPanel.tsx
+++ b/src/panels/NetClassPanel.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { Plus, Trash2, X } from "lucide-react";
+import { useSchematicStore } from "@/stores/schematic";
+import { cn } from "@/lib/utils";
+
+export function NetClassPanel() {
+  const data = useSchematicStore((s) => s.data);
+  const addNetClass = useSchematicStore((s) => s.addNetClass);
+  const removeNetClass = useSchematicStore((s) => s.removeNetClass);
+  const assignNetToClass = useSchematicStore((s) => s.assignNetToClass);
+  const removeNetFromClass = useSchematicStore((s) => s.removeNetFromClass);
+  const [newClassName, setNewClassName] = useState("");
+  const [selectedClass, setSelectedClass] = useState<string | null>(null);
+  const [assignNet, setAssignNet] = useState("");
+
+  const netClasses = data?.net_classes ?? [];
+
+  const handleAdd = () => {
+    const name = newClassName.trim();
+    if (!name) return;
+    addNetClass(name);
+    setNewClassName("");
+    setSelectedClass(name);
+  };
+
+  const handleAssignNet = () => {
+    const net = assignNet.trim();
+    if (!net || !selectedClass) return;
+    assignNetToClass(net, selectedClass);
+    setAssignNet("");
+  };
+
+  return (
+    <div className="flex flex-col h-full text-xs select-none">
+      <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border-subtle bg-bg-secondary/80 shrink-0">
+        <span className="text-[10px] font-semibold text-accent uppercase tracking-wider">Net Classes</span>
+      </div>
+
+      {/* Add class */}
+      <div className="flex items-center gap-1 px-2 py-1 border-b border-border-subtle shrink-0">
+        <input
+          value={newClassName}
+          onChange={(e) => setNewClassName(e.target.value)}
+          onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Enter") handleAdd(); }}
+          placeholder="New class name..."
+          className="flex-1 bg-bg-surface border border-border-subtle rounded px-1.5 py-0.5 text-[10px] outline-none focus:border-accent"
+        />
+        <button onClick={handleAdd} disabled={!newClassName.trim()}
+          className="p-0.5 text-text-muted hover:text-accent disabled:opacity-30">
+          <Plus size={12} />
+        </button>
+      </div>
+
+      {/* Class list */}
+      <div className="flex-1 overflow-y-auto">
+        {netClasses.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-[10px] text-text-muted/40">
+            No net classes defined
+          </div>
+        ) : (
+          netClasses.map((nc) => (
+            <div key={nc.name}>
+              <div
+                className={cn(
+                  "flex items-center gap-1.5 px-2 py-[3px] cursor-pointer transition-colors",
+                  selectedClass === nc.name ? "bg-accent/15 text-accent" : "text-text-secondary hover:bg-bg-hover/50"
+                )}
+                onClick={() => setSelectedClass(selectedClass === nc.name ? null : nc.name)}
+              >
+                {nc.color && <div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: nc.color }} />}
+                <span className="flex-1 text-[11px] font-medium truncate">{nc.name}</span>
+                <span className="text-[9px] text-text-muted">{nc.nets.length} nets</span>
+                <button onClick={(e) => { e.stopPropagation(); removeNetClass(nc.name); }}
+                  className="p-0.5 text-text-muted/30 hover:text-error">
+                  <Trash2 size={10} />
+                </button>
+              </div>
+
+              {selectedClass === nc.name && (
+                <div className="pl-6 pr-2 py-1 bg-bg-surface/30">
+                  {nc.nets.length > 0 ? (
+                    nc.nets.map((net) => (
+                      <div key={net} className="flex items-center gap-1 py-[1px] text-[10px] text-text-muted">
+                        <span className="flex-1 font-mono truncate">{net}</span>
+                        <button onClick={() => removeNetFromClass(net, nc.name)}
+                          className="p-0.5 text-text-muted/20 hover:text-error">
+                          <X size={8} />
+                        </button>
+                      </div>
+                    ))
+                  ) : (
+                    <span className="text-[9px] text-text-muted/30 italic">No nets assigned</span>
+                  )}
+                  <div className="flex items-center gap-1 mt-1">
+                    <input
+                      value={assignNet}
+                      onChange={(e) => setAssignNet(e.target.value)}
+                      onKeyDown={(e) => { e.stopPropagation(); if (e.key === "Enter") handleAssignNet(); }}
+                      placeholder="Add net..."
+                      className="flex-1 bg-bg-surface border border-border-subtle rounded px-1 py-0.5 text-[9px] outline-none focus:border-accent"
+                    />
+                    <button onClick={handleAssignNet} disabled={!assignNet.trim()}
+                      className="p-0.5 text-text-muted hover:text-accent disabled:opacity-30">
+                      <Plus size={10} />
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/panels/NetInspectorPanel.tsx
+++ b/src/panels/NetInspectorPanel.tsx
@@ -1,0 +1,99 @@
+import { useMemo, useState } from "react";
+import { usePcbStore } from "@/stores/pcb";
+import { generateNetReport } from "@/lib/pcbOutputFormats";
+import { cn } from "@/lib/utils";
+
+export function NetInspectorPanel() {
+  const pcbData = usePcbStore((s) => s.data);
+  const [sortCol, setSortCol] = useState<"name" | "segments" | "vias" | "totalLength">("name");
+  const [sortAsc, setSortAsc] = useState(true);
+  const [filter, setFilter] = useState("");
+
+  const report = useMemo(() => {
+    if (!pcbData) return [];
+    return generateNetReport(pcbData);
+  }, [pcbData]);
+
+  const filtered = useMemo(() => {
+    let rows = report;
+    if (filter) {
+      const q = filter.toLowerCase();
+      rows = rows.filter((r) => r.name.toLowerCase().includes(q));
+    }
+    rows = [...rows].sort((a, b) => {
+      const av = a[sortCol], bv = b[sortCol];
+      if (typeof av === "string" && typeof bv === "string") return sortAsc ? av.localeCompare(bv) : bv.localeCompare(av);
+      return sortAsc ? (av as number) - (bv as number) : (bv as number) - (av as number);
+    });
+    return rows;
+  }, [report, sortCol, sortAsc, filter]);
+
+  const toggleSort = (col: typeof sortCol) => {
+    if (sortCol === col) setSortAsc(!sortAsc);
+    else { setSortCol(col); setSortAsc(true); }
+  };
+
+  if (!pcbData) {
+    return (
+      <div className="flex flex-col h-full">
+        <div className="px-3 py-2 border-b border-border-subtle bg-bg-secondary/80 text-[10px] font-semibold text-text-secondary">
+          Net Inspector
+        </div>
+        <div className="flex-1 flex items-center justify-center p-4">
+          <span className="text-[10px] text-text-muted/40">No PCB data loaded</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full text-xs select-none">
+      <div className="flex items-center gap-2 px-2 py-1.5 border-b border-border-subtle bg-bg-secondary/80 shrink-0">
+        <span className="text-[10px] font-semibold text-accent uppercase tracking-wider">Net Inspector</span>
+        <input
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          onKeyDown={(e) => e.stopPropagation()}
+          placeholder="Filter..."
+          className="flex-1 bg-bg-surface border border-border-subtle rounded px-1.5 py-0.5 text-[9px] outline-none focus:border-accent"
+        />
+        <span className="text-[9px] text-text-muted">{filtered.length} nets</span>
+      </div>
+
+      <div className="flex items-center px-2 py-0.5 border-b border-border-subtle bg-bg-secondary/40 text-[9px] font-semibold text-text-muted/50 shrink-0">
+        <span className="flex-1 cursor-pointer hover:text-text-primary" onClick={() => toggleSort("name")}>
+          Net {sortCol === "name" ? (sortAsc ? "\u25b2" : "\u25bc") : ""}
+        </span>
+        <span className="w-[50px] text-right cursor-pointer hover:text-text-primary" onClick={() => toggleSort("segments")}>
+          Segs {sortCol === "segments" ? (sortAsc ? "\u25b2" : "\u25bc") : ""}
+        </span>
+        <span className="w-[40px] text-right cursor-pointer hover:text-text-primary" onClick={() => toggleSort("vias")}>
+          Vias {sortCol === "vias" ? (sortAsc ? "\u25b2" : "\u25bc") : ""}
+        </span>
+        <span className="w-[60px] text-right cursor-pointer hover:text-text-primary" onClick={() => toggleSort("totalLength")}>
+          Length {sortCol === "totalLength" ? (sortAsc ? "\u25b2" : "\u25bc") : ""}
+        </span>
+        <span className="w-[40px] text-right">Status</span>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {filtered.map((r) => (
+          <div key={r.number}
+            className="flex items-center px-2 py-[2px] border-b border-border-subtle/20 hover:bg-bg-hover/30 cursor-pointer text-[10px]"
+            onClick={() => {
+              usePcbStore.getState().setNetColor(r.number, "#ff0");
+            }}
+          >
+            <span className="flex-1 font-mono truncate text-text-primary">{r.name || `Net ${r.number}`}</span>
+            <span className="w-[50px] text-right text-text-muted">{r.segments}</span>
+            <span className="w-[40px] text-right text-text-muted">{r.vias}</span>
+            <span className="w-[60px] text-right text-text-muted font-mono">{r.totalLength.toFixed(2)}</span>
+            <span className={cn("w-[40px] text-right text-[9px]", r.routed ? "text-success" : "text-warning")}>
+              {r.routed ? "OK" : "OPEN"}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/panels/NetInspectorPanel.tsx
+++ b/src/panels/NetInspectorPanel.tsx
@@ -81,7 +81,15 @@ export function NetInspectorPanel() {
           <div key={r.number}
             className="flex items-center px-2 py-[2px] border-b border-border-subtle/20 hover:bg-bg-hover/30 cursor-pointer text-[10px]"
             onClick={() => {
-              usePcbStore.getState().setNetColor(r.number, "#ff0");
+              const store = usePcbStore.getState();
+              const current = store.netColors[r.number];
+              if (current) {
+                // Toggle off — remove the color override
+                const { [r.number]: _, ...rest } = store.netColors;
+                usePcbStore.setState({ netColors: rest });
+              } else {
+                store.setNetColor(r.number, "#ffff00");
+              }
             }}
           >
             <span className="flex-1 font-mono truncate text-text-primary">{r.name || `Net ${r.number}`}</span>

--- a/src/panels/OutputJobsPanel.tsx
+++ b/src/panels/OutputJobsPanel.tsx
@@ -2,8 +2,13 @@ import { useState } from "react";
 import { Play, Plus, Trash2, ChevronDown, ChevronUp, Settings2, PlayCircle, Loader2 } from "lucide-react";
 import { useOutputJobsStore, getJobTypeLabel } from "@/stores/outputJobs";
 import { useSchematicStore } from "@/stores/schematic";
+import { usePcbStore } from "@/stores/pcb";
 import { invoke } from "@tauri-apps/api/core";
 import { exportSchematicPdf } from "@/lib/pdfExport";
+import { exportGerberSet } from "@/lib/pcbGerberExport";
+import { generateOdbPlusPlus } from "@/lib/pcbOdbExport";
+import { generateStepFile } from "@/lib/pcbStepExport";
+import { generatePickAndPlace, generateAssemblySvg, generateIpc2581 } from "@/lib/pcbOutputFormats";
 import { cn } from "@/lib/utils";
 import type { OutputJob, OutputJobType } from "@/stores/outputJobs";
 
@@ -15,12 +20,13 @@ export function OutputJobsPanel() {
   const updateJob = useOutputJobsStore((s) => s.updateJob);
   const reorderJob = useOutputJobsStore((s) => s.reorderJob);
   const data = useSchematicStore((s) => s.data);
+  const pcbData = usePcbStore((s) => s.data);
   const [runningId, setRunningId] = useState<string | null>(null);
   const [runningAll, setRunningAll] = useState(false);
   const [configId, setConfigId] = useState<string | null>(null);
   const [showAddMenu, setShowAddMenu] = useState(false);
 
-  const jobTypes: OutputJobType[] = ["bom", "netlist", "pdf", "png"];
+  const jobTypes: OutputJobType[] = ["bom", "netlist", "pdf", "png", "gerber", "odb", "step", "pick_place", "ipc2581", "assembly_svg"];
 
   const runJob = async (job: OutputJob) => {
     if (!data) return;
@@ -60,6 +66,43 @@ export function OutputJobsPanel() {
         }
         case "png": {
           window.dispatchEvent(new CustomEvent("alp-export-png"));
+          break;
+        }
+        case "gerber": {
+          if (!pcbData) { alert("No PCB data loaded"); break; }
+          const files = exportGerberSet(pcbData);
+          for (const f of files) downloadBlob(f.content, f.filename, "application/octet-stream");
+          break;
+        }
+        case "odb": {
+          if (!pcbData) { alert("No PCB data loaded"); break; }
+          const odbFiles = generateOdbPlusPlus(pcbData);
+          for (const f of odbFiles) downloadBlob(f.content, f.filename, "text/plain");
+          break;
+        }
+        case "step": {
+          if (!pcbData) { alert("No PCB data loaded"); break; }
+          const stepContent = generateStepFile(pcbData);
+          downloadBlob(stepContent, "board.step", "application/step");
+          break;
+        }
+        case "pick_place": {
+          if (!pcbData) { alert("No PCB data loaded"); break; }
+          const ppContent = generatePickAndPlace(pcbData);
+          downloadBlob(ppContent, "pick_and_place.csv", "text/csv");
+          break;
+        }
+        case "ipc2581": {
+          if (!pcbData) { alert("No PCB data loaded"); break; }
+          const ipcContent = generateIpc2581(pcbData);
+          downloadBlob(ipcContent, "board.xml", "application/xml");
+          break;
+        }
+        case "assembly_svg": {
+          if (!pcbData) { alert("No PCB data loaded"); break; }
+          const side = job.config.assemblySide || "top";
+          const svgContent = generateAssemblySvg(pcbData, side);
+          downloadBlob(svgContent, `assembly_${side}.svg`, "image/svg+xml");
           break;
         }
       }
@@ -255,6 +298,47 @@ function JobConfigPanel({ job, onUpdate }: { job: OutputJob; onUpdate: (u: Parti
       {job.type === "png" && (
         <div className="text-[10px] text-text-muted/60 italic">
           Uses current canvas settings
+        </div>
+      )}
+
+      {job.type === "gerber" && (
+        <div className="text-[10px] text-text-muted/60 italic">
+          Exports all copper, silkscreen, mask, paste layers + drill file
+        </div>
+      )}
+
+      {job.type === "odb" && (
+        <div className="text-[10px] text-text-muted/60 italic">
+          ODB++ directory-based fabrication format
+        </div>
+      )}
+
+      {job.type === "step" && (
+        <div className="text-[10px] text-text-muted/60 italic">
+          STEP AP214 3D board geometry for mechanical review
+        </div>
+      )}
+
+      {job.type === "pick_place" && (
+        <div className="text-[10px] text-text-muted/60 italic">
+          CSV centroid file for pick-and-place machines
+        </div>
+      )}
+
+      {job.type === "ipc2581" && (
+        <div className="text-[10px] text-text-muted/60 italic">
+          IPC-2581 XML board description
+        </div>
+      )}
+
+      {job.type === "assembly_svg" && (
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] text-text-muted w-14">Side</span>
+          <select value={job.config.assemblySide || "top"} onChange={(e) => updateConfig("assemblySide", e.target.value)}
+            className="bg-bg-surface border border-border-subtle rounded px-2 py-0.5 text-[10px] text-text-primary outline-none focus:border-accent">
+            <option value="top">Top</option>
+            <option value="bottom">Bottom</option>
+          </select>
         </div>
       )}
     </div>

--- a/src/panels/PcbLibraryPanel.tsx
+++ b/src/panels/PcbLibraryPanel.tsx
@@ -60,8 +60,8 @@ export function PcbLibraryPanel() {
           };
           store.openFootprint(emptyFp, store.sourcePath || "user_library.snxpkg", "NewFootprint");
         }} />
-        <ActionButton icon={<Trash2 size={12} />} label="Delete" onClick={() => {}} />
-        <ActionButton icon={<Pencil size={12} />} label="Edit" onClick={() => {}} />
+        <ActionButton icon={<Trash2 size={12} />} label="Delete" disabled onClick={() => {}} />
+        <ActionButton icon={<Pencil size={12} />} label="Edit" disabled onClick={() => {}} />
       </div>
     </div>
   );
@@ -119,11 +119,15 @@ function FootprintTreeItem({ footprint, isActive }: {
   );
 }
 
-function ActionButton({ icon, label, onClick }: { icon: React.ReactNode; label: string; onClick: () => void }) {
+function ActionButton({ icon, label, onClick, disabled }: { icon: React.ReactNode; label: string; onClick: () => void; disabled?: boolean }) {
   return (
     <button
       onClick={onClick}
-      className="flex items-center gap-1 px-2 py-1 text-[10px] text-text-secondary hover:text-text-primary hover:bg-bg-hover rounded transition-colors"
+      disabled={disabled}
+      className={cn(
+        "flex items-center gap-1 px-2 py-1 text-[10px] rounded transition-colors",
+        disabled ? "text-text-muted/30 cursor-default" : "text-text-secondary hover:text-text-primary hover:bg-bg-hover"
+      )}
     >
       {icon}
       <span>{label}</span>

--- a/src/panels/PcbLibraryPanel.tsx
+++ b/src/panels/PcbLibraryPanel.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+import { useFootprintEditorStore } from "@/stores/footprintEditor";
+import type { FootprintData } from "@/stores/footprintEditor";
+import { ChevronDown, ChevronRight, Box, Play, Plus, Trash2, Pencil } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * PCB Library Panel — Altium-style footprint browser.
+ * Shows all footprints in the current library with pad/primitive counts.
+ * Provides Place, Add, Delete, Edit actions.
+ */
+export function PcbLibraryPanel() {
+  const footprint = useFootprintEditorStore(s => s.footprint);
+  const active = useFootprintEditorStore(s => s.active);
+
+  if (!active || !footprint) {
+    return (
+      <div className="flex flex-col h-full">
+        <div className="px-3 py-2 border-b border-border-subtle bg-bg-secondary/80 text-[10px] font-semibold text-text-secondary">
+          PCB Library
+        </div>
+        <div className="flex-1 flex items-center justify-center p-4">
+          <span className="text-[10px] text-text-muted/40">No library open</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full text-xs select-none">
+      {/* Header */}
+      <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border-subtle bg-bg-secondary/80 shrink-0">
+        <span className="text-[10px] font-semibold text-accent uppercase tracking-wider">PCB Library</span>
+      </div>
+
+      {/* Column headers */}
+      <div className="flex items-center px-2 py-0.5 border-b border-border-subtle bg-bg-secondary/40 text-[9px] font-semibold text-text-muted/50">
+        <span className="flex-1">Name</span>
+        <span className="w-[50px] text-right">Pads</span>
+        <span className="w-[70px] text-right">Primitives</span>
+      </div>
+
+      {/* Footprint list */}
+      <div className="flex-1 overflow-y-auto">
+        <FootprintTreeItem footprint={footprint} isActive={true} />
+      </div>
+
+      {/* Action bar */}
+      <div className="flex items-center gap-1 px-2 py-1.5 border-t border-border-subtle bg-bg-secondary/80 shrink-0">
+        <ActionButton icon={<Play size={12} />} label="Place" onClick={() => {}} />
+        <ActionButton icon={<Plus size={12} />} label="Add" onClick={() => {
+          const store = useFootprintEditorStore.getState();
+          if (!store.footprint) return;
+          const emptyFp: FootprintData = {
+            id: "NewFootprint",
+            pads: [],
+            graphics: [],
+            courtyard: [],
+            model3d: "",
+          };
+          store.openFootprint(emptyFp, store.sourcePath || "user_library.snxpkg", "NewFootprint");
+        }} />
+        <ActionButton icon={<Trash2 size={12} />} label="Delete" onClick={() => {}} />
+        <ActionButton icon={<Pencil size={12} />} label="Edit" onClick={() => {}} />
+      </div>
+    </div>
+  );
+}
+
+function FootprintTreeItem({ footprint, isActive }: {
+  footprint: FootprintData;
+  isActive: boolean;
+}) {
+  const [expanded, setExpanded] = useState(true);
+  const padCount = footprint.pads.length;
+  const graphicCount = footprint.graphics.length;
+  const hasPrimitives = graphicCount > 0;
+
+  return (
+    <div>
+      <div
+        className={cn(
+          "flex items-center gap-1.5 px-2 py-[3px] cursor-pointer transition-colors",
+          isActive ? "bg-accent/15 text-accent" : "text-text-secondary hover:bg-bg-hover/50"
+        )}
+        onClick={() => hasPrimitives && setExpanded(!expanded)}
+      >
+        {hasPrimitives ? (
+          expanded ? <ChevronDown size={10} /> : <ChevronRight size={10} />
+        ) : (
+          <span className="w-[10px]" />
+        )}
+        <Box size={11} className="shrink-0 text-warning/70" />
+        <span className="flex-1 text-[11px] truncate font-medium">{footprint.id}</span>
+        <span className="w-[50px] text-right text-[10px] text-text-muted">{padCount}</span>
+        <span className="w-[70px] text-right text-[10px] text-text-muted">{graphicCount}</span>
+      </div>
+
+      {hasPrimitives && expanded && (
+        <div>
+          {/* Footprint Primitives section */}
+          <div className="flex items-center gap-1.5 pl-8 pr-2 py-[2px] text-[10px] text-text-muted/60 font-semibold">
+            Primitives
+          </div>
+          {footprint.graphics.map((g, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-1.5 pl-10 pr-2 py-[2px] text-[10px] text-text-muted hover:bg-bg-hover/50 cursor-pointer"
+            >
+              <span className="w-[10px]" />
+              <span className="capitalize">{g.type}</span>
+              <span className="flex-1" />
+              <span className="text-text-muted/40">{g.layer}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ActionButton({ icon, label, onClick }: { icon: React.ReactNode; label: string; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex items-center gap-1 px-2 py-1 text-[10px] text-text-secondary hover:text-text-primary hover:bg-bg-hover rounded transition-colors"
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/src/panels/ProjectPanel.tsx
+++ b/src/panels/ProjectPanel.tsx
@@ -50,9 +50,9 @@ function TreeItem({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
           }
         }}
         onContextMenu={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
           if (node.onContextMenu) {
-            e.preventDefault();
-            e.stopPropagation();
             node.onContextMenu(e);
           }
         }}
@@ -161,6 +161,7 @@ export function ProjectPanel() {
     label: `[${idx + 1}] ${sheet.name}`,
     icon: <FileText size={12} className="text-warning/70" />,
     badge: `${sheet.symbols_count}c ${sheet.wires_count}w`,
+    onContextMenu: handleProjectContextMenu,
     onClick: () => {
       const tabId = `sch-${project.path}:${sheet.filename}`;
       openTab({
@@ -231,6 +232,7 @@ export function ProjectPanel() {
         icon: <FolderClosed size={12} className="text-warning/80" />,
         expandedIcon: <FolderOpen size={12} className="text-warning/80" />,
         isFolder: true,
+        onContextMenu: handleProjectContextMenu,
         children: sourceDocChildren,
       },
       {
@@ -261,7 +263,7 @@ export function ProjectPanel() {
   };
 
   return (
-    <div className="py-1" onContextMenu={handlePanelContextMenu}>
+    <div className="py-1 h-full" onContextMenu={(e) => { e.preventDefault(); handlePanelContextMenu(e); }}>
       <TreeItem node={tree} />
       {project.format === "kicad" && (
         <div className="mx-3 mt-3 px-2 py-1.5 text-[10px] text-text-muted/40 bg-bg-surface/30 rounded border border-border-subtle">

--- a/src/panels/ProjectPanel.tsx
+++ b/src/panels/ProjectPanel.tsx
@@ -8,8 +8,13 @@ import {
   Component,
   Cable,
   Tag,
+  FolderSearch,
+  RefreshCw,
+  Save,
+  FilePlus,
+  FolderPlus,
 } from "lucide-react";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { cn } from "@/lib/utils";
 import { useProjectStore } from "@/stores/project";
 
@@ -20,6 +25,7 @@ interface TreeNode {
   badge?: string;
   children?: TreeNode[];
   onClick?: () => void;
+  onContextMenu?: (e: React.MouseEvent) => void;
   defaultExpanded?: boolean;
   isFolder?: boolean;
 }
@@ -41,6 +47,13 @@ function TreeItem({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
             node.onClick();
           } else if (isExpandable) {
             setExpanded(!expanded);
+          }
+        }}
+        onContextMenu={(e) => {
+          if (node.onContextMenu) {
+            e.preventDefault();
+            e.stopPropagation();
+            node.onContextMenu(e);
           }
         }}
       >
@@ -79,17 +92,67 @@ function TreeItem({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
   );
 }
 
+// Context menu types
+interface CtxMenu {
+  x: number;
+  y: number;
+  type: "panel" | "project" | "sheet";
+  sheetIdx?: number;
+}
+
+function ContextMenuItem({ label, icon, onClick, disabled, hasSubmenu }: {
+  label: string; icon?: React.ReactNode; onClick?: () => void; disabled?: boolean; hasSubmenu?: boolean;
+}) {
+  return (
+    <button onClick={onClick} disabled={disabled}
+      className={cn("flex items-center gap-2 w-full px-3 py-1 text-[11px] text-left transition-colors",
+        disabled ? "text-text-muted/30 cursor-default" : "text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+      )}>
+      {icon && <span className="w-4 shrink-0">{icon}</span>}
+      <span className="flex-1">{label}</span>
+      {hasSubmenu && <ChevronRight size={10} className="text-text-muted/40" />}
+    </button>
+  );
+}
+
+function ContextMenuSep() {
+  return <div className="my-1 border-t border-border-subtle" />;
+}
+
 export function ProjectPanel() {
   const project = useProjectStore((s) => s.project);
   const openTab = useProjectStore((s) => s.openTab);
   const setActiveTab = useProjectStore((s) => s.setActiveTab);
+  const recentProjects = useProjectStore((s) => s.recentProjects);
+  const [ctxMenu, setCtxMenu] = useState<CtxMenu | null>(null);
+
+  const closeCtx = useCallback(() => { setCtxMenu(null); }, []);
+
+  const handlePanelContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setCtxMenu({ x: e.clientX, y: e.clientY, type: "panel" });
+  }, []);
+
+  const handleProjectContextMenu = useCallback((e: React.MouseEvent) => {
+    setCtxMenu({ x: e.clientX, y: e.clientY, type: "project" });
+  }, []);
+
+  const handleExplore = useCallback(() => {
+    if (!project) return;
+    closeCtx();
+    import("@tauri-apps/api/core").then(({ invoke }) => invoke("open_path", { path: project.dir })).catch(() => {});
+  }, [project, closeCtx]);
 
   if (!project) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-text-muted text-xs gap-3 p-6">
+      <div className="flex flex-col items-center justify-center h-full text-text-muted text-xs gap-3 p-6"
+        onContextMenu={handlePanelContextMenu}>
         <FolderOpen size={28} className="text-text-muted/20" />
         <span className="text-text-muted/50">No project open</span>
         <span className="text-text-muted/30 text-[11px]">Ctrl+O to open</span>
+        {ctxMenu?.type === "panel" && (
+          <PanelContextMenu x={ctxMenu.x} y={ctxMenu.y} onClose={closeCtx} recentProjects={recentProjects} />
+        )}
       </div>
     );
   }
@@ -153,6 +216,7 @@ export function ProjectPanel() {
     label: project.name,
     icon: <FolderClosed size={13} className="text-accent" />,
     expandedIcon: <FolderOpen size={13} className="text-accent" />,
+    onContextMenu: handleProjectContextMenu,
     children: [
       {
         label: "Variants",
@@ -197,13 +261,103 @@ export function ProjectPanel() {
   };
 
   return (
-    <div className="py-1">
+    <div className="py-1" onContextMenu={handlePanelContextMenu}>
       <TreeItem node={tree} />
       {project.format === "kicad" && (
         <div className="mx-3 mt-3 px-2 py-1.5 text-[10px] text-text-muted/40 bg-bg-surface/30 rounded border border-border-subtle">
           Imported from KiCad
         </div>
       )}
+
+      {/* Context menus */}
+      {ctxMenu?.type === "panel" && (
+        <PanelContextMenu x={ctxMenu.x} y={ctxMenu.y} onClose={closeCtx} recentProjects={recentProjects} />
+      )}
+      {ctxMenu?.type === "project" && (
+        <ProjectContextMenu x={ctxMenu.x} y={ctxMenu.y} onClose={closeCtx}
+          onExplore={handleExplore} projectName={project.name} />
+      )}
     </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════
+// CONTEXT MENUS
+// ═══════════════════════════════════════════════════════════════
+
+function PanelContextMenu({ x, y, onClose, recentProjects }: {
+  x: number; y: number; onClose: () => void; recentProjects: string[];
+}) {
+  const [showRecent, setShowRecent] = useState(false);
+  return (
+    <>
+      <div className="fixed inset-0 z-[90]" onClick={onClose} onContextMenu={(e) => { e.preventDefault(); onClose(); }} />
+      <div className="fixed z-[95] bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[200px]"
+        style={{ left: x, top: y }}>
+        <div className="relative" onMouseEnter={() => setShowRecent(true)} onMouseLeave={() => setShowRecent(false)}>
+          <ContextMenuItem label="Recent Project Groups" hasSubmenu />
+          {showRecent && recentProjects.length > 0 && (
+            <div className="absolute left-full top-0 bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[250px]">
+              {recentProjects.map((p, i) => (
+                <ContextMenuItem key={i} label={`${i + 1}  ${p}`} onClick={onClose} />
+              ))}
+            </div>
+          )}
+        </div>
+        <ContextMenuSep />
+        <ContextMenuItem label="Add New Project..." icon={<FilePlus size={12} />} onClick={onClose} />
+        <ContextMenuItem label="Add Existing Project..." icon={<FolderPlus size={12} />} onClick={onClose} />
+        <ContextMenuSep />
+        <ContextMenuItem label="Open Project Group..." icon={<FolderSearch size={12} />} onClick={onClose} />
+        <ContextMenuItem label="Save Project Group" icon={<Save size={12} />} onClick={onClose} />
+        <ContextMenuItem label="Rename..." onClick={onClose} />
+        <ContextMenuItem label="Save All" disabled />
+        <ContextMenuSep />
+        <ContextMenuItem label="Explore" onClick={onClose} />
+        <ContextMenuItem label="Refresh" icon={<RefreshCw size={12} />} onClick={onClose} />
+      </div>
+    </>
+  );
+}
+
+function ProjectContextMenu({ x, y, onClose, onExplore, projectName }: {
+  x: number; y: number; onClose: () => void; onExplore: () => void; projectName: string;
+}) {
+  const [showAddNew, setShowAddNew] = useState(false);
+  return (
+    <>
+      <div className="fixed inset-0 z-[90]" onClick={onClose} onContextMenu={(e) => { e.preventDefault(); onClose(); }} />
+      <div className="fixed z-[95] bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[220px]"
+        style={{ left: x, top: y }}>
+        <ContextMenuItem label={`Validate PCB Project ${projectName}`} onClick={onClose} disabled />
+        <ContextMenuSep />
+        <div className="relative" onMouseEnter={() => setShowAddNew(true)} onMouseLeave={() => setShowAddNew(false)}>
+          <ContextMenuItem label="Add New to Project" hasSubmenu />
+          {showAddNew && (
+            <div className="absolute left-full top-0 bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[180px]">
+              <ContextMenuItem label="Schematic" icon={<FileText size={12} />} onClick={onClose} />
+              <ContextMenuItem label="PCB" icon={<Cpu size={12} />} onClick={onClose} />
+              <ContextMenuSep />
+              <ContextMenuItem label="Schematic Library" icon={<FileText size={12} className="text-accent" />} onClick={onClose} />
+              <ContextMenuItem label="PCB Library" icon={<Cpu size={12} className="text-success" />} onClick={onClose} />
+              <ContextMenuSep />
+              <ContextMenuItem label="Output Job File" onClick={onClose} />
+            </div>
+          )}
+        </div>
+        <ContextMenuItem label="Add Existing to Project..." onClick={onClose} />
+        <ContextMenuSep />
+        <ContextMenuItem label="Save" icon={<Save size={12} />} onClick={onClose} />
+        <ContextMenuItem label="Rename..." onClick={onClose} />
+        <ContextMenuSep />
+        <ContextMenuItem label="Close Project Documents" onClick={onClose} />
+        <ContextMenuItem label="Close Project" onClick={onClose} />
+        <ContextMenuSep />
+        <ContextMenuItem label="Explore" onClick={onExplore} />
+        <ContextMenuItem label="Variants..." onClick={onClose} />
+        <ContextMenuSep />
+        <ContextMenuItem label="Project Options..." onClick={onClose} />
+      </div>
+    </>
   );
 }

--- a/src/panels/ProjectPanel.tsx
+++ b/src/panels/ProjectPanel.tsx
@@ -333,31 +333,40 @@ function PanelContextMenu({ x, y, onClose, recentProjects }: {
 function ProjectContextMenu({ x, y, onClose, onExplore, projectName }: {
   x: number; y: number; onClose: () => void; onExplore: () => void; projectName: string;
 }) {
-  const [showAddNew, setShowAddNew] = useState(false);
+  const [sub, setSub] = useState<string | null>(null);
   return (
     <>
       <div className="fixed inset-0 z-[90]" onClick={onClose} onContextMenu={(e) => { e.preventDefault(); onClose(); }} />
-      <div className="fixed z-[95] bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[220px]"
-        style={{ left: x, top: y }}>
-        <ContextMenuItem label={`Validate PCB Project ${projectName}`} onClick={onClose} disabled />
+      <div className="fixed z-[95] bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[260px]"
+        style={{ left: Math.min(x, window.innerWidth - 280), top: Math.min(y, window.innerHeight - 500) }}>
+        <ContextMenuItem label={`Validate PCB Project ${projectName}`} disabled />
         <ContextMenuSep />
-        <div className="relative" onMouseEnter={() => setShowAddNew(true)} onMouseLeave={() => setShowAddNew(false)}>
+
+        {/* Add New to Project — submenu */}
+        <div className="relative" onMouseEnter={() => setSub("addNew")} onMouseLeave={() => setSub(null)}>
           <ContextMenuItem label="Add New to Project" hasSubmenu />
-          {showAddNew && (
-            <div className="absolute left-full top-0 bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[180px]">
-              <ContextMenuItem label="Schematic" icon={<FileText size={12} />} onClick={onClose} />
-              <ContextMenuItem label="PCB" icon={<Cpu size={12} />} onClick={onClose} />
+          {sub === "addNew" && (
+            <div className="absolute left-full top-0 bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[180px] z-[100]">
+              <ContextMenuItem label="Schematic" icon={<FileText size={12} className="text-warning/70" />} onClick={onClose} />
+              <ContextMenuItem label="PCB" icon={<Cpu size={12} className="text-success/70" />} onClick={onClose} />
+              <ContextMenuItem label="PCB3D" icon={<Cpu size={12} className="text-accent/70" />} onClick={onClose} disabled />
+              <ContextMenuItem label="Draftsman Document" disabled />
               <ContextMenuSep />
               <ContextMenuItem label="Schematic Library" icon={<FileText size={12} className="text-accent" />} onClick={onClose} />
               <ContextMenuItem label="PCB Library" icon={<Cpu size={12} className="text-success" />} onClick={onClose} />
+              <ContextMenuItem label="Pad Via Library" disabled />
               <ContextMenuSep />
+              <ContextMenuItem label="CAM Document" disabled />
               <ContextMenuItem label="Output Job File" onClick={onClose} />
+              <ContextMenuItem label="Database Link File" disabled />
             </div>
           )}
         </div>
+
         <ContextMenuItem label="Add Existing to Project..." onClick={onClose} />
-        <ContextMenuSep />
+        <ContextMenuItem label="Save to Server..." disabled />
         <ContextMenuItem label="Save" icon={<Save size={12} />} onClick={onClose} />
+        <ContextMenuItem label="Make a copy..." disabled />
         <ContextMenuItem label="Rename..." onClick={onClose} />
         <ContextMenuSep />
         <ContextMenuItem label="Close Project Documents" onClick={onClose} />
@@ -366,6 +375,26 @@ function ProjectContextMenu({ x, y, onClose, onExplore, projectName }: {
         <ContextMenuItem label="Explore" onClick={onExplore} />
         <ContextMenuItem label="Variants..." onClick={onClose} />
         <ContextMenuSep />
+
+        {/* History & Version Control — submenu */}
+        <div className="relative" onMouseEnter={() => setSub("history")} onMouseLeave={() => setSub(null)}>
+          <ContextMenuItem label="History && Version Control" hasSubmenu />
+          {sub === "history" && (
+            <div className="absolute left-full top-0 bg-bg-secondary border border-border-subtle rounded shadow-xl py-1 min-w-[160px] z-[100]">
+              <ContextMenuItem label="Show History" disabled />
+              <ContextMenuItem label="Compare..." disabled />
+            </div>
+          )}
+        </div>
+
+        <ContextMenuSep />
+        <ContextMenuItem label="Project Packager..." disabled />
+        <ContextMenuItem label="Project Releaser..." disabled />
+        <ContextMenuSep />
+        <ContextMenuItem label="Show in Explorer" onClick={onExplore} />
+        <ContextMenuItem label="Show in Web Browser" disabled />
+        <ContextMenuSep />
+        <ContextMenuItem label="Share..." disabled />
         <ContextMenuItem label="Project Options..." onClick={onClose} />
       </div>
     </>

--- a/src/panels/ProjectPanel.tsx
+++ b/src/panels/ProjectPanel.tsx
@@ -177,14 +177,17 @@ export function ProjectPanel() {
       {
         label: `${sheet.symbols_count} components`,
         icon: <Component size={11} className="text-text-muted/50" />,
+        onContextMenu: handleProjectContextMenu,
       },
       {
         label: `${sheet.wires_count} wires`,
         icon: <Cable size={11} className="text-text-muted/50" />,
+        onContextMenu: handleProjectContextMenu,
       },
       {
         label: `${sheet.labels_count} labels`,
         icon: <Tag size={11} className="text-text-muted/50" />,
+        onContextMenu: handleProjectContextMenu,
       },
     ],
   }));
@@ -197,6 +200,7 @@ export function ProjectPanel() {
           {
             label: project.pcb_file,
             icon: <Cpu size={12} className="text-success/70" />,
+            onContextMenu: handleProjectContextMenu,
             onClick: () => {
               const tabId = `pcb-${project.path}:${project.pcb_file}`;
               openTab({
@@ -225,6 +229,7 @@ export function ProjectPanel() {
         expandedIcon: <FolderOpen size={12} className="text-text-muted/60" />,
         isFolder: true,
         defaultExpanded: false,
+        onContextMenu: handleProjectContextMenu,
         children: [],
       },
       {
@@ -241,6 +246,7 @@ export function ProjectPanel() {
         expandedIcon: <FolderOpen size={12} className="text-text-muted/60" />,
         isFolder: true,
         defaultExpanded: false,
+        onContextMenu: handleProjectContextMenu,
         children: [],
       },
       {
@@ -249,6 +255,7 @@ export function ProjectPanel() {
         expandedIcon: <FolderOpen size={12} className="text-purple-400/70" />,
         isFolder: true,
         defaultExpanded: false,
+        onContextMenu: handleProjectContextMenu,
         children: [],
       },
       {
@@ -257,6 +264,7 @@ export function ProjectPanel() {
         expandedIcon: <FolderOpen size={12} className="text-text-muted/60" />,
         isFolder: true,
         defaultExpanded: false,
+        onContextMenu: handleProjectContextMenu,
         children: [],
       },
     ],

--- a/src/panels/PropertiesPanel.tsx
+++ b/src/panels/PropertiesPanel.tsx
@@ -1,17 +1,32 @@
 import { useState, useEffect, useMemo } from "react";
 import { useSchematicStore } from "@/stores/schematic";
 import { useEditorStore } from "@/stores/editor";
+import { useLibraryEditorStore } from "@/stores/libraryEditor";
+import { useFootprintEditorStore } from "@/stores/footprintEditor";
 import { MousePointer2, Eye, EyeOff, ChevronDown, ChevronRight, Lock, X, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { mmToDisplay, displayToMm } from "@/lib/units";
 import { useProjectStore } from "@/stores/project";
 import { BUILT_IN_TEMPLATES } from "@/lib/sheetTemplate";
+import { LibraryEditorProperties } from "@/components/LibraryEditorProperties";
+import { FootprintEditorProperties as FpEditorProps } from "@/components/FootprintEditorProperties";
 
 // ═══════════════════════════════════════════════════════════════════
 // MAIN PANEL ROUTER
 // ═══════════════════════════════════════════════════════════════════
 
 export function PropertiesPanel() {
+  const libEditorActive = useLibraryEditorStore((s) => s.active);
+  const fpEditorActive = useFootprintEditorStore((s) => s.active);
+
+  // Context-aware: show library/footprint properties when those editors are active
+  if (libEditorActive) return <LibraryEditorProperties />;
+  if (fpEditorActive) return <FpEditorProps />;
+
+  return <SchematicPropertiesPanel />;
+}
+
+function SchematicPropertiesPanel() {
   const data = useSchematicStore((s) => s.data);
   const selectedIds = useSchematicStore((s) => s.selectedIds);
   const editMode = useSchematicStore((s) => s.editMode);

--- a/src/panels/SchLibraryPanel.tsx
+++ b/src/panels/SchLibraryPanel.tsx
@@ -53,11 +53,8 @@ export function SchLibraryPanel() {
           // Create a new empty symbol
           const emptySymbol: LibSymbol = {
             id: "NewComponent",
-            graphics: [{ type: "Rectangle", start: { x: -2.54, y: -5.08 }, end: { x: 2.54, y: 5.08 }, width: 0.254, fill_type: "none" }],
-            pins: [
-              { pin_type: "passive", shape: "line", position: { x: -5.08, y: 2.54 }, rotation: 0, length: 2.54, name: "1", number: "1", name_visible: true, number_visible: true },
-              { pin_type: "passive", shape: "line", position: { x: -5.08, y: -2.54 }, rotation: 0, length: 2.54, name: "2", number: "2", name_visible: true, number_visible: true },
-            ],
+            graphics: [],
+            pins: [],
             show_pin_numbers: true,
             show_pin_names: true,
             pin_name_offset: 1.016,

--- a/src/panels/SchLibraryPanel.tsx
+++ b/src/panels/SchLibraryPanel.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import { useLibraryEditorStore } from "@/stores/libraryEditor";
+import { ChevronDown, ChevronRight, Component, Play, Plus, Trash2, Pencil } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { LibSymbol } from "@/types";
+
+/**
+ * SCH Library Panel — Altium-style library symbol browser.
+ * Shows all symbols in the current library file with multi-part expansion.
+ * Provides Place, Add, Delete, Edit actions.
+ */
+export function SchLibraryPanel() {
+  const symbol = useLibraryEditorStore(s => s.symbol);
+  const active = useLibraryEditorStore(s => s.active);
+
+  if (!active || !symbol) {
+    return (
+      <div className="flex flex-col h-full">
+        <div className="px-3 py-2 border-b border-border-subtle bg-bg-secondary/80 text-[10px] font-semibold text-text-secondary">
+          SCH Library
+        </div>
+        <div className="flex-1 flex items-center justify-center p-4">
+          <span className="text-[10px] text-text-muted/40">No library open</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full text-xs select-none">
+      {/* Header */}
+      <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border-subtle bg-bg-secondary/80 shrink-0">
+        <span className="text-[10px] font-semibold text-accent uppercase tracking-wider">SCH Library</span>
+      </div>
+
+      {/* Column headers */}
+      <div className="flex items-center px-2 py-0.5 border-b border-border-subtle bg-bg-secondary/40 text-[9px] font-semibold text-text-muted/50">
+        <span className="flex-1">Design Item ID</span>
+        <span className="w-[100px] text-right">Description</span>
+      </div>
+
+      {/* Symbol list */}
+      <div className="flex-1 overflow-y-auto">
+        <SymbolTreeItem symbol={symbol} isActive={true} />
+      </div>
+
+      {/* Action bar */}
+      <div className="flex items-center gap-1 px-2 py-1.5 border-t border-border-subtle bg-bg-secondary/80 shrink-0">
+        <ActionButton icon={<Play size={12} />} label="Place" onClick={() => {}} />
+        <ActionButton icon={<Plus size={12} />} label="Add" onClick={() => {
+          const store = useLibraryEditorStore.getState();
+          if (!store.symbol) return;
+          // Create a new empty symbol
+          const emptySymbol: LibSymbol = {
+            id: "NewComponent",
+            graphics: [{ type: "Rectangle", start: { x: -2.54, y: -5.08 }, end: { x: 2.54, y: 5.08 }, width: 0.254, fill_type: "none" }],
+            pins: [
+              { pin_type: "passive", shape: "line", position: { x: -5.08, y: 2.54 }, rotation: 0, length: 2.54, name: "1", number: "1", name_visible: true, number_visible: true },
+              { pin_type: "passive", shape: "line", position: { x: -5.08, y: -2.54 }, rotation: 0, length: 2.54, name: "2", number: "2", name_visible: true, number_visible: true },
+            ],
+            show_pin_numbers: true,
+            show_pin_names: true,
+            pin_name_offset: 1.016,
+          };
+          store.openSymbol(emptySymbol, store.sourcePath || "user_library.snxsym", "NewComponent");
+        }} />
+        <ActionButton icon={<Trash2 size={12} />} label="Delete" onClick={() => {}} />
+        <ActionButton icon={<Pencil size={12} />} label="Edit" onClick={() => {}} />
+      </div>
+    </div>
+  );
+}
+
+function SymbolTreeItem({ symbol, isActive }: {
+  symbol: LibSymbol;
+  isActive: boolean;
+}) {
+  const [expanded, setExpanded] = useState(true);
+  const unitCount = symbol.unit_count ?? 1;
+  const hasParts = unitCount > 1;
+
+  return (
+    <div>
+      <div
+        className={cn(
+          "flex items-center gap-1.5 px-2 py-[3px] cursor-pointer transition-colors",
+          isActive ? "bg-accent/15 text-accent" : "text-text-secondary hover:bg-bg-hover/50"
+        )}
+        onClick={() => hasParts && setExpanded(!expanded)}
+      >
+        {hasParts ? (
+          expanded ? <ChevronDown size={10} /> : <ChevronRight size={10} />
+        ) : (
+          <span className="w-[10px]" />
+        )}
+        <Component size={11} className="shrink-0 text-warning/70" />
+        <span className="flex-1 text-[11px] truncate font-medium">{symbol.id}</span>
+      </div>
+
+      {hasParts && expanded && (
+        <div>
+          {Array.from({ length: unitCount }, (_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-1.5 pl-8 pr-2 py-[2px] text-[10px] text-text-muted hover:bg-bg-hover/50 cursor-pointer"
+            >
+              <span className="w-[10px]" />
+              <span>Part {String.fromCharCode(65 + i)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ActionButton({ icon, label, onClick }: { icon: React.ReactNode; label: string; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex items-center gap-1 px-2 py-1 text-[10px] text-text-secondary hover:text-text-primary hover:bg-bg-hover rounded transition-colors"
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/src/stores/footprintEditor.ts
+++ b/src/stores/footprintEditor.ts
@@ -129,9 +129,7 @@ export const useFootprintEditorStore = create<FootprintEditorState>()((set, get)
     const { footprint } = get();
     if (!footprint) return;
     get().pushUndo();
-    const fp = clone(footprint);
-    fp.pads.push(pad);
-    set({ footprint: fp, dirty: true });
+    set({ footprint: { ...clone(footprint), pads: [...footprint.pads, pad] }, dirty: true });
   },
 
   updatePad: (index, updates) => {
@@ -147,18 +145,14 @@ export const useFootprintEditorStore = create<FootprintEditorState>()((set, get)
     const { footprint } = get();
     if (!footprint || index < 0 || index >= footprint.pads.length) return;
     get().pushUndo();
-    const fp = clone(footprint);
-    fp.pads.splice(index, 1);
-    set({ footprint: fp, dirty: true, selectedItem: null });
+    set({ footprint: { ...clone(footprint), pads: footprint.pads.filter((_, i) => i !== index) }, dirty: true, selectedItem: null });
   },
 
   addGraphic: (graphic) => {
     const { footprint } = get();
     if (!footprint) return;
     get().pushUndo();
-    const fp = clone(footprint);
-    fp.graphics.push(graphic);
-    set({ footprint: fp, dirty: true });
+    set({ footprint: { ...clone(footprint), graphics: [...footprint.graphics, graphic] }, dirty: true });
   },
 
   updateGraphic: (index, graphic) => {
@@ -174,9 +168,7 @@ export const useFootprintEditorStore = create<FootprintEditorState>()((set, get)
     const { footprint } = get();
     if (!footprint || index < 0 || index >= footprint.graphics.length) return;
     get().pushUndo();
-    const fp = clone(footprint);
-    fp.graphics.splice(index, 1);
-    set({ footprint: fp, dirty: true, selectedItem: null });
+    set({ footprint: { ...clone(footprint), graphics: footprint.graphics.filter((_, i) => i !== index) }, dirty: true, selectedItem: null });
   },
 
   updateFootprintId: (id) => {

--- a/src/stores/footprintEditor.ts
+++ b/src/stores/footprintEditor.ts
@@ -1,0 +1,190 @@
+import { create } from "zustand";
+import type { PcbPad, PcbGraphic, PcbLayerId } from "@/types/pcb";
+
+export type FpEditMode = "select" | "addPadSmd" | "addPadTh" | "addLine" | "addRect" | "addCircle" | "addArc" | "addPoly" | "addText";
+
+export type FpSelectedItem =
+  | { type: "pad"; index: number }
+  | { type: "graphic"; index: number }
+  | null;
+
+export interface FootprintData {
+  id: string;
+  pads: PcbPad[];
+  graphics: PcbGraphic[];
+  courtyard: { x: number; y: number }[];
+  model3d: string;
+}
+
+interface FootprintEditorState {
+  active: boolean;
+  footprint: FootprintData | null;
+  selectedItem: FpSelectedItem;
+  editMode: FpEditMode;
+  activeLayer: PcbLayerId;
+  dirty: boolean;
+  undoStack: FootprintData[];
+  redoStack: FootprintData[];
+  sourcePath: string | null;
+  sourceId: string | null;
+
+  openFootprint: (fp: FootprintData, sourcePath: string, id: string) => void;
+  closeEditor: () => void;
+  setEditMode: (mode: FpEditMode) => void;
+  setSelectedItem: (item: FpSelectedItem) => void;
+  setActiveLayer: (layer: PcbLayerId) => void;
+
+  pushUndo: () => void;
+  undo: () => void;
+  redo: () => void;
+
+  addPad: (pad: PcbPad) => void;
+  updatePad: (index: number, updates: Partial<PcbPad>) => void;
+  removePad: (index: number) => void;
+
+  addGraphic: (graphic: PcbGraphic) => void;
+  updateGraphic: (index: number, graphic: PcbGraphic) => void;
+  removeGraphic: (index: number) => void;
+
+  updateFootprintId: (id: string) => void;
+}
+
+function clone(fp: FootprintData): FootprintData {
+  return structuredClone(fp);
+}
+
+export const useFootprintEditorStore = create<FootprintEditorState>()((set, get) => ({
+  active: false,
+  footprint: null,
+  selectedItem: null,
+  editMode: "select",
+  activeLayer: "F.Cu" as PcbLayerId,
+  dirty: false,
+  undoStack: [],
+  redoStack: [],
+  sourcePath: null,
+  sourceId: null,
+
+  openFootprint: (fp, sourcePath, id) => set({
+    active: true,
+    footprint: clone(fp),
+    selectedItem: null,
+    editMode: "select",
+    dirty: false,
+    undoStack: [],
+    redoStack: [],
+    sourcePath,
+    sourceId: id,
+  }),
+
+  closeEditor: () => set({
+    active: false,
+    footprint: null,
+    selectedItem: null,
+    editMode: "select",
+    dirty: false,
+    undoStack: [],
+    redoStack: [],
+    sourcePath: null,
+    sourceId: null,
+  }),
+
+  setEditMode: (mode) => set({ editMode: mode, selectedItem: null }),
+  setSelectedItem: (item) => set({ selectedItem: item }),
+  setActiveLayer: (layer) => set({ activeLayer: layer }),
+
+  pushUndo: () => {
+    const { footprint, undoStack } = get();
+    if (!footprint) return;
+    const stack = [...undoStack, clone(footprint)];
+    if (stack.length > 50) stack.shift();
+    set({ undoStack: stack, redoStack: [] });
+  },
+
+  undo: () => {
+    const { footprint, undoStack, redoStack } = get();
+    if (undoStack.length === 0 || !footprint) return;
+    set({
+      footprint: undoStack[undoStack.length - 1],
+      undoStack: undoStack.slice(0, -1),
+      redoStack: [...redoStack, clone(footprint)],
+      selectedItem: null,
+      dirty: true,
+    });
+  },
+
+  redo: () => {
+    const { footprint, undoStack, redoStack } = get();
+    if (redoStack.length === 0 || !footprint) return;
+    set({
+      footprint: redoStack[redoStack.length - 1],
+      redoStack: redoStack.slice(0, -1),
+      undoStack: [...undoStack, clone(footprint!)],
+      selectedItem: null,
+      dirty: true,
+    });
+  },
+
+  addPad: (pad) => {
+    const { footprint } = get();
+    if (!footprint) return;
+    get().pushUndo();
+    const fp = clone(footprint);
+    fp.pads.push(pad);
+    set({ footprint: fp, dirty: true });
+  },
+
+  updatePad: (index, updates) => {
+    const { footprint } = get();
+    if (!footprint || index < 0 || index >= footprint.pads.length) return;
+    get().pushUndo();
+    const fp = clone(footprint);
+    fp.pads[index] = { ...fp.pads[index], ...updates };
+    set({ footprint: fp, dirty: true });
+  },
+
+  removePad: (index) => {
+    const { footprint } = get();
+    if (!footprint || index < 0 || index >= footprint.pads.length) return;
+    get().pushUndo();
+    const fp = clone(footprint);
+    fp.pads.splice(index, 1);
+    set({ footprint: fp, dirty: true, selectedItem: null });
+  },
+
+  addGraphic: (graphic) => {
+    const { footprint } = get();
+    if (!footprint) return;
+    get().pushUndo();
+    const fp = clone(footprint);
+    fp.graphics.push(graphic);
+    set({ footprint: fp, dirty: true });
+  },
+
+  updateGraphic: (index, graphic) => {
+    const { footprint } = get();
+    if (!footprint || index < 0 || index >= footprint.graphics.length) return;
+    get().pushUndo();
+    const fp = clone(footprint);
+    fp.graphics[index] = graphic;
+    set({ footprint: fp, dirty: true });
+  },
+
+  removeGraphic: (index) => {
+    const { footprint } = get();
+    if (!footprint || index < 0 || index >= footprint.graphics.length) return;
+    get().pushUndo();
+    const fp = clone(footprint);
+    fp.graphics.splice(index, 1);
+    set({ footprint: fp, dirty: true, selectedItem: null });
+  },
+
+  updateFootprintId: (id) => {
+    const { footprint } = get();
+    if (!footprint) return;
+    get().pushUndo();
+    const fp = clone(footprint);
+    fp.id = id;
+    set({ footprint: fp, dirty: true, sourceId: id });
+  },
+}));

--- a/src/stores/libraryEditor.ts
+++ b/src/stores/libraryEditor.ts
@@ -23,6 +23,14 @@ interface LibraryEditorState {
   sourcePath: string | null;
   sourceLibId: string | null;
 
+  // Component metadata (persisted alongside symbol)
+  designatorPrefix: string;
+  comment: string;
+  description: string;
+  footprint: string;
+  componentType: "standard" | "standard_no_bom" | "mechanical" | "graphical";
+  mirrored: boolean;
+
   // Lifecycle
   openSymbol: (symbol: LibSymbol, sourcePath: string, libId: string) => void;
   closeEditor: () => void;
@@ -50,6 +58,14 @@ interface LibraryEditorState {
   updateSymbolId: (id: string) => void;
   toggleDisplayMode: () => void;
 
+  // Component metadata setters
+  setDesignatorPrefix: (v: string) => void;
+  setComment: (v: string) => void;
+  setDescription: (v: string) => void;
+  setFootprint: (v: string) => void;
+  setComponentType: (v: LibraryEditorState["componentType"]) => void;
+  setMirrored: (v: boolean) => void;
+
   // Panel view
   panelView: LibPanelView;
   setPanelView: (view: LibPanelView) => void;
@@ -70,6 +86,12 @@ export const useLibraryEditorStore = create<LibraryEditorState>()((set, get) => 
   redoStack: [],
   sourcePath: null,
   sourceLibId: null,
+  designatorPrefix: "U",
+  comment: "*",
+  description: "",
+  footprint: "",
+  componentType: "standard_no_bom" as LibraryEditorState["componentType"],
+  mirrored: false,
   panelView: "properties" as LibPanelView,
 
   openSymbol: (symbol, sourcePath, libId) => {
@@ -221,6 +243,13 @@ export const useLibraryEditorStore = create<LibraryEditorState>()((set, get) => 
   toggleDisplayMode: () => {
     set((s) => ({ displayMode: s.displayMode === "normal" ? "alternate" : "normal" }));
   },
+
+  setDesignatorPrefix: (v) => set({ designatorPrefix: v, dirty: true }),
+  setComment: (v) => set({ comment: v, dirty: true }),
+  setDescription: (v) => set({ description: v, dirty: true }),
+  setFootprint: (v) => set({ footprint: v, dirty: true }),
+  setComponentType: (v) => set({ componentType: v, dirty: true }),
+  setMirrored: (v) => set({ mirrored: v, dirty: true }),
 
   setPanelView: (view) => set({ panelView: view }),
 }));

--- a/src/stores/outputJobs.ts
+++ b/src/stores/outputJobs.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-export type OutputJobType = "bom" | "netlist" | "pdf" | "png";
+export type OutputJobType = "bom" | "netlist" | "pdf" | "png" | "gerber" | "odb" | "step" | "pick_place" | "ipc2581" | "assembly_svg";
 
 export interface OutputJobConfig {
   // BOM
@@ -14,6 +14,8 @@ export interface OutputJobConfig {
   pdfDpi?: 150 | 300;
   pdfColorMode?: "color" | "monochrome";
   pdfShowGrid?: boolean;
+  // Assembly
+  assemblySide?: "top" | "bottom";
 }
 
 export interface OutputJob {
@@ -38,6 +40,12 @@ const defaultConfig: Record<OutputJobType, OutputJobConfig> = {
   netlist: { netlistFormat: "kicad" },
   pdf: { pdfDpi: 300, pdfColorMode: "color", pdfShowGrid: false },
   png: {},
+  gerber: {},
+  odb: {},
+  step: {},
+  pick_place: {},
+  ipc2581: {},
+  assembly_svg: { assemblySide: "top" },
 };
 
 const typeLabels: Record<OutputJobType, string> = {
@@ -45,6 +53,12 @@ const typeLabels: Record<OutputJobType, string> = {
   netlist: "Netlist",
   pdf: "PDF Export",
   png: "PNG Export",
+  gerber: "Gerber (RS-274X)",
+  odb: "ODB++",
+  step: "STEP 3D",
+  pick_place: "Pick & Place",
+  ipc2581: "IPC-2581",
+  assembly_svg: "Assembly Drawing",
 };
 
 export function getJobTypeLabel(type: OutputJobType): string {

--- a/src/stores/pcb.ts
+++ b/src/stores/pcb.ts
@@ -4,6 +4,9 @@ import type { PcbData, PcbPoint, PcbLayerId } from "@/types/pcb";
 export type PcbEditMode =
   | "select"
   | "routeTrack"
+  | "routeDiffPair"
+  | "routeMultiTrack"
+  | "lengthTune"
   | "placeVia"
   | "placeFootprint"
   | "drawBoardOutline"

--- a/src/stores/pcb.ts
+++ b/src/stores/pcb.ts
@@ -37,6 +37,7 @@ interface PcbState {
   routingWidth: number;
   routingNet: number;
   routeCornerMode: "45" | "90" | "arc45" | "arc90" | "any";
+  routeMode: "ignore" | "walkaround" | "push" | "hug_push";
 
   // Actions
   loadPcb: (data: PcbData) => void;
@@ -119,6 +120,7 @@ export const usePcbStore = create<PcbState>()((set, get) => ({
   routingWidth: 0.25,
   routingNet: 0,
   routeCornerMode: "45",
+  routeMode: "walkaround",
 
   loadPcb: (data) => set({
     data,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,8 @@ export type PanelId =
   | "libraryMgmt"
   | "schLibrary"
   | "pcbLibrary"
+  | "netClasses"
+  | "netInspector"
   | "properties"
   | "filter"
   | "list"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export type PanelId =
   | "components"
   | "navigator"
   | "libraryMgmt"
+  | "schLibrary"
   | "properties"
   | "filter"
   | "list"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export type PanelId =
   | "navigator"
   | "libraryMgmt"
   | "schLibrary"
+  | "pcbLibrary"
   | "properties"
   | "filter"
   | "list"


### PR DESCRIPTION
## Summary
Complete new footprint/package editor for Signex, using `.snxpkg` native extension.

### New files (1020 lines)
- **`src/canvas/FootprintEditorCanvas.tsx`** — Canvas2D editor with PCB-accurate 0.1mm grid, origin cross, multi-layer rendering, pad/graphic hit testing, zoom/pan
- **`src/stores/footprintEditor.ts`** — Zustand store: pad CRUD, graphic CRUD, undo/redo (50 levels), active layer, footprint metadata
- **`src/components/FootprintEditorToolbar.tsx`** — Tools: select, SMD pad, TH pad, line, rect, circle, arc, text + active layer dropdown
- **`src/components/FootprintEditorProperties.tsx`** — Pad properties (type/shape/size/position/drill/roundrect ratio/layers), graphic properties, footprint metadata, pad table view

### Features
- **SMD Pad placement**: 1.0x1.2mm roundrect default, auto-increment pad numbers, layers [F.Cu, F.Paste, F.Mask]
- **Through-Hole Pad placement**: 1.7mm circle with 1.0mm drill, auto-increment, layers [*.Cu, *.Mask]
- **Graphics**: Line, rectangle, circle, arc, text on any layer (F.SilkS, F.Fab, F.CrtYd, F.Cu, B.Cu, etc.)
- **Layer selector**: dropdown in toolbar, graphics placed on active layer with correct colors
- **Pad Properties panel**: edit number, type (smd/thru_hole/np_thru_hole), shape (rect/roundrect/circle/oval), size, position, drill diameter, roundrect corner ratio, layer display
- **Pad Table**: spreadsheet view of all pads with inline type/shape editing
- **Undo/Redo**: 50 levels with structuredClone
- **New Footprint button**: in Components panel, creates empty footprint with F.Fab + F.CrtYd outlines

### Integration
- Footprint editor replaces main canvas when active (same pattern as Library Editor)
- Toolbar + Canvas + Properties panel layout
- Close button returns to schematic/PCB view

## Test plan
- [ ] Click New Footprint (CPU icon) in Components panel — footprint editor opens
- [ ] Click SMD Pad tool, click canvas — pad placed with auto-numbering
- [ ] Click TH Pad tool, click canvas — through-hole pad with drill hole renders
- [ ] Select pad — Properties panel shows type/shape/size/drill fields, all editable
- [ ] Change active layer to F.SilkS, draw line — line renders in yellow
- [ ] Undo/Redo works for all operations
- [ ] Pad Table tab shows all pads in spreadsheet view
- [ ] Close button exits footprint editor, returns to previous view