### PR TITLE
feat(release): per-OS installers — setup.exe, .dmg, .deb, .AppImage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,18 +21,18 @@ jobs:
         include:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            artifact: signex.exe
-            archive: signex-windows-x86_64.zip
+            arch: x64
+            arch_suffix: x86_64
 
           - target: aarch64-pc-windows-msvc
             os: windows-latest
-            artifact: signex.exe
-            archive: signex-windows-aarch64.zip
+            arch: arm64
+            arch_suffix: aarch64
 
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: signex
-            archive: signex-linux-x86_64.tar.gz
+            arch: amd64
+            arch_suffix: x86_64
 
           # aarch64-unknown-linux-gnu deferred — cross-compiling iced +
           # wgpu with their native C/C++ deps on ubuntu-latest needs
@@ -41,8 +41,8 @@ jobs:
 
           - target: aarch64-apple-darwin
             os: macos-14
-            artifact: signex
-            archive: signex-macos-aarch64.tar.gz
+            arch: aarch64
+            arch_suffix: aarch64
 
           # macos-latest was stalling on v0.6.2 (set-up job failed in 2s
           # — queue exhausted). Pinned to macos-14 (Apple Silicon) for
@@ -51,13 +51,23 @@ jobs:
           # x86_64-apple-darwin deferred — macos-13 runners are in the
           # deprecated queue and take 30+ minutes to pick up a job. Apple
           # Silicon Macs run the aarch64-apple-darwin binary natively;
-          # Intel Macs can run it under Rosetta 2. Revisit once GitHub
-          # stabilises macos-13 capacity or we move to self-hosted.
+          # Intel Macs can run it under Rosetta 2.
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: false
+
+      - name: Extract version from tag
+        id: version
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          # Strip the leading "v" for the installer's internal version
+          # fields; keep the original tag around for release-page naming.
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -73,32 +83,97 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libxkbcommon-dev libwayland-dev libvulkan-dev \
-            libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+            libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+            desktop-file-utils fakeroot
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} -p signex-app
 
-      - name: Package (Windows)
+      # ─── Windows: InnoSetup installer ────────────────────────────
+      - name: Install InnoSetup
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: choco install innosetup -y --no-progress
+
+      - name: Build Windows installer
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          mkdir staging
-          Copy-Item "target/${{ matrix.target }}/release/${{ matrix.artifact }}" staging/
-          Compress-Archive -Path staging/* -DestinationPath ${{ matrix.archive }}
+          $binary = "$PWD\target\${{ matrix.target }}\release\signex.exe"
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
+            "/DVersion=${{ steps.version.outputs.version }}" `
+            "/DArch=${{ matrix.arch }}" `
+            "/DBinary=$binary" `
+            "/Q" `
+            installer\windows\signex.iss
+          # InnoSetup writes the installer alongside the .iss script;
+          # move it to the repo root so upload-artifact can find it.
+          Move-Item installer\windows\signex-setup-${{ matrix.arch_suffix }}-${{ steps.version.outputs.version }}.exe .
 
-      - name: Package (Unix)
-        if: runner.os != 'Windows'
+      - name: Package Windows portable ZIP (alongside installer)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          mkdir staging | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/signex.exe" staging/
+          Compress-Archive -Path staging/* -DestinationPath "signex-windows-${{ matrix.arch_suffix }}-${{ steps.version.outputs.version }}.zip"
+
+      # ─── macOS: .app bundle → .dmg ────────────────────────────────
+      - name: Build macOS DMG installer
+        if: runner.os == 'macOS'
+        run: |
+          chmod +x installer/macos/build-dmg.sh
+          ./installer/macos/build-dmg.sh \
+            "target/${{ matrix.target }}/release/signex" \
+            "${{ steps.version.outputs.version }}" \
+            "${{ matrix.arch_suffix }}"
+
+      # ─── Linux: .deb package ──────────────────────────────────────
+      - name: Build Linux .deb package
+        if: runner.os == 'Linux'
+        run: |
+          chmod +x installer/linux/build-deb.sh
+          ./installer/linux/build-deb.sh \
+            "target/${{ matrix.target }}/release/signex" \
+            "${{ steps.version.outputs.version }}" \
+            "${{ matrix.arch }}"
+
+      # ─── Linux: AppImage ──────────────────────────────────────────
+      - name: Build Linux AppImage
+        if: runner.os == 'Linux'
+        run: |
+          # Fetch appimagetool so the script can package the AppDir.
+          wget -q -O appimagetool "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${{ matrix.arch_suffix }}.AppImage"
+          chmod +x appimagetool
+          export APPIMAGETOOL="$PWD/appimagetool"
+          chmod +x installer/linux/build-appimage.sh
+          ./installer/linux/build-appimage.sh \
+            "target/${{ matrix.target }}/release/signex" \
+            "${{ steps.version.outputs.version }}" \
+            "${{ matrix.arch_suffix }}"
+          # AppImage tool runs fuse at runtime; ensure CI has it.
+
+      - name: Package Linux tarball (alongside installer)
+        if: runner.os == 'Linux'
         run: |
           mkdir staging
-          cp target/${{ matrix.target }}/release/${{ matrix.artifact }} staging/
+          cp "target/${{ matrix.target }}/release/signex" staging/
           cd staging
-          tar czf ../${{ matrix.archive }} *
+          tar czf "../signex-linux-${{ matrix.arch_suffix }}-${{ steps.version.outputs.version }}.tar.gz" *
 
-      - name: Upload artifact
+      # ─── Upload all artifacts for this target ─────────────────────
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.archive }}
-          path: ${{ matrix.archive }}
+          name: signex-${{ matrix.target }}-${{ steps.version.outputs.version }}
+          path: |
+            signex-setup-*-${{ steps.version.outputs.version }}.exe
+            signex-windows-*-${{ steps.version.outputs.version }}.zip
+            signex-macos-*-${{ steps.version.outputs.version }}.dmg
+            signex_${{ steps.version.outputs.version }}_*.deb
+            Signex-${{ steps.version.outputs.version }}-*.AppImage
+            signex-linux-*-${{ steps.version.outputs.version }}.tar.gz
+          if-no-files-found: ignore
 
   release:
     name: Create Release
@@ -130,9 +205,13 @@ jobs:
           draft: false
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
           generate_release_notes: true
+          # Explicit list — the installer stack is what users want, the
+          # tarball/zip are fallbacks for scripted installs.
           files: |
-            artifacts/signex-windows-x86_64.zip
-            artifacts/signex-windows-aarch64.zip
-            artifacts/signex-linux-x86_64.tar.gz
-            artifacts/signex-macos-aarch64.tar.gz
+            artifacts/signex-setup-*.exe
+            artifacts/signex-windows-*.zip
+            artifacts/signex-macos-*.dmg
+            artifacts/signex_*.deb
+            artifacts/Signex-*.AppImage
+            artifacts/signex-linux-*.tar.gz
             artifacts/SHA256SUMS.txt

--- a/installer/linux/build-appimage.sh
+++ b/installer/linux/build-appimage.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Build an AppImage from a compiled signex binary. AppImage is a
+# single-file portable Linux app — users download, chmod +x, run.
+#
+# Invocation:
+#   installer/linux/build-appimage.sh <binary_path> <version> <arch>
+#
+#   <arch> — "x86_64" or "aarch64".
+# Output: Signex-<version>-<arch>.AppImage in the CWD.
+
+set -euo pipefail
+
+BINARY_PATH="${1:?usage: build-appimage.sh <binary> <version> <arch>}"
+VERSION="${2:?missing version}"
+ARCH="${3:?missing arch}"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+APP_DIR="$WORK_DIR/Signex.AppDir"
+mkdir -p "$APP_DIR/usr/bin"
+mkdir -p "$APP_DIR/usr/share/applications"
+mkdir -p "$APP_DIR/usr/share/icons/hicolor/256x256/apps"
+
+cp "$BINARY_PATH" "$APP_DIR/usr/bin/signex"
+chmod +x "$APP_DIR/usr/bin/signex"
+
+# AppRun — the entry point AppImage calls.
+cat > "$APP_DIR/AppRun" <<'APPRUN_EOF'
+#!/bin/bash
+HERE="$(dirname "$(readlink -f "$0")")"
+exec "$HERE/usr/bin/signex" "$@"
+APPRUN_EOF
+chmod +x "$APP_DIR/AppRun"
+
+# Top-level .desktop for AppImage tooling.
+cat > "$APP_DIR/signex.desktop" <<DESKTOP_EOF
+[Desktop Entry]
+Type=Application
+Name=Signex
+Comment=AI-first EDA editor
+Exec=signex
+Icon=signex
+Categories=Development;Electronics;Engineering;
+Terminal=false
+DESKTOP_EOF
+cp "$APP_DIR/signex.desktop" "$APP_DIR/usr/share/applications/signex.desktop"
+
+# Placeholder icon — a 1×1 PNG so AppImage's validator doesn't trip.
+# Swap for a real signex.png (256×256) once we have one.
+python3 -c "import struct,zlib,sys;data=b'\\x89PNG\\r\\n\\x1a\\n'+b''.join((struct.pack('>I',len(c))+t+c+struct.pack('>I',zlib.crc32(t+c)&0xffffffff)) for t,c in [(b'IHDR',struct.pack('>IIBBBBB',1,1,8,2,0,0,0)),(b'IDAT',zlib.compress(b'\\x00\\x40\\x40\\x40')),(b'IEND',b'')]);open(sys.argv[1],'wb').write(data)" "$APP_DIR/signex.png"
+cp "$APP_DIR/signex.png" "$APP_DIR/usr/share/icons/hicolor/256x256/apps/signex.png"
+
+# appimagetool runtime (linuxdeploy in CI handles this; fall back to
+# appimagetool AppImage if available locally).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [[ -n "${APPIMAGETOOL:-}" ]]; then
+    TOOL="$APPIMAGETOOL"
+elif command -v appimagetool &>/dev/null; then
+    TOOL="$(command -v appimagetool)"
+elif [[ -x "$SCRIPT_DIR/appimagetool" ]]; then
+    TOOL="$SCRIPT_DIR/appimagetool"
+else
+    echo "appimagetool not found. Set APPIMAGETOOL=/path/to/appimagetool or place it next to build-appimage.sh." >&2
+    exit 1
+fi
+
+OUTPUT="Signex-$VERSION-$ARCH.AppImage"
+rm -f "$OUTPUT"
+
+ARCH="$ARCH" "$TOOL" --no-appstream "$APP_DIR" "$OUTPUT"
+
+chmod +x "$OUTPUT"
+echo "Built $OUTPUT"

--- a/installer/linux/build-deb.sh
+++ b/installer/linux/build-deb.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Build a Debian .deb package from a compiled signex binary.
+# Produces: signex_<version>_<arch>.deb (Debian naming convention).
+#
+# Invocation:
+#   installer/linux/build-deb.sh <binary_path> <version> <arch>
+#
+#   <arch> — "amd64" (x86_64) or "arm64" (aarch64) in Debian terminology.
+
+set -euo pipefail
+
+BINARY_PATH="${1:?usage: build-deb.sh <binary> <version> <arch>}"
+VERSION="${2:?missing version}"
+ARCH="${3:?missing arch}"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+PKG_DIR="$WORK_DIR/signex_${VERSION}_${ARCH}"
+mkdir -p "$PKG_DIR/DEBIAN"
+mkdir -p "$PKG_DIR/usr/bin"
+mkdir -p "$PKG_DIR/usr/share/applications"
+mkdir -p "$PKG_DIR/usr/share/icons/hicolor/scalable/apps"
+mkdir -p "$PKG_DIR/usr/share/doc/signex"
+
+cp "$BINARY_PATH" "$PKG_DIR/usr/bin/signex"
+chmod 755 "$PKG_DIR/usr/bin/signex"
+
+# Control file — Installed-Size is approx (binary + assets); dpkg-deb
+# computes the actual compressed size when it builds.
+INSTALLED_SIZE=$(du -sk "$PKG_DIR/usr" | cut -f1)
+cat > "$PKG_DIR/DEBIAN/control" <<CONTROL_EOF
+Package: signex
+Version: $VERSION
+Section: electronics
+Priority: optional
+Architecture: $ARCH
+Depends: libc6, libgcc-s1, libxkbcommon0, libxkbcommon-x11-0, libwayland-client0, libx11-6, libxcursor1, libxrandr2, libxi6, libxinerama1, libvulkan1
+Installed-Size: $INSTALLED_SIZE
+Maintainer: alpCaner <alpcaner92@gmail.com>
+Homepage: https://github.com/alplabai/signex
+Description: AI-first EDA editor with KiCad round-trip
+ Signex is a KiCad-compatible electronics design automation editor with
+ an Altium-inspired interaction layer. It opens KiCad projects, edits
+ them through a faster UI, and saves them back without format drift.
+CONTROL_EOF
+
+# .desktop entry for menu integration.
+cat > "$PKG_DIR/usr/share/applications/signex.desktop" <<DESKTOP_EOF
+[Desktop Entry]
+Type=Application
+Name=Signex
+Comment=AI-first EDA editor
+Exec=/usr/bin/signex %F
+Terminal=false
+Categories=Development;Electronics;Engineering;
+MimeType=application/x-kicad-schematic;application/x-kicad-project;
+StartupNotify=true
+DESKTOP_EOF
+
+# README copied into the docs dir — Debian policy expects at least a
+# changelog, but a short README keeps the lintian warning small.
+cat > "$PKG_DIR/usr/share/doc/signex/README.Debian" <<DOC_EOF
+Signex $VERSION
+---------------
+Installed by signex_${VERSION}_${ARCH}.deb.
+Report issues at https://github.com/alplabai/signex/issues.
+DOC_EOF
+
+OUTPUT="signex_${VERSION}_${ARCH}.deb"
+rm -f "$OUTPUT"
+
+# --root-owner-group emits root:root for every file, which lintian requires.
+dpkg-deb --root-owner-group --build "$PKG_DIR" "$OUTPUT"
+
+echo "Built $OUTPUT"

--- a/installer/macos/Info.plist
+++ b/installer/macos/Info.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>signex</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.alpcaner.signex</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Signex</string>
+    <key>CFBundleDisplayName</key>
+    <string>Signex</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>__VERSION__</string>
+    <key>CFBundleVersion</key>
+    <string>__VERSION__</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>11.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>KiCad Schematic</string>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>kicad_sch</string>
+            </array>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+        </dict>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>KiCad Project</string>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>kicad_pro</string>
+            </array>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/installer/macos/build-dmg.sh
+++ b/installer/macos/build-dmg.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Build a macOS DMG installer from a compiled signex binary.
+#
+# Invocation from CI:
+#   installer/macos/build-dmg.sh <binary_path> <version> <arch>
+#
+#   <binary_path> — path to the compiled signex binary
+#   <version>     — version string without the leading "v"
+#   <arch>        — "aarch64" or "x86_64"
+#
+# Output: signex-macos-<arch>-<version>.dmg in the CWD.
+
+set -euo pipefail
+
+BINARY_PATH="${1:?usage: build-dmg.sh <binary> <version> <arch>}"
+VERSION="${2:?missing version}"
+ARCH="${3:?missing arch}"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+APP_BUNDLE="$WORK_DIR/Signex.app"
+CONTENTS="$APP_BUNDLE/Contents"
+MACOS="$CONTENTS/MacOS"
+RESOURCES="$CONTENTS/Resources"
+
+mkdir -p "$MACOS" "$RESOURCES"
+
+# Binary goes into MacOS/, named exactly what Info.plist CFBundleExecutable says.
+cp "$BINARY_PATH" "$MACOS/signex"
+chmod +x "$MACOS/signex"
+
+# Info.plist with version substituted.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+sed "s/__VERSION__/$VERSION/g" "$SCRIPT_DIR/Info.plist" > "$CONTENTS/Info.plist"
+
+# Optional icon — drop a Signex.icns next to build-dmg.sh to include it.
+if [[ -f "$SCRIPT_DIR/Signex.icns" ]]; then
+    cp "$SCRIPT_DIR/Signex.icns" "$RESOURCES/Signex.icns"
+    # Patch Info.plist to reference it.
+    /usr/libexec/PlistBuddy -c "Add :CFBundleIconFile string Signex" "$CONTENTS/Info.plist" || true
+fi
+
+# Assemble the DMG contents: the .app plus a symlink to /Applications so
+# the user can drag-and-drop to install.
+DMG_STAGING="$WORK_DIR/dmg-staging"
+mkdir -p "$DMG_STAGING"
+cp -R "$APP_BUNDLE" "$DMG_STAGING/Signex.app"
+ln -s /Applications "$DMG_STAGING/Applications"
+
+OUTPUT="signex-macos-$ARCH-$VERSION.dmg"
+rm -f "$OUTPUT"
+
+hdiutil create \
+    -volname "Signex $VERSION" \
+    -srcfolder "$DMG_STAGING" \
+    -ov \
+    -format UDZO \
+    "$OUTPUT"
+
+echo "Built $OUTPUT"

--- a/installer/windows/signex.iss
+++ b/installer/windows/signex.iss
@@ -1,0 +1,76 @@
+; Signex — Windows installer (InnoSetup)
+;
+; Invoked from CI via:
+;   ISCC.exe installer\windows\signex.iss /DVersion=0.6.3 /DArch=x64
+;
+; /DVersion  — version string without the leading "v" (tag minus "v")
+; /DArch     — "x64" or "arm64" — picks the right binary source path
+; /DBinary   — absolute path to the compiled signex.exe; overrides the
+;              target-default when testing locally.
+
+#ifndef Version
+  #define Version "0.0.0"
+#endif
+
+#ifndef Arch
+  #define Arch "x64"
+#endif
+
+#if Arch == "x64"
+  #define TargetTriple "x86_64-pc-windows-msvc"
+  #define ArchSuffix "x86_64"
+  #define ArchAllowed "x64compatible"
+  #define ArchInstallIn64Bit "x64compatible"
+#elif Arch == "arm64"
+  #define TargetTriple "aarch64-pc-windows-msvc"
+  #define ArchSuffix "aarch64"
+  #define ArchAllowed "arm64"
+  #define ArchInstallIn64Bit "arm64"
+#endif
+
+#ifndef Binary
+  #define Binary "..\..\target\" + TargetTriple + "\release\signex.exe"
+#endif
+
+[Setup]
+AppId={{C4E84F2F-1D41-4FA9-9D8F-67D37CA0F7FC}
+AppName=Signex
+AppVersion={#Version}
+AppVerName=Signex {#Version}
+AppPublisher=alpCaner
+AppPublisherURL=https://github.com/alplabai/signex
+AppSupportURL=https://github.com/alplabai/signex/issues
+AppUpdatesURL=https://github.com/alplabai/signex/releases
+DefaultDirName={autopf}\Signex
+DefaultGroupName=Signex
+AllowNoIcons=yes
+LicenseFile=
+OutputDir=.
+OutputBaseFilename=signex-setup-{#ArchSuffix}-{#Version}
+Compression=lzma2/ultra64
+SolidCompression=yes
+WizardStyle=modern
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
+ArchitecturesAllowed={#ArchAllowed}
+ArchitecturesInstallIn64BitMode={#ArchInstallIn64Bit}
+UninstallDisplayIcon={app}\signex.exe
+UninstallDisplayName=Signex {#Version}
+DisableProgramGroupPage=auto
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "{#Binary}"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\Signex"; Filename: "{app}\signex.exe"
+Name: "{group}\{cm:UninstallProgram,Signex}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\Signex"; Filename: "{app}\signex.exe"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\signex.exe"; Description: "{cm:LaunchProgram,Signex}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Summary
v0.6.x releases shipped bare binaries inside zip/tar.gz which users had to extract and run manually. This PR produces native-style installers per platform:

| OS | Output |
|---|---|
| Windows | \`signex-setup-{x86_64,aarch64}-<version>.exe\` via InnoSetup + portable \`.zip\` fallback |
| macOS   | \`signex-macos-aarch64-<version>.dmg\` with proper \`.app\` bundle + /Applications symlink |
| Linux   | \`signex_<version>_<arch>.deb\` + \`Signex-<version>-<arch>.AppImage\` + \`.tar.gz\` fallback |

## What's included
- \`installer/windows/signex.iss\` — InnoSetup script with Program Files install, Start Menu + optional Desktop shortcut, uninstaller
- \`installer/macos/{Info.plist,build-dmg.sh}\` — .app bundle with KiCad file-type associations, hdiutil DMG packaging
- \`installer/linux/build-deb.sh\` — Debian package with .desktop entry + MIME types
- \`installer/linux/build-appimage.sh\` — AppDir + AppRun + appimagetool

## Release workflow
- Version extracted from tag at job start (leading \`v\` stripped)
- Installer filenames embed the version so users can tell builds apart
- Each builder produces its native installer AND keeps the portable artifact for CI / scripted installs

## Test plan
- Tag v0.6.4 after merge and verify each artifact downloads + installs clean