### PR TITLE
fix(ci): pin aarch64-apple-darwin to macos-14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,13 @@ jobs:
           # image. Revisit in a patch release; drop here so v0.6 can ship.
 
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-14
             artifact: signex
             archive: signex-macos-aarch64.tar.gz
+
+          # macos-latest was stalling on v0.6.2 (set-up job failed in 2s
+          # — queue exhausted). Pinned to macos-14 (Apple Silicon) for
+          # stable capacity. Bump to macos-15 when macos-14 rolls off.
 
           # x86_64-apple-darwin deferred — macos-13 runners are in the
           # deprecated queue and take 30+ minutes to pick up a job. Apple


### PR DESCRIPTION
## Summary
v0.6.2's release workflow failed its aarch64-apple-darwin Build job at set-up (2s into the run) — GitHub's macos-latest alias was returning a runner that couldn't complete the job. Same symptom as the earlier macos-13 stall that forced dropping x86_64-apple-darwin.

## Fix
Pin aarch64-apple-darwin to macos-14 explicitly (Apple Silicon, stable capacity). No behaviour change for users; binary output is identical.

## Test plan
Merge + re-run release workflow on v0.6.2 tag (or bump to v0.6.3 tag if re-run isn't available).