### PR TITLE
fix(ci): drop aarch64-linux from release matrix so v0.6.0 can ship

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,10 @@ jobs:
             artifact: signex
             archive: signex-linux-x86_64.tar.gz
 
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            artifact: signex
-            archive: signex-linux-aarch64.tar.gz
-            cross: true
+          # aarch64-unknown-linux-gnu deferred — cross-compiling iced +
+          # wgpu with their native C/C++ deps on ubuntu-latest needs
+          # dedicated arm64 runners or the `cross` action with a custom
+          # image. Revisit in a patch release; drop here so v0.6 can ship.
 
           - target: aarch64-apple-darwin
             os: macos-latest
@@ -64,31 +63,12 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Install Linux dependencies
-        if: runner.os == 'Linux' && !matrix.cross
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             libxkbcommon-dev libwayland-dev libvulkan-dev \
             libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
-
-      - name: Install Linux cross-compilation dependencies (aarch64)
-        if: matrix.cross
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
-            libxkbcommon-dev:arm64 libwayland-dev:arm64 \
-            libx11-dev:arm64 libxrandr-dev:arm64 libxcursor-dev:arm64 libxi-dev:arm64
-          sudo dpkg --add-architecture arm64
-          sudo apt-get update
-        continue-on-error: true
-
-      - name: Set cross-compilation env
-        if: matrix.cross
-        run: |
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-          echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-          echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> "$GITHUB_ENV"
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} -p signex-app
@@ -149,7 +129,6 @@ jobs:
             artifacts/signex-windows-x86_64.zip
             artifacts/signex-windows-aarch64.zip
             artifacts/signex-linux-x86_64.tar.gz
-            artifacts/signex-linux-aarch64.tar.gz
             artifacts/signex-macos-aarch64.tar.gz
             artifacts/signex-macos-x86_64.tar.gz
             artifacts/SHA256SUMS.txt


### PR DESCRIPTION
## Problem
v0.6.0 tag push triggered release.yml; every target built except
aarch64-unknown-linux-gnu, which failed because cross-compiling iced +
wgpu's native C/C++ deps on ubuntu-latest isn't configured correctly
(add-architecture ordering, missing arm64 sources, native GL libs).

The overall build job fails → release job's `needs: build` requirement
isn't met → no GitHub Release published.

## Fix
Drop aarch64-unknown-linux-gnu from the matrix for v0.6. The 5
remaining targets cover the real user base (Windows x64/arm64, Linux
x64, macOS Intel/Apple Silicon).

Revisit in a later patch release using `cross` with a custom image or
dedicated arm64 runners.

## After merge
I'll re-tag v0.6.0 on main to retrigger the release workflow.