### PR TITLE
Release v0.6.1 — schematic render + KiCad round-trip fixes

### DIFF
--- a/crates/kicad-parser/src/schematic.rs
+++ b/crates/kicad-parser/src/schematic.rs
@@ -70,7 +70,14 @@ fn parse_text_prop(prop_node: &SExpr, _fallback_pos: Point) -> TextProp {
         .and_then(|s| s.arg_f64(0))
         .unwrap_or(1.27);
 
-    let hidden = is_effects_hidden(effects);
+    // KiCad 8: (hide yes) may sit at the property level (direct child of the
+    // property node) instead of inside (effects ...).  Check both locations.
+    let hidden_in_effects = is_effects_hidden(effects);
+    let hidden_on_prop = prop_node
+        .find("hide")
+        .map(|h| h.first_arg().map(|v| v == "yes").unwrap_or(true))
+        .unwrap_or(false);
+    let hidden = hidden_in_effects || hidden_on_prop;
 
     // Parse justify: (justify left bottom), (justify right), (justify center), etc.
     let justify = effects.and_then(|e| e.find("justify"));

--- a/crates/kicad-writer/src/schematic.rs
+++ b/crates/kicad-writer/src/schematic.rs
@@ -370,13 +370,29 @@ fn write_symbol(out: &mut String, sym: &Symbol) {
     }
     wln!(out, "    (uuid \"{}\")", sym.uuid);
 
-    // Reference property
-    if let Some(ref ref_text) = sym.ref_text {
-        write_property(out, "Reference", &sym.reference, ref_text, sym.rotation);
+    // Reference property — always written; hidden when ref_text is None (power symbols).
+    match sym.ref_text.as_ref() {
+        Some(ref_text) => write_property(out, "Reference", &sym.reference, ref_text, sym.rotation),
+        None => {
+            wln!(out, "    (property \"Reference\" \"{}\"", escape(&sym.reference));
+            wln!(out, "      (at {} {} 0)", fmt_f64(sym.position.x), fmt_f64(sym.position.y));
+            wln!(out, "      (show_name no)");
+            wln!(out, "      (do_not_autoplace no)");
+            wln!(out, "      (effects (font (size 1.27 1.27)) (hide yes))");
+            wln!(out, "    )");
+        }
     }
-    // Value property
-    if let Some(ref val_text) = sym.val_text {
-        write_property(out, "Value", &sym.value, val_text, sym.rotation);
+    // Value property — always written; hidden when val_text is None.
+    match sym.val_text.as_ref() {
+        Some(val_text) => write_property(out, "Value", &sym.value, val_text, sym.rotation),
+        None => {
+            wln!(out, "    (property \"Value\" \"{}\"", escape(&sym.value));
+            wln!(out, "      (at {} {} 0)", fmt_f64(sym.position.x), fmt_f64(sym.position.y));
+            wln!(out, "      (show_name no)");
+            wln!(out, "      (do_not_autoplace no)");
+            wln!(out, "      (effects (font (size 1.27 1.27)))");
+            wln!(out, "    )");
+        }
     }
     // Footprint property (hidden)
     wln!(
@@ -511,14 +527,10 @@ fn write_sheet_instances(out: &mut String, instances: &[SheetInstance]) {
     wln!(out, "    )");
 }
 
-fn write_property(out: &mut String, key: &str, value: &str, text: &TextProp, sym_rot: f64) {
-    // Reconstruct stored rotation (reverse the toggle applied during parsing)
-    let sym_90_270 = (sym_rot - 90.0).abs() < 0.1 || (sym_rot - 270.0).abs() < 0.1;
-    let stored_rot = if sym_90_270 {
-        if text.rotation.abs() < 0.1 { 90.0 } else { 0.0 }
-    } else {
-        text.rotation
-    };
+fn write_property(out: &mut String, key: &str, value: &str, text: &TextProp, _sym_rot: f64) {
+    // prop.rotation is stored in world-frame (same as KiCad file storage).
+    // Write it back verbatim — the renderer composes sym+prop to get screen angle.
+    let stored_rot = text.rotation;
 
     wln!(out, "    (property \"{}\" \"{}\"", key, escape(value));
     wln!(

--- a/crates/kicad-writer/src/schematic.rs
+++ b/crates/kicad-writer/src/schematic.rs
@@ -378,7 +378,8 @@ fn write_symbol(out: &mut String, sym: &Symbol) {
             wln!(out, "      (at {} {} 0)", fmt_f64(sym.position.x), fmt_f64(sym.position.y));
             wln!(out, "      (show_name no)");
             wln!(out, "      (do_not_autoplace no)");
-            wln!(out, "      (effects (font (size 1.27 1.27)) (hide yes))");
+            wln!(out, "      (hide yes)");
+            wln!(out, "      (effects (font (size 1.27 1.27)))");
             wln!(out, "    )");
         }
     }
@@ -394,37 +395,21 @@ fn write_symbol(out: &mut String, sym: &Symbol) {
             wln!(out, "    )");
         }
     }
-    // Footprint property (hidden)
-    wln!(
-        out,
-        "    (property \"Footprint\" \"{}\"",
-        escape(&sym.footprint)
-    );
-    wln!(
-        out,
-        "      (at {} {} 0)",
-        fmt_f64(sym.position.x),
-        fmt_f64(sym.position.y)
-    );
+    // Footprint and Datasheet: always hidden at property level (KiCad 8 format).
+    wln!(out, "    (property \"Footprint\" \"{}\"", escape(&sym.footprint));
+    wln!(out, "      (at {} {} 0)", fmt_f64(sym.position.x), fmt_f64(sym.position.y));
     wln!(out, "      (show_name no)");
     wln!(out, "      (do_not_autoplace no)");
-    wln!(out, "      (effects (font (size 1.27 1.27)) (hide yes))");
+    wln!(out, "      (hide yes)");
+    wln!(out, "      (effects (font (size 1.27 1.27)))");
     wln!(out, "    )");
 
-    wln!(
-        out,
-        "    (property \"Datasheet\" \"{}\"",
-        escape(&sym.datasheet)
-    );
-    wln!(
-        out,
-        "      (at {} {} 0)",
-        fmt_f64(sym.position.x),
-        fmt_f64(sym.position.y)
-    );
+    wln!(out, "    (property \"Datasheet\" \"{}\"", escape(&sym.datasheet));
+    wln!(out, "      (at {} {} 0)", fmt_f64(sym.position.x), fmt_f64(sym.position.y));
     wln!(out, "      (show_name no)");
     wln!(out, "      (do_not_autoplace no)");
-    wln!(out, "      (effects (font (size 1.27 1.27)) (hide yes))");
+    wln!(out, "      (hide yes)");
+    wln!(out, "      (effects (font (size 1.27 1.27)))");
     wln!(out, "    )");
 
     // Custom fields — sort keys for deterministic output order
@@ -542,15 +527,17 @@ fn write_property(out: &mut String, key: &str, value: &str, text: &TextProp, _sy
     );
     wln!(out, "      (show_name no)");
     wln!(out, "      (do_not_autoplace no)");
+    // KiCad 8: (hide yes) is a direct child of the property node, NOT inside
+    // (effects ...).  Write it here so round-trips preserve visibility.
+    if text.hidden {
+        wln!(out, "      (hide yes)");
+    }
     w!(
         out,
         "      (effects (font (size {} {}))",
         fmt_f64(text.font_size),
         fmt_f64(text.font_size)
     );
-    if text.hidden {
-        w!(out, " (hide yes)");
-    }
     if text.justify_h != HAlign::Center || text.justify_v != VAlign::Center {
         w!(out, " (justify");
         if text.justify_h != HAlign::Center {

--- a/crates/signex-app/src/app/actions.rs
+++ b/crates/signex-app/src/app/actions.rs
@@ -134,7 +134,7 @@ impl Signex {
             ref_text: Some(signex_types::schematic::TextProp {
                 position: signex_types::schematic::Point::new(wx, wy - 2.54),
                 rotation,
-                font_size: 1.8,
+                font_size: signex_types::schematic::SCHEMATIC_TEXT_MM,
                 justify_h: signex_types::schematic::HAlign::Center,
                 justify_v: signex_types::schematic::VAlign::default(),
                 hidden: false,
@@ -142,7 +142,7 @@ impl Signex {
             val_text: Some(signex_types::schematic::TextProp {
                 position: signex_types::schematic::Point::new(wx, wy + 2.54),
                 rotation,
-                font_size: 1.8,
+                font_size: signex_types::schematic::SCHEMATIC_TEXT_MM,
                 justify_h: signex_types::schematic::HAlign::Center,
                 justify_v: signex_types::schematic::VAlign::default(),
                 hidden: false,

--- a/crates/signex-app/src/app/dispatch/tool.rs
+++ b/crates/signex-app/src/app/dispatch/tool.rs
@@ -50,7 +50,7 @@ impl Signex {
                     rotation: 0.0,
                     label_type,
                     shape,
-                    font_size: 1.8,
+                    font_size: signex_types::schematic::SCHEMATIC_TEXT_MM,
                     justify: sch::HAlign::Left,
                 };
                 self.apply_engine_command(
@@ -77,7 +77,7 @@ impl Signex {
                     },
                     position: sch::Point::new(wx, wy),
                     rotation: 0.0,
-                    font_size: 1.8,
+                    font_size: signex_types::schematic::SCHEMATIC_TEXT_MM,
                     justify_h: sch::HAlign::Left,
                     justify_v: sch::VAlign::default(),
                 };
@@ -380,7 +380,7 @@ impl Signex {
                             text: "Text".to_string(),
                             position: signex_types::schematic::Point::new(0.0, 0.0),
                             rotation: 0.0,
-                            font_size: 1.8,
+                            font_size: signex_types::schematic::SCHEMATIC_TEXT_MM,
                             justify_h: signex_types::schematic::HAlign::Left,
                             justify_v: signex_types::schematic::VAlign::default(),
                         });

--- a/crates/signex-app/src/app/handlers/active_bar/action_groups.rs
+++ b/crates/signex-app/src/app/handlers/active_bar/action_groups.rs
@@ -35,7 +35,7 @@ impl Signex {
                     rotation: 0.0,
                     label_type: signex_types::schematic::LabelType::Net,
                     shape: String::new(),
-                    font_size: 1.8,
+                    font_size: signex_types::schematic::SCHEMATIC_TEXT_MM,
                     justify: signex_types::schematic::HAlign::Left,
                 });
                 task
@@ -70,7 +70,7 @@ impl Signex {
                         text: default_text.to_string(),
                         position: signex_types::schematic::Point::new(0.0, 0.0),
                         rotation: 0.0,
-                        font_size: 1.8,
+                        font_size: signex_types::schematic::SCHEMATIC_TEXT_MM,
                         justify_h: signex_types::schematic::HAlign::Left,
                         justify_v: signex_types::schematic::VAlign::default(),
                     });

--- a/crates/signex-app/src/app/handlers/active_bar/placement_presets.rs
+++ b/crates/signex-app/src/app/handlers/active_bar/placement_presets.rs
@@ -50,7 +50,7 @@ impl Signex {
                     rotation: 0.0,
                     label_type: signex_types::schematic::LabelType::Global,
                     shape: "bidirectional".to_string(),
-                    font_size: 1.8,
+                    font_size: signex_types::schematic::SCHEMATIC_TEXT_MM,
                     justify: signex_types::schematic::HAlign::Left,
                 });
             }
@@ -67,7 +67,7 @@ impl Signex {
                     rotation: 0.0,
                     label_type: signex_types::schematic::LabelType::Hierarchical,
                     shape: String::new(),
-                    font_size: 1.8,
+                    font_size: signex_types::schematic::SCHEMATIC_TEXT_MM,
                     justify: signex_types::schematic::HAlign::Left,
                 });
             }

--- a/crates/signex-app/src/app/handlers/canvas.rs
+++ b/crates/signex-app/src/app/handlers/canvas.rs
@@ -279,7 +279,7 @@ impl Signex {
                                 val_text: Some(signex_types::schematic::TextProp {
                                     position: signex_types::schematic::Point::new(wx, wy - 1.27),
                                     rotation: 0.0,
-                                    font_size: 1.8,
+                                    font_size: signex_types::schematic::SCHEMATIC_TEXT_MM,
                                     justify_h: signex_types::schematic::HAlign::Center,
                                     justify_v: signex_types::schematic::VAlign::default(),
                                     hidden: false,
@@ -340,7 +340,7 @@ impl Signex {
                             text: note_text,
                             position: signex_types::schematic::Point::new(wx, wy),
                             rotation: 0.0,
-                            font_size: 1.8,
+                            font_size: signex_types::schematic::SCHEMATIC_TEXT_MM,
                             justify_h: signex_types::schematic::HAlign::Left,
                             justify_v: signex_types::schematic::VAlign::default(),
                         };
@@ -386,8 +386,8 @@ impl Signex {
                             .panel_ctx
                             .pre_placement
                             .as_ref()
-                            .map(|pp| (pp.rotation, pp.font_size_pt as f64 * 0.254, pp.justify_h))
-                            .unwrap_or((0.0, 1.8, signex_types::schematic::HAlign::Left));
+                            .map(|pp| (pp.rotation, pp.font_size_pt as f64 * signex_types::schematic::SCHEMATIC_PT_TO_MM, pp.justify_h))
+                            .unwrap_or((0.0, signex_types::schematic::SCHEMATIC_TEXT_MM, signex_types::schematic::HAlign::Left));
                         let label = signex_types::schematic::Label {
                             uuid: uuid::Uuid::new_v4(),
                             text,

--- a/crates/signex-app/src/app/handlers/dock/panel_controls.rs
+++ b/crates/signex-app/src/app/handlers/dock/panel_controls.rs
@@ -94,7 +94,7 @@ impl Signex {
                 if let Some(pp) = &mut self.document_state.panel_ctx.pre_placement {
                     pp.font_size_pt = *pt;
                 }
-                let fs_mm = *pt as f64 * 0.254;
+                let fs_mm = *pt as f64 * signex_types::schematic::SCHEMATIC_PT_TO_MM;
                 if let Some(g) = &mut self.interaction_state.canvas.ghost_label {
                     g.font_size = fs_mm;
                 }

--- a/crates/signex-app/src/app/handlers/dock/property_editor.rs
+++ b/crates/signex-app/src/app/handlers/dock/property_editor.rs
@@ -113,7 +113,7 @@ impl Signex {
                     signex_engine::Command::UpdateSymbolTextSize {
                         symbol_id: *uuid,
                         field: signex_engine::SymbolTextField::Value,
-                        font_size_mm: (*pt as f64) * 0.18,
+                        font_size_mm: (*pt as f64) * signex_types::schematic::SCHEMATIC_PT_TO_MM,
                     },
                     true,
                     true,
@@ -168,7 +168,7 @@ impl Signex {
                 );
             }
             crate::panels::PanelMsg::EditLabelFontSizePt(uuid, pt) => {
-                let mm = (*pt as f64) * 0.18;
+                let mm = (*pt as f64) * signex_types::schematic::SCHEMATIC_PT_TO_MM;
                 self.apply_engine_command(
                     signex_engine::Command::UpdateLabelProps {
                         label_id: *uuid,

--- a/crates/signex-app/src/app/load_gateway.rs
+++ b/crates/signex-app/src/app/load_gateway.rs
@@ -285,8 +285,7 @@ impl Signex {
         commit_to_active_tab: bool,
         refresh_panel_ctx: bool,
     ) {
-        if let Some(mut schematic) = schematic {
-            normalize_font_sizes(&mut schematic);
+        if let Some(schematic) = schematic {
             self.sync_engine_from_schematic(Some(schematic));
         }
         if self.document_state.engine.is_none() {
@@ -374,33 +373,3 @@ impl Signex {
     }
 }
 
-/// Bump font sizes that are at KiCad's default (0 or 1.27 mm) up to Signex's
-/// Altium-style 10 pt (`SCHEMATIC_TEXT_MM`). Keeps user-set sizes intact.
-/// Applied once on load so the Properties panel shows the effective size
-/// rather than the stored default.
-fn normalize_font_sizes(sheet: &mut SchematicSheet) {
-    let default_mm = signex_render::SCHEMATIC_TEXT_MM;
-    let is_default = |f: f64| f <= 0.0 || (f - 1.27).abs() < 0.01;
-    for l in sheet.labels.iter_mut() {
-        if is_default(l.font_size) {
-            l.font_size = default_mm;
-        }
-    }
-    for tn in sheet.text_notes.iter_mut() {
-        if is_default(tn.font_size) {
-            tn.font_size = default_mm;
-        }
-    }
-    for sym in sheet.symbols.iter_mut() {
-        if let Some(tp) = sym.ref_text.as_mut()
-            && is_default(tp.font_size)
-        {
-            tp.font_size = default_mm;
-        }
-        if let Some(tp) = sym.val_text.as_mut()
-            && is_default(tp.font_size)
-        {
-            tp.font_size = default_mm;
-        }
-    }
-}

--- a/crates/signex-engine/src/lib.rs
+++ b/crates/signex-engine/src/lib.rs
@@ -9,7 +9,7 @@ pub use error::EngineError;
 pub use patch::{CommandResult, DocumentPatch, PatchPair, SemanticPatch};
 use signex_types::schematic::{
     Bus, Junction, Label, NoConnect, SchematicSheet, SelectedItem, SelectedKind, Symbol, TextNote,
-    Wire,
+    Wire, SCHEMATIC_PT_TO_MM,
 };
 
 const JUNCTION_TOLERANCE_MM: f64 = 0.01;
@@ -917,7 +917,7 @@ impl Engine {
                 info.push(("Rotation".into(), format!("{:.0}°", label.rotation)));
                 info.push((
                     "Text Size".into(),
-                    format!("{}", (label.font_size.max(0.0) / 0.18).round() as i32),
+                    format!("{}", (label.font_size.max(0.0) / SCHEMATIC_PT_TO_MM).round() as i32),
                 ));
                 info.push((
                     "Horizontal Justification".into(),
@@ -963,7 +963,7 @@ impl Engine {
                 info.push(("Rotation".into(), format!("{:.0}°", text_note.rotation)));
                 info.push((
                     "Text Size".into(),
-                    format!("{}", (text_note.font_size.max(0.0) / 0.18).round() as i32),
+                    format!("{}", (text_note.font_size.max(0.0) / SCHEMATIC_PT_TO_MM).round() as i32),
                 ));
                 info.push((
                     "Horizontal Justification".into(),
@@ -1028,7 +1028,7 @@ impl Engine {
                 info.push(("Rotation".into(), format!("{:.0}°", ref_text.rotation)));
                 info.push((
                     "Text Size".into(),
-                    format!("{}", (ref_text.font_size.max(0.0) / 0.18).round() as i32),
+                    format!("{}", (ref_text.font_size.max(0.0) / SCHEMATIC_PT_TO_MM).round() as i32),
                 ));
                 info.push((
                     "Horizontal Justification".into(),
@@ -1072,7 +1072,7 @@ impl Engine {
                 info.push(("Rotation".into(), format!("{:.0}°", value_text.rotation)));
                 info.push((
                     "Text Size".into(),
-                    format!("{}", (value_text.font_size.max(0.0) / 0.18).round() as i32),
+                    format!("{}", (value_text.font_size.max(0.0) / SCHEMATIC_PT_TO_MM).round() as i32),
                 ));
                 info.push((
                     "Horizontal Justification".into(),

--- a/crates/signex-render/src/lib.rs
+++ b/crates/signex-render/src/lib.rs
@@ -14,11 +14,8 @@ use std::sync::{OnceLock, RwLock};
 /// available by name once the application starts.
 pub const IOSEVKA: iced::Font = iced::Font::with_name("Iosevka");
 
-/// Default text size used everywhere on the schematic canvas — labels, symbol
-/// designators/values, pin name/number, graphic text. Kept as a single source
-/// so size changes flow through the whole renderer. 1.8 mm ≈ Altium "10 pt"
-/// (cap-height basis). Variable instead of a hardcoded literal.
-pub const SCHEMATIC_TEXT_MM: f64 = 1.8;
+pub use signex_types::schematic::SCHEMATIC_TEXT_MM;
+pub use signex_types::schematic::SCHEMATIC_PT_TO_MM;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PowerPortStyle {

--- a/crates/signex-render/src/lib.rs
+++ b/crates/signex-render/src/lib.rs
@@ -17,6 +17,10 @@ pub const IOSEVKA: iced::Font = iced::Font::with_name("Iosevka");
 pub use signex_types::schematic::SCHEMATIC_TEXT_MM;
 pub use signex_types::schematic::SCHEMATIC_PT_TO_MM;
 
+/// KiCad stroke font stores "size" as cap-height; Iced TrueType uses em-square.
+/// Cap height ≈ 72 % of em-square → scale up by 1/0.72 so visual sizes match KiCad.
+pub const STROKE_FONT_SCALE: f32 = 1.0 / 0.72;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PowerPortStyle {
     KiCad,

--- a/crates/signex-render/src/schematic/label.rs
+++ b/crates/signex-render/src/schematic/label.rs
@@ -28,7 +28,7 @@ pub fn draw_label(
     // mutating the stored value keeps save round-trips stable.
     let font_size_mm = crate::SCHEMATIC_TEXT_MM;
     let _stored = label.font_size;
-    let screen_font = transform.world_len(font_size_mm).abs();
+    let screen_font = transform.world_len(font_size_mm).abs() * crate::STROKE_FONT_SCALE;
     if screen_font < 1.0 {
         return;
     }

--- a/crates/signex-render/src/schematic/mod.rs
+++ b/crates/signex-render/src/schematic/mod.rs
@@ -868,7 +868,7 @@ fn draw_builtin_power(
     let label_y = (pin_len + body_extent + 0.25) * dir;
     // 10 pt — the canvas-wide default — matching Altium.
     let font_size_mm = crate::SCHEMATIC_TEXT_MM;
-    let screen_font = transform.world_len(font_size_mm).abs();
+    let screen_font = transform.world_len(font_size_mm).abs() * crate::STROKE_FONT_SCALE;
     if screen_font >= 1.0 {
         let (tx, ty) = instance_transform(sym, &signex_types::schematic::Point::new(0.0, label_y));
         let sp = transform.to_screen_point(tx, ty);

--- a/crates/signex-render/src/schematic/pin.rs
+++ b/crates/signex-render/src/schematic/pin.rs
@@ -183,7 +183,7 @@ fn draw_pin(
 
     // Pin name is drawn near the symbol-side end of the pin.
     let font_size_mm = crate::SCHEMATIC_TEXT_MM;
-    let screen_font = transform.world_len(font_size_mm).abs();
+    let screen_font = transform.world_len(font_size_mm).abs() * crate::STROKE_FONT_SCALE;
 
     if screen_font >= 1.0
         && lib.show_pin_names
@@ -359,14 +359,15 @@ fn draw_pin(
         let (wdx, wdy) = instance_rotate_dir(sym, dir_x, dir_y);
         let perp_offset_px = transform.world_len(0.8);
 
-        // Always offset toward screen-up for horizontal pins, screen-left for
-        // vertical pins.  This keeps numbers above (never below) the pin line
-        // regardless of lib-local rotation (0° vs 180° pins agree).
+        // Offset perpendicular to the pin so the number clears the pin line.
+        // Horizontal pins → above line; vertical (top/bottom) pins → left of
+        // line. Both cases render horizontal, unrotated text — same convention
+        // as side-pin numbers, keeping numbers outside the IC body.
         let (perp_sx, perp_sy, num_align) = if wdx.abs() >= wdy.abs() {
             // Horizontal pin → above line (screen -Y), centered on X.
             (0.0_f32, -1.0_f32, iced::alignment::Horizontal::Center)
         } else {
-            // Vertical pin → left of line (screen -X), right-aligned text.
+            // Vertical pin → left of pin line (screen -X), right-aligned.
             (-1.0_f32, 0.0_f32, iced::alignment::Horizontal::Right)
         };
 
@@ -375,11 +376,11 @@ fn draw_pin(
             np_base.y + perp_sy * perp_offset_px,
         );
 
-        let small_font = (screen_font * 0.8).abs();
-        if small_font < 1.0 {
+        let num_font = screen_font;
+        if num_font < 1.0 {
             return;
         }
-        let fanout_step_px = transform.world_len(0.9).max(small_font * 0.8);
+        let fanout_step_px = transform.world_len(0.9).max(num_font * 0.8);
         let stack_center = stack.index as f32 - (stack.total as f32 - 1.0) * 0.5;
         let line_dx = p2.x - p1.x;
         let line_dy = p2.y - p1.y;
@@ -392,7 +393,7 @@ fn draw_pin(
             content: display_text_content(&pin.number),
             position: stack_np,
             color: pin_color,
-            size: iced::Pixels(small_font),
+            size: iced::Pixels(num_font),
             font: crate::canvas_font(),
             align_x: num_align.into(),
             align_y: iced::alignment::Vertical::Center,

--- a/crates/signex-render/src/schematic/pin.rs
+++ b/crates/signex-render/src/schematic/pin.rs
@@ -273,29 +273,75 @@ fn draw_pin(
         // a separate stroke above the text with a small visible gap, which
         // matches KiCad's look.
         let (plain, overbars) = display_text_with_overbars(&pin.name);
-        let text = canvas::Text {
-            content: plain.clone(),
-            position: np,
-            color: pin_color,
-            size: iced::Pixels(screen_font),
-            font: crate::canvas_font(),
-            align_x: h_align.into(),
-            align_y: v_align,
-            ..canvas::Text::default()
-        };
-        frame.fill_text(text);
 
-        if !overbars.is_empty() {
-            draw_overbars(
-                frame,
-                &plain,
-                &overbars,
-                np,
-                screen_font,
-                h_align,
-                v_align,
-                pin_color,
-            );
+        // Determine whether the pin runs vertically on screen.
+        let (wdx, wdy) = instance_rotate_dir(sym, dir_x, dir_y);
+        let is_vertical_pin = wdx.abs() < wdy.abs();
+
+        if is_vertical_pin {
+            // Rotate the frame so text baseline is parallel to the pin.
+            //
+            // KiCad convention for downward pins (wdy < 0 = body above pin):
+            //   CCW 90° (+π/2): rotated +X = screen UP.
+            //   h_align = Left  → first char at np (body edge), text extends upward into IC.
+            //   h_align = Right → last char at np, text extends upward into IC.
+            //
+            // For upward pins (wdy > 0 = body below pin):
+            //   CW 90° (-π/2): rotated +X = screen DOWN.
+            //   h_align = Left  → first char at np (body edge), text extends downward into IC.
+            // frame.rotate uses Iced's convention: positive = CCW visual in
+            // screen Y-down space.  For bottom-exiting pins (wdy < 0 = body
+            // above) we want CCW visual so text reads A→D from body-edge
+            // upward (matching KiCad).  Top-exiting pins use the mirror.
+            let rot = if wdy < 0.0 {
+                -std::f32::consts::FRAC_PI_2  // CCW visual → bottom-to-top
+            } else {
+                std::f32::consts::FRAC_PI_2   // CW visual  → top-to-bottom
+            };
+            // In the rotated frame, align_x controls the along-pin axis and
+            // align_y controls the perpendicular axis.  We always want:
+            //   - text to start at the body edge (Left = first char at anchor)
+            //   - text centered across the pin line (Center)
+            frame.with_save(|frame| {
+                frame.translate(iced::Vector::new(np.x, np.y));
+                frame.rotate(rot);
+                let text = canvas::Text {
+                    content: plain.clone(),
+                    position: iced::Point::ORIGIN,
+                    color: pin_color,
+                    size: iced::Pixels(screen_font),
+                    font: crate::canvas_font(),
+                    align_x: iced::alignment::Horizontal::Left.into(),
+                    align_y: iced::alignment::Vertical::Center,
+                    ..canvas::Text::default()
+                };
+                frame.fill_text(text);
+            });
+        } else {
+            let text = canvas::Text {
+                content: plain.clone(),
+                position: np,
+                color: pin_color,
+                size: iced::Pixels(screen_font),
+                font: crate::canvas_font(),
+                align_x: h_align.into(),
+                align_y: v_align,
+                ..canvas::Text::default()
+            };
+            frame.fill_text(text);
+
+            if !overbars.is_empty() {
+                draw_overbars(
+                    frame,
+                    &plain,
+                    &overbars,
+                    np,
+                    screen_font,
+                    h_align,
+                    v_align,
+                    pin_color,
+                );
+            }
         }
     }
 

--- a/crates/signex-render/src/schematic/symbol.rs
+++ b/crates/signex-render/src/schematic/symbol.rs
@@ -434,7 +434,7 @@ fn draw_graphic_text(
     // Force 10 pt (1.8 mm) for all symbol-embedded graphic text.
     let _stored = font_size;
     let base_size = transform.world_len(crate::SCHEMATIC_TEXT_MM);
-    let size = base_size.abs();
+    let size = base_size.abs() * crate::STROKE_FONT_SCALE;
     if size < 1.0 {
         return;
     }

--- a/crates/signex-render/src/schematic/text.rs
+++ b/crates/signex-render/src/schematic/text.rs
@@ -192,7 +192,7 @@ pub fn draw_text_note(
     // Fixed 10 pt (1.8 mm) for all canvas text — matches Altium default.
     let font_size_mm = crate::SCHEMATIC_TEXT_MM;
     let _stored = note.font_size;
-    let screen_font = transform.world_len(font_size_mm).abs();
+    let screen_font = transform.world_len(font_size_mm).abs() * crate::STROKE_FONT_SCALE;
     if screen_font < 1.0 {
         return;
     }
@@ -267,7 +267,7 @@ pub fn draw_text_prop(
     // All symbol ref/val text renders at 10 pt (1.8 mm).
     let font_size_mm = crate::SCHEMATIC_TEXT_MM;
     let _stored = prop.font_size;
-    let screen_font = transform.world_len(font_size_mm).abs();
+    let screen_font = transform.world_len(font_size_mm).abs() * crate::STROKE_FONT_SCALE;
     if screen_font < 1.0 {
         return;
     }

--- a/crates/signex-types/src/schematic.rs
+++ b/crates/signex-types/src/schematic.rs
@@ -4,6 +4,16 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 // ---------------------------------------------------------------------------
+// Schematic text constants
+// ---------------------------------------------------------------------------
+
+/// Default schematic text height: 1.27 mm = 50 mils = 10 Altium pt.
+pub const SCHEMATIC_TEXT_MM: f64 = 1.27;
+
+/// Altium schematic point → mm: 1 pt = 0.127 mm (10 pt = 1.27 mm).
+pub const SCHEMATIC_PT_TO_MM: f64 = 0.127;
+
+// ---------------------------------------------------------------------------
 // Point -- KiCad mm-space coordinate (f64). Copy-friendly.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Merge v0.6.1 (Hakan's font/pin/power-port fixes) into main for the v0.6.1 release.
- All changes previously landed on \`dev\` via PR #29.

## What's in this release
- KiCad stroke-font scale (1/0.72) applied across every schematic text renderer so visual sizes match KiCad.
- Pin numbers: remove spurious 0.8 shrink; vertical pins render number horizontally offset left of the line.
- Parser: recognise property-level \`(hide yes)\` (KiCad 8) on Reference / Footprint / Datasheet.
- Writer: emit \`(hide yes)\` at property level so KiCad re-reads power-port refs as hidden after save.
- Earlier v0.6.1 fixes: font-size constants (10pt=1.27mm/pt=0.127mm), rotated prop rotation, pin-name offset 0.

## Test plan
- [x] \`cargo check --workspace\` clean
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo test --workspace\` passing
- [ ] Round-trip a .kicad_sch via KiCad → open in Signex → save → re-open in KiCad; confirm power-port refs stay hidden.

## Release
- Tag \`v0.6.1\` on main after merge; release.yml builds binaries for the 3 platforms.