### PR TITLE
fix(ci): drop x86_64-apple-darwin so v0.6.0 can ship

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,11 @@ jobs:
             artifact: signex
             archive: signex-macos-aarch64.tar.gz
 
-          - target: x86_64-apple-darwin
-            os: macos-13
-            artifact: signex
-            archive: signex-macos-x86_64.tar.gz
+          # x86_64-apple-darwin deferred — macos-13 runners are in the
+          # deprecated queue and take 30+ minutes to pick up a job. Apple
+          # Silicon Macs run the aarch64-apple-darwin binary natively;
+          # Intel Macs can run it under Rosetta 2. Revisit once GitHub
+          # stabilises macos-13 capacity or we move to self-hosted.
 
     steps:
       - uses: actions/checkout@v4
@@ -130,5 +131,4 @@ jobs:
             artifacts/signex-windows-aarch64.zip
             artifacts/signex-linux-x86_64.tar.gz
             artifacts/signex-macos-aarch64.tar.gz
-            artifacts/signex-macos-x86_64.tar.gz
             artifacts/SHA256SUMS.txt


### PR DESCRIPTION
macos-13 runners (Intel Mac) are on GitHub's deprecated queue with 30+ minute wait. Intel Macs run the aarch64 build natively via Rosetta 2, so dropping this target doesn't leave Intel users without a binary.

After merge I'll re-tag v0.6.0 — release then ships with 4 targets:
- Windows x64, Windows arm64
- Linux x64
- macOS Apple Silicon (covers Intel Macs via Rosetta)