### PR TITLE
chore(release): CHANGELOG-driven release body + docs-first pre-release hook

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -46,6 +46,26 @@ main                    # Protected. Stable releases only. Tagged vX.Y.Z.
 - Each version gets its own branch from dev when work starts. No placeholder branches.
 - Every merge to main gets a version tag (e.g., `v0.6.0`).
 
+## Release Flow
+
+**Docs-first.** The tagged commit ships to users, so `CHANGELOG.md`, `README.md`, `docs/ROADMAP.md`, and `.claude/CLAUDE.md` must already reflect the new version **before** the tag is created. The release workflow reads the matching `CHANGELOG.md` section as the GitHub Release body — no entry, no rich release notes.
+
+Release cut for version `vX.Y.Z`:
+
+1. **Prep branch** `chore/release-prep-vX.Y.Z` off `dev`:
+   - Add `## [X.Y.Z] — <today>` section in `CHANGELOG.md` with feature-level detail (model on the v0.7.0 entry).
+   - Bump version badge in `README.md`; flip `vX.Y` row in the Roadmap table from In Progress → Done; bump the Status line.
+   - Flip `vX.Y.Z` in the Versioning section of `.claude/CLAUDE.md` from 🔄 → ✅.
+   - Update `docs/internal` submodule progress markers (MASTER_PLAN, ARCHITECTURE if architectural change). Commit inside submodule, push, back-bump the submodule pointer in the outer repo.
+2. **PR** `chore/release-prep-vX.Y.Z` → `dev`, merge.
+3. **PR** `dev` → `main`, merge (CI runs here).
+4. **Tag** `vX.Y.Z` on main's new tip; push the tag.
+   - `release.yml` builds installers and extracts the `CHANGELOG.md` section as the release body.
+   - PostToolUse hook fires and reminds Claude to sync `../signex-website`.
+5. **Close** the `vX.Y.Z` milestone.
+
+The pre-release guard (`.claude/hooks/pre-release-guard.sh`) blocks step 4 with exit 2 if step 1's `CHANGELOG.md` entry is missing, so the docs-first order can't be skipped accidentally.
+
 ## Conventions
 
 - **Coordinate system:** i64 nanometers internally. KiCad uses mm floats — convert at parse/write boundary.
@@ -70,7 +90,7 @@ main                    # Protected. Stable releases only. Tagged vX.Y.Z.
 - v0.4.0 — Schematic Viewer ✅
 - v0.5.0 — Schematic Editor (selection, wire drawing, undo/redo) ✅
 - v0.6.0 — Full Schematic Editor (drag-move, properties editing, placement tools, iced_aw, Active Bar) ✅
-- v0.7.0 — Validation & ERC + multi-window (11 ERC rules, annotation, pin matrix, per-window engine/canvas via `iced::daemon` — undocked tabs are fully interactive) 🔄
+- v0.7.0 — Validation & ERC + multi-window (11 ERC rules, annotation, pin matrix, per-window engine/canvas via `iced::daemon` — undocked tabs are fully interactive) ✅
 - v0.8.0 — Output Generation (PDF, BOM, netlist)
 - v0.9.0 — Library & Polish (symbol/footprint editor, installers)
 - v1.0.0 — Community Preview (schematic-only early access)

--- a/.claude/hooks/on-release-intent.sh
+++ b/.claude/hooks/on-release-intent.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook — fires once per user message.
+#
+# Matches release intents ("release v0.7.0", "cut v0.8.0", etc.) and
+# emits a checklist reminder BEFORE the session starts doing git work,
+# so Claude does the doc sync first instead of finding out only when
+# the pre-release-guard blocks the tag push.
+
+set -euo pipefail
+
+if ! input="$(cat)"; then
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+prompt=$(echo "$input" | jq -r '.prompt // empty')
+[[ -z "$prompt" ]] && exit 0
+
+# Match release intent:
+#   "release v0.7.0", "release 0.7.0", "cut v0.7.0", "ship v0.7.0",
+#   "tag v0.7.0", "publish v0.7.0"
+if ! echo "$prompt" | grep -qiE '(release|cut|ship|tag|publish)[[:space:]]+v?[0-9]+\.[0-9]+\.[0-9]+'; then
+  exit 0
+fi
+
+tag=$(echo "$prompt" | grep -oiE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+# Normalise to leading-v form.
+if [[ "$tag" != v* ]]; then
+  tag="v$tag"
+fi
+version="${tag#v}"
+
+cat <<EOF
+<system-reminder>
+Release intent detected for ${tag}. Before touching git, run the full
+pre-release doc sync in THIS session. The pre-release-guard hook will
+block the tag push if these aren't done first:
+
+1. **CHANGELOG.md** — add a "## [${version}] — <today>" section with
+   feature-level detail. Use the existing v0.7.0 entry as a template.
+2. **README.md** — bump the version badge; flip any ${version} row in
+   "What's next" from in-progress to shipped.
+3. **docs/ROADMAP.md** + **docs/REPOSITORY_AND_CODEBASE.md** — flip the
+   status marker for ${version} (🔄 → ✅), update "current version".
+4. **.claude/CLAUDE.md** — flip ${version} in the Versioning section.
+5. **docs/internal** submodule — MASTER_PLAN.md progress markers,
+   ARCHITECTURE.md if the release shipped an architectural change,
+   other docs/internal/docs/ progress files. Commit inside the
+   submodule on chore/docs-sync-${tag}, push it, back-bump the
+   submodule pointer in the outer repo.
+6. **Commit + PR**: feature branch chore/release-prep-${tag} → dev (PR),
+   then dev → main (PR), then tag ${tag} on main, then push.
+
+Do the website sync (../signex-website, separate repo) as the LAST step —
+handled by the PostToolUse on-release-push.sh hook after the tag push
+succeeds. You don't need to drive that part manually.
+</system-reminder>
+EOF

--- a/.claude/hooks/on-release-push.sh
+++ b/.claude/hooks/on-release-push.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
-# PostToolUse hook — fires after every Bash tool call in this repo.
+# PostToolUse hook — fires after every Bash call in this repo.
 #
-# When a release-tag push is detected, emits a system-reminder so the
-# current Claude Code session immediately syncs:
-#   (A) signex's own public docs (README, ROADMAP, CHANGELOG)
-#   (B) the signex.dev marketing site (separate repo)
+# When a release-tag push succeeds, emits a system-reminder telling the
+# current Claude Code session to sync the signex.dev marketing site.
+# Docs inside signex itself are expected to be correct already —
+# pre-release-guard.sh (PreToolUse) blocks any tag push that doesn't
+# have a CHANGELOG.md entry for that version, so by the time we get
+# here the public-facing repo is already in a consistent state.
 #
-# Runs for everyone who clones signex + opens it in Claude Code — uses
-# whatever Claude Code subscription the contributor is signed into.
-# No API key, no CI billing.
+# The website lives in a separate repo (../signex-website) and is not
+# part of the release commit, so it genuinely needs post-tag syncing.
+#
+# Runs entirely inside whatever Claude Code subscription the
+# contributor is signed into — no API key, no CI billing.
 
 set -euo pipefail
 
@@ -16,7 +20,6 @@ if ! input="$(cat)"; then
   exit 0
 fi
 if ! command -v jq >/dev/null 2>&1; then
-  # Silent no-op if jq is missing — never break a session.
   exit 0
 fi
 
@@ -26,7 +29,6 @@ tool_name=$(echo "$input" | jq -r '.tool_name // empty')
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 [[ -z "$command" ]] && exit 0
 
-# Detect a push that includes a semver tag.
 tag=""
 if echo "$command" | grep -qE 'git[[:space:]]+push[[:space:]].*v[0-9]+\.[0-9]+\.[0-9]+'; then
   tag=$(echo "$command" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
@@ -41,51 +43,29 @@ success=$(echo "$input" | jq -r '.tool_response.success // true')
 
 cat <<EOF
 <system-reminder>
-Release tag ${tag} was just pushed to signex.
+Release tag ${tag} was just pushed. The signex repo itself is already
+in sync (pre-release-guard.sh verified CHANGELOG.md and friends before
+the push), so the only remaining step is the signex.dev marketing site.
 
-Please sync both the public docs and the marketing site now, in this same
-session. Don't wait for a second ask — just do it.
+Sync ../signex-website now, in this same session:
 
-Part A — signex docs, public + internal (this repo + docs/internal submodule):
-  1. Read the release notes (gh release view ${tag} or the matching CHANGELOG entry).
-  2. Update README.md:
-       * Version badge at the top.
-       * "What's next" table, if a roadmap row needs to flip from in-progress to shipped.
-  3. Update docs/ROADMAP.md and docs/REPOSITORY_AND_CODEBASE.md if either
-     references the old version number or status.
-  4. If CHANGELOG.md exists and does not already contain an entry for ${tag},
-     generate one from git log since the previous tag.
-  5. Update the private docs/internal/ submodule. Inside the submodule:
-       * MASTER_PLAN.md — flip completed-milestone checkboxes, bump
-         "current version" or similar status fields.
-       * ARCHITECTURE.md — only if the release shipped an architectural
-         change (e.g. multi-window, new crate, storage format).
-       * Any other progress-tracking files under docs/internal/docs/.
-     Commit inside the submodule on a matching branch, push, then
-     back-bump the submodule pointer in the outer repo.
-  6. Commit the outer repo's README/ROADMAP/CHANGELOG changes + the
-     submodule pointer bump together on a feature branch
-     (chore/docs-sync-${tag}) and open a PR against dev. NEVER push
-     directly to main or dev.
+1. cd to the signex-website repo (typically ../signex-website or
+   ~/Documents/GitHub/signex-website).
+2. Edit index.html:
+     * Hero eyebrow: "v<next-in-dev> in development — open source, Apache-2.0".
+     * JSON-LD softwareVersion → ${tag}.
+     * Roadmap <ol class="timeline"> — previous tl-now → tl-done,
+       next-in-progress → tl-now, refresh descriptions if new features shipped.
+     * "What's in the box" feature cards — only edit if this release
+       materially changed what ships; never duplicate a card.
+3. Preserve HTML structure, class names, whitespace style, and tone.
+4. Do not touch nav, footer, SVG assets, Organization JSON-LD, styles.css,
+   or scripts.js.
+5. Commit on main of signex-website with message
+   "chore(website): sync to ${tag}" and push. The deploy.yml workflow
+   rsyncs the change to Hostinger automatically.
 
-Part B — signex.dev website (separate repo at ../signex-website):
-  1. cd to the signex-website repo (typically ../signex-website or
-     ~/Documents/GitHub/signex-website).
-  2. Edit index.html:
-       * Hero eyebrow: "vX.Y in development — open source, Apache-2.0".
-       * JSON-LD softwareVersion.
-       * Roadmap <ol class="timeline"> — previous tl-now → tl-done,
-         next-in-progress → tl-now, and refresh descriptions if the
-         release notes named new shipped features.
-       * "What's in the box" feature cards — only edit if a release
-         materially changed what ships; never duplicate a card.
-  3. Preserve HTML structure, class names, whitespace style, and tone.
-  4. Do not touch nav, footer, SVG assets, Organization JSON-LD, styles.css,
-     or scripts.js.
-  5. Commit on main of signex-website with message "chore(website): sync
-     to ${tag}" and push. The deploy.yml workflow rsyncs it to Hostinger.
-
-If the user has explicitly deferred either part, skip that part and
-acknowledge. Otherwise proactively do both.
+If the user has explicitly deferred the website update, acknowledge and
+skip. Otherwise proactively do it.
 </system-reminder>
 EOF

--- a/.claude/hooks/pre-release-guard.sh
+++ b/.claude/hooks/pre-release-guard.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# PreToolUse hook — fires before every Bash call in this repo.
+#
+# When a release-tag push is about to happen, this guard verifies that
+# CHANGELOG.md already has an entry for the tag about to ship. If the
+# entry is missing, it blocks the push with exit 2 and tells the
+# current Claude Code session to sync docs first.
+#
+# Pairs with on-release-push.sh (PostToolUse), which handles *website*
+# sync after a successful push — a sync that doesn't need to be in the
+# tagged commit, just needs to fire reliably once the tag is live.
+#
+# The entire flow runs inside whatever Claude Code subscription the
+# contributor is signed into — no API key, no CI billing.
+
+set -euo pipefail
+
+if ! input="$(cat)"; then
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  # Silent no-op if jq is missing — never break a session.
+  exit 0
+fi
+
+tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+[[ "$tool_name" != "Bash" ]] && exit 0
+
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+[[ -z "$command" ]] && exit 0
+
+# Only care about git-push commands that ship a semver tag.
+if ! echo "$command" | grep -qE 'git[[:space:]]+push[[:space:]].*v[0-9]+\.[0-9]+\.[0-9]+'; then
+  # Also catch `git push --tags` which pushes every local tag.
+  if ! echo "$command" | grep -qE 'git[[:space:]]+push[[:space:]].*--tags'; then
+    exit 0
+  fi
+fi
+
+tag=""
+if echo "$command" | grep -qE 'v[0-9]+\.[0-9]+\.[0-9]+'; then
+  tag=$(echo "$command" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+else
+  repo_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+  # Picking the newest local tag that isn't already on the remote — that's
+  # the one about to ship. Falls back to the newest tag of any kind.
+  tag=$(git -C "$repo_dir" tag --list 'v*.*.*' --sort=-creatordate 2>/dev/null | head -1 || true)
+fi
+[[ -z "$tag" ]] && exit 0
+
+version="${tag#v}"
+repo_dir="${CLAUDE_PROJECT_DIR:-$PWD}"
+changelog="$repo_dir/CHANGELOG.md"
+
+if [[ ! -f "$changelog" ]]; then
+  cat >&2 <<EOF
+{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"Refusing to push tag ${tag} — CHANGELOG.md is missing. Create it with an entry for ${tag} before tagging so the release workflow uses the rich notes instead of the 5-bullet auto-generator."}}
+EOF
+  exit 0
+fi
+
+# Look for a heading like "## [0.7.0]" or "## 0.7.0". Accept any format
+# that names the version in a level-2 heading.
+if ! grep -qE "^##\s+\[?${version}\]?" "$changelog"; then
+  cat <<EOF
+<system-reminder>
+Blocked pushing tag ${tag}: CHANGELOG.md has no "## [${version}]" entry.
+
+Release binaries are built from the tagged commit — if CHANGELOG.md and
+README / ROADMAP / CLAUDE.md don't already reflect the new version at
+tag time, source downloads from the GitHub Release carry stale docs and
+the Release body falls back to GitHub's auto-generated PR-title summary
+(usually 3–5 bullets).
+
+Before re-running the push, do all of this in order, in this same session:
+
+1. **CHANGELOG.md** — add a "## [${version}] — <today's date>" section with
+   the full feature-level changelog. Model the formatting on the existing
+   v0.7.0 entry. Include headings for ERC / Editor / Multi-window / Brand
+   / Refactors etc. as appropriate to what shipped.
+2. **README.md** — bump the version badge at the top; flip any "What's
+   next" row for ${version} from in-progress to shipped.
+3. **docs/ROADMAP.md** and **docs/REPOSITORY_AND_CODEBASE.md** — flip
+   ${version}'s status marker (🔄 → ✅) and update "current version" fields.
+4. **.claude/CLAUDE.md** — flip ${version} in the Versioning section from 🔄 to ✅.
+5. **docs/internal submodule** — inside the submodule, update
+   MASTER_PLAN.md progress markers, ARCHITECTURE.md if architectural
+   surface changed, and any other progress-tracking files under
+   docs/internal/docs/. Commit inside the submodule on a matching
+   branch, push it, then bump the submodule pointer in the outer repo.
+6. **Commit all of the above** on a feature branch (chore/release-prep-${tag}),
+   push it, open a PR against dev, get it merged into dev, then cascade
+   dev → main via a normal release PR — and THEN tag and push.
+
+Do the work now. When CHANGELOG.md has the ${version} section committed,
+the re-run of this push will succeed.
+</system-reminder>
+EOF
+  # exit 2 tells Claude Code to treat the stderr/stdout as a feedback
+  # signal and abort the tool call. The reminder is surfaced to the
+  # model automatically so it can drive the sync.
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,26 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/on-release-intent.sh\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-release-guard.sh\""
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,13 +198,62 @@ jobs:
           sha256sum * > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
+      - name: Extract CHANGELOG entry for this tag
+        id: notes
+        shell: bash
+        run: |
+          # Strip the leading "v" so CHANGELOG headings like
+          # "## [0.7.0] — 2026-04-22" match regardless of tag prefix.
+          TAG="${{ steps.version.outputs.version }}"
+          VER="${TAG#v}"
+          if [[ ! -f CHANGELOG.md ]]; then
+            echo "no CHANGELOG.md — will fall back to auto-generated notes"
+            echo "has_notes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Pull the section from "## [VER]" (or "## VER") up to the
+          # next "## " heading. python3 because bash regex across lines
+          # is painful and the runner always has python.
+          python3 - "$VER" > release-notes.md <<'PY'
+          import re, sys
+          from pathlib import Path
+          ver = sys.argv[1]
+          text = Path("CHANGELOG.md").read_text(encoding="utf-8")
+          # Match "## [VER]" or "## VER" as the section heading.
+          pat = re.compile(
+              rf"^##\s+\[?{re.escape(ver)}\]?.*?(?=^##\s+|\Z)",
+              re.DOTALL | re.MULTILINE,
+          )
+          m = pat.search(text)
+          if not m:
+              sys.exit(1)
+          # Drop the heading line — GitHub already renders the tag as
+          # the release title, so the duplicate "## [0.7.0]" on top of
+          # the body looks noisy.
+          body = m.group(0).split("\n", 1)[1] if "\n" in m.group(0) else m.group(0)
+          print(body.strip())
+          PY
+          if [[ -s release-notes.md ]]; then
+            echo "has_notes=true" >> "$GITHUB_OUTPUT"
+            echo "path=release-notes.md" >> "$GITHUB_OUTPUT"
+            echo "----- CHANGELOG extract for $VER -----"
+            cat release-notes.md
+          else
+            echo "no $VER section in CHANGELOG.md — falling back to auto-generated notes"
+            echo "has_notes=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           name: Signex ${{ steps.version.outputs.version }}
           draft: false
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
-          generate_release_notes: true
+          # Prefer the hand-authored CHANGELOG section; fall back to
+          # GitHub's auto-generated PR-title summary if we couldn't
+          # find one (so a missed update never blocks the release).
+          body_path: ${{ steps.notes.outputs.has_notes == 'true' && steps.notes.outputs.path || '' }}
+          generate_release_notes: ${{ steps.notes.outputs.has_notes != 'true' }}
           # Explicit list — the installer stack is what users want, the
           # tarball/zip are fallbacks for scripted installs.
           files: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,147 @@
+# Changelog
+
+All notable changes to Signex ship here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) loosely and [Semantic Versioning](https://semver.org/spec/v2.0.0.html) strictly.
+
+Each release section is authored **before** the `vX.Y.Z` tag is created, so the release workflow picks it up as the GitHub Release body. See `.claude/hooks/pre-release-guard.sh` for the enforcement.
+
+## [Unreleased]
+
+## [0.7.0] — 2026-04-22
+
+The schematic-phase release. Adds ERC & validation, project-wide annotation, real multi-window architecture via `iced::daemon`, per-window engine/canvas, borderless chrome, and a full Signex brand rollout. Every v0.7.x sub-feature ships under this one tag.
+
+### ERC & validation
+
+- New `signex-erc` crate with **11 rule kinds** (`run()` single-sheet, `run_with_project()` cross-sheet)
+- Project-wide ERC across open, cached, and unopened sheets
+- Cross-sheet BadHierSheetPin: parent pins ↔ child hier-labels, both directions
+- ERC markers rendered as overlays — zero KiCad schema drift
+- Messages panel with E/W/I severity pips and per-sheet cached results
+- Altium-style ERC dialog + Preferences panel (per-rule Error / Warning / Info / Off grid)
+- `ErcContext` abstraction + rule metadata infrastructure
+- Shortcuts: `F8` Run ERC, `F9` AutoFocus, `Alt+A` Annotate, `Shift+Alt+A` Reset & Renumber
+
+### Annotation
+
+- Project-wide change list parsed from every sheet in the project
+- Altium two-column Annotate dialog with Reset All / Reset & Renumber / Reset Duplicates
+- Per-symbol lock, draggable modals
+- Power-port skip in both annotation and change list
+- Design → Annotation submenu matching Altium's layout
+
+### Multi-window (`iced::daemon`)
+
+- Borderless main window + OS-decorated secondary windows
+- Modals, tabs, and panels all detach into real OS windows
+- Per-window engine: `document_state.engines: HashMap<PathBuf, Engine>` — every open tab keeps its Engine loaded so undocked tabs edit independently
+- Per-window canvas: `interaction_state.canvases: HashMap<window::Id, SchematicCanvas>` — pan / zoom / selection / render cache per window
+- `document_state.window_active_path: HashMap<window::Id, PathBuf>` — each undocked-tab window can show a different tab
+- Canvas events routed via `CanvasEventInWindow { window_id, event }`
+- macOS: process exits when main window closes
+
+### Editor & tools
+
+- Lasso freehand select (Altium), bbox child-sheet hit, detached-field support
+- Tab / panel drag-reorder with visual feedback
+- Reorder picker polish — gray-X cursor while armed, Esc-cancel visible
+- Unified gray-X placement cursor across every armed tool
+- TAB-during-placement for Line / Rect / Circle / Arc / Polygon (width + fill pre-configured)
+- Editable drawing Properties panel with live DrawingPreview canvas
+- Stroke colour per drawing (round-trips in KiCad format)
+- Erasable numeric `text_input` (per-field `String` buffer)
+- Context-aware menus — Annotate / ERC / Save / Edit gated by `has_schematic` / selection
+- Net-colour pen — strict-hit snap, union-find flood, render-only overrides, undo stack
+- Move / z-order engine commands — `MoveSymbolAbsolute`, `ReorderObjects` (Front / Back / JustAbove / JustBelow)
+- Active Bar — BringToFront / SendToBack + BringToFrontOf / SendToBackOf pickers
+- Reset Duplicate Designators (project-wide, undoable for open tabs)
+- Arc (3-click) + Polygon (click-by-click) placement tools
+
+### Hierarchical sheets
+
+- Double-click a sheet block → opens the child schematic
+- Sheet-pin snaps to all four edges of the hierarchical sheet block
+- Sheet-pin interactions + Altium label-style option
+
+### Borderless chrome & brand
+
+- Custom title bar: wordmark + menus + drag zone + search bar + min / max / close
+- Per-monitor v2 DPI manifest (no bitmap stretching on hi-DPI)
+- Roboto UI font (panels / toolbars / menus / dialogs); Iosevka stays the canvas font
+- Windows 11 DWM rounded corners + drop shadow via `DwmSetWindowAttribute` (silent no-op on Win10 and non-Windows)
+- Diagonal resize hit zones (NW / NE / SW / SE) via Stack overlay — keeps content y-origin natural
+- Header logo bumped 74×24 → 96×31 for readability
+
+### Icons & installer
+
+- Signex brand SVGs (mark, wordmark, logo variants)
+- Panton Bold wordmark regenerated from actual font (not fallback outlines)
+- Tighter `signex-mark.svg` viewBox: S fills ~97 % of icon canvas (was ~58 %)
+- Regenerated installer artifacts: Windows `.ico` (multi-size), macOS `.icns`, Linux PNGs
+- Runtime window icon embedded via `iced::window::Icon`
+- `signex.exe` icon + DPI manifest embedded at build time via `winres`
+- Pure-Python fallback for `build-icons.sh` — `tools/build_icons.py`, no rsvg-convert / magick / inkscape needed
+
+### Refactors
+
+- `signex-engine/src/lib.rs` split into semantic modules
+- `kicad-writer` migrated from `wln!` string formatting to full SExpr AST (`kicad-parser/sexpr_builder` → `kicad-writer/sexpr_render`)
+- Named constants for PCB magic numbers; `lib_symbol` unit round-trip fix
+- Wire rendering chains connected segments into polylines (rounded corners)
+- Font-size constants corrected, hidden refs and pin-name rotation fixed
+
+### Merged-in dependencies
+
+- v0.6.1 render fixes (font scale, pin numbers, power-ref visibility)
+- v0.6.2 AST sexpr pipeline
+- v0.6.3 macOS runner pin (`macos-14`)
+- v0.6.4 per-OS installers (`.exe`, `.dmg`, `.deb`, `.AppImage`)
+- Node.js 24 Actions bump
+
+### Performance
+
+- `expand_to_net` is now `O(N)` via quantised `HashSet` (was `O(P²·N²)`)
+
+[Full changelog](https://github.com/alplabai/signex/compare/v0.6.4...v0.7.0) · [Release artifacts](https://github.com/alplabai/signex/releases/tag/v0.7.0)
+
+## [0.6.4] — 2026-04-20
+
+First cumulative release since v0.6.1. Rolls in the abandoned v0.6.2 and the CI-fix-only v0.6.3.
+
+### Installers (new)
+
+- **Windows** — `signex-setup-x86_64-0.6.4.exe` / `signex-setup-aarch64-0.6.4.exe` via InnoSetup. Installs to `Program Files`, adds Start Menu entry and optional Desktop shortcut, proper uninstaller. Portable `.zip` also attached for scripted installs.
+- **macOS** — `signex-macos-aarch64-0.6.4.dmg` with a full `Signex.app` bundle and `/Applications` drag-target. Registered as the editor for `.kicad_sch` / `.kicad_pro` files.
+- **Linux** — native `.deb` (with `.desktop` entry + MIME types) plus a portable `.AppImage`. `.tar.gz` fallback also attached.
+
+### KiCad pipeline refactor (from v0.6.2)
+
+- AST-based S-expression pipeline in `kicad-parser` / `kicad-writer` with a property-metadata layer. More robust round-trip, less fragile than prior ad-hoc string handling.
+- Named constants replace the magic numbers scattered through `signex-types`, `kicad-parser`, and `kicad-writer`.
+
+### Release pipeline fixes (from v0.6.3)
+
+- `aarch64-apple-darwin` pinned to `macos-14` so GitHub's `macos-latest` queue stalls don't take the whole release down (symptom that killed v0.6.2).
+
+### Upgrade notes
+
+No `.kicad_sch` / `.kicad_pcb` breaking changes — opening a v0.6.1 project in v0.6.4 is a clean round-trip. If you were on v0.6.2 or v0.6.3, nothing additional to migrate — v0.6.4 is a superset.
+
+[Full changelog](https://github.com/alplabai/signex/compare/v0.6.1...v0.6.4)
+
+## [0.6.3] — 2026-04-20 _(superseded by 0.6.4)_
+
+- fix(ci): pin aarch64-apple-darwin to macos-14 (#34)
+
+[Full changelog](https://github.com/alplabai/signex/compare/v0.6.2...v0.6.3)
+
+## [0.6.1] — 2026-04-20
+
+Render + KiCad round-trip fixes (font scale, pin numbers, power-ref visibility).
+
+[Full changelog](https://github.com/alplabai/signex/compare/v0.6.0...v0.6.1)
+
+## [0.6.0] — 2026-04-18
+
+Full Schematic Editor — drag-move, properties editing, placement tools, iced_aw, Active Bar.
+
+[Full changelog](https://github.com/alplabai/signex/commits/v0.6.0)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <p align="center">
   <a href="https://github.com/alplabai/signex/blob/dev/LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="License"></a>
-  <a href="https://github.com/alplabai/signex/milestone/7"><img src="https://img.shields.io/badge/version-v0.7--dev-orange.svg" alt="Version"></a>
+  <a href="https://github.com/alplabai/signex/releases/tag/v0.7.0"><img src="https://img.shields.io/badge/version-v0.7.0-green.svg" alt="Version"></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/rust-1.80%2B-orange.svg" alt="Rust"></a>
   <a href="https://github.com/alplabai/signex/discussions"><img src="https://img.shields.io/badge/discussions-join-brightgreen.svg" alt="Discussions"></a>
 </p>
@@ -37,7 +37,7 @@ get a better editor without leaving the ecosystem they trust.
 - **Signex Pro** (subscription) — adds Signal AI (Claude-powered design
   copilot), real-time collaboration, and Signex 365 cloud PLM
 
-> **Status:** Early development — v0.7 (ERC validation + multi-window editing)
+> **Status:** Early development — v0.7.0 shipped; next up v0.8 (PDF / BOM / netlist output)
 > in progress. [Join the discussion](https://github.com/alplabai/signex/discussions)
 > or check the [roadmap](#roadmap).
 
@@ -147,8 +147,8 @@ cargo clippy --workspace -- -D warnings  # Lint
 | Schematic Viewer — render all elements, multi-sheet nav | v0.4 | Done |
 | Schematic Editor — select, move, wire, undo/redo, save | v0.5 | Done |
 | Full SCH Editor — copy/paste, labels, components, Active Bar | v0.6 | Done |
-| Validation + Multi-Window — ERC, annotation, pin matrix, undockable tabs | v0.7 | **In Progress** |
-| Output — PDF, BOM, netlist | v0.8 | |
+| Validation + Multi-Window — ERC, annotation, pin matrix, undockable tabs | v0.7 | Done |
+| Output — PDF, BOM, netlist | v0.8 | **In Progress** |
 | Library & Polish — symbol/footprint editor, installers | v0.9 | |
 | **Community Preview** — schematic-only editor | **v1.0** | |
 | PCB Viewer — GPU rendering, layers, cross-probe | v2.0 | |


### PR DESCRIPTION
## Problem

v0.7.0 shipped with two cosmetic regressions worth fixing before v0.8 so the next cut is clean:

1. **5-bullet release body** — `release.yml` used `generate_release_notes: true`, which only picks up PR titles between tags. v0.6.4 → v0.7.0 had exactly 5 PRs, so 5 bullets was all GitHub produced, even though 78 commits and ~30 feature headings landed.
2. **Stale docs in the tagged commit** — README, ROADMAP, CLAUDE.md all still said v0.7 🔄 In Progress at the tagged commit. Only `on-release-push.sh` (PostToolUse) reminded anyone to sync docs, and it fires *after* the tag is pushed — too late to affect the tagged snapshot or the source archives in the GitHub Release.

## Fix — docs-first, CHANGELOG-driven

### CHANGELOG.md (new)

Keep a Changelog format. v0.7.0 entry mirrors the updated GitHub release body (feature-level detail across ERC, annotation, multi-window, brand, etc.). v0.6.0..v0.6.4 backfilled so history isn't lost.

### release.yml

Extracts the matching \`## [X.Y.Z]\` section from \`CHANGELOG.md\` via a small Python script and passes it as \`body_path\` to \`softprops/action-gh-release\`. Falls back to \`generate_release_notes: true\` only when no matching section exists, so a missed update never blocks a release.

### Hooks (all run inside the contributor's signed-in Claude Code — no API key, no CI billing)

| Phase | Hook | Purpose |
|---|---|---|
| UserPromptSubmit | \`on-release-intent.sh\` | Matches \"release vX.Y.Z\" / \"cut\" / \"ship\" / \"tag\" / \"publish\" and emits the ordered release checklist upfront |
| PreToolUse (Bash) | \`pre-release-guard.sh\` | Detects \`git push ... vX.Y.Z\` / \`--tags\` and blocks with exit 2 if \`CHANGELOG.md\` is missing an \`## [X.Y.Z]\` section |
| PostToolUse (Bash) | \`on-release-push.sh\` | Simplified to website-only sync — signex docs are already correct at tag time |

### CLAUDE.md

New **Release Flow** section documents the ordered process (prep branch → dev PR → main PR → tag → website sync), so even a reader without Claude Code sees it. v0.7.0 marker flipped 🔄 → ✅.

### README.md

Version badge v0.7-dev → v0.7.0, v0.7 row In Progress → Done, v0.8 flipped to In Progress.

## Test plan

- [x] \`release.yml\` Python extract matches \`## [0.7.0]\` heading format
- [x] Hook scripts are marked executable (\`100755\`)
- [x] CHANGELOG.md v0.7.0 section matches the edited GitHub Release body
- [ ] Manually trigger \`pre-release-guard.sh\` (feed a fake tag push on stdin, confirm exit 2 + reminder); deferred — the guard will self-verify on v0.8's release