### PR TITLE
fix: ad-hoc codesign macOS .app for Apple Silicon launch (#49)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -91,6 +91,7 @@ The pre-release guard (`.claude/hooks/pre-release-guard.sh`) blocks step 4 with 
 - v0.5.0 — Schematic Editor (selection, wire drawing, undo/redo) ✅
 - v0.6.0 — Full Schematic Editor (drag-move, properties editing, placement tools, iced_aw, Active Bar) ✅
 - v0.7.0 — Validation & ERC + multi-window (11 ERC rules, annotation, pin matrix, per-window engine/canvas via `iced::daemon` — undocked tabs are fully interactive) ✅
+- v0.7.1 — macOS Apple-Silicon launch fix (ad-hoc codesign the shipped `.app` bundle, #49) ✅
 - v0.8.0 — Output Generation (PDF, BOM, netlist)
 - v0.9.0 — Library & Polish (symbol/footprint editor, installers)
 - v1.0.0 — Community Preview (schematic-only early access)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ Each release section is authored **before** the `vX.Y.Z` tag is created, so the 
 
 ## [Unreleased]
 
+## [0.7.1] — 2026-04-24
+
+Patch release addressing a macOS launch failure on Apple Silicon.
+
+### Fixed
+
+- **macOS (Apple Silicon) cannot launch the shipped `.app`** (#49). The
+  DMG-packaged bundle was unsigned; arm64 macOS refuses to execute any
+  binary without at least an ad-hoc signature, so users on M-series
+  Macs saw "Signex is damaged and can't be opened" / "cannot be
+  verified" immediately after dragging the app to Applications. The
+  installer script now ad-hoc signs the bundle (`codesign --force
+  --deep --sign -`) as part of DMG assembly. This is the minimum
+  viable shipping state for arm64 until a Developer ID certificate
+  and notarisation credentials are wired into CI.
+
+### Known issues / workarounds
+
+- The DMG still carries the downloaded-from-internet quarantine flag,
+  so first-launch users will see a "cannot be verified" Gatekeeper
+  prompt. Bypass it with **right-click → Open** on the app icon the
+  first time, or run
+  `xattr -dr com.apple.quarantine /Applications/Signex.app` in
+  Terminal. Subsequent launches work without prompts.
+
 ## [0.7.0] — 2026-04-22
 
 The schematic-phase release. Adds ERC & validation, project-wide annotation, real multi-window architecture via `iced::daemon`, per-window engine/canvas, borderless chrome, and a full Signex brand rollout. Every v0.7.x sub-feature ships under this one tag.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <p align="center">
   <a href="https://github.com/alplabai/signex/blob/dev/LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="License"></a>
-  <a href="https://github.com/alplabai/signex/releases/tag/v0.7.0"><img src="https://img.shields.io/badge/version-v0.7.0-green.svg" alt="Version"></a>
+  <a href="https://github.com/alplabai/signex/releases/tag/v0.7.1"><img src="https://img.shields.io/badge/version-v0.7.1-green.svg" alt="Version"></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/rust-1.80%2B-orange.svg" alt="Rust"></a>
   <a href="https://github.com/alplabai/signex/discussions"><img src="https://img.shields.io/badge/discussions-join-brightgreen.svg" alt="Discussions"></a>
 </p>
@@ -37,7 +37,7 @@ get a better editor without leaving the ecosystem they trust.
 - **Signex Pro** (subscription) — adds Signal AI (Claude-powered design
   copilot), real-time collaboration, and Signex 365 cloud PLM
 
-> **Status:** Early development — v0.7.0 shipped; next up v0.8 (PDF / BOM / netlist output)
+> **Status:** Early development — v0.7.1 shipped (macOS Apple-Silicon launch fix); next up v0.8 (PDF / BOM / netlist output)
 > in progress. [Join the discussion](https://github.com/alplabai/signex/discussions)
 > or check the [roadmap](#roadmap).
 

--- a/installer/macos/build-dmg.sh
+++ b/installer/macos/build-dmg.sh
@@ -41,6 +41,23 @@ if [[ -f "$SCRIPT_DIR/Signex.icns" ]]; then
     /usr/libexec/PlistBuddy -c "Add :CFBundleIconFile string Signex" "$CONTENTS/Info.plist" || true
 fi
 
+# Ad-hoc codesign the bundle.
+#
+# Apple Silicon (arm64) macOS refuses to launch any executable that
+# isn't at least ad-hoc signed — the user sees "Signex is damaged and
+# can't be opened" or "cannot be verified" (issue #49 on an M3 Pro).
+# Ad-hoc signing (`--sign -`) doesn't need a Developer ID certificate
+# and doesn't vouch for origin, but it's enough for the kernel to
+# accept the binary. Users still need to right-click → Open on first
+# launch to bypass Gatekeeper's unidentified-developer warning because
+# the DMG carries the downloaded-from-internet quarantine flag; that's
+# documented in the release notes / README.
+#
+# Notarisation is the proper long-term fix but needs an Apple Developer
+# Program membership + signing credentials in CI secrets. Until then
+# ad-hoc signing is the minimum viable shipping state for arm64.
+codesign --force --deep --sign - "$APP_BUNDLE"
+
 # Assemble the DMG contents: the .app plus a symlink to /Applications so
 # the user can drag-and-drop to install.
 DMG_STAGING="$WORK_DIR/dmg-staging"


### PR DESCRIPTION
Closes #49.

## Problem

v0.7.0 on macOS Apple Silicon (tested on M3 Pro, macOS Sequoia
26.3.1) refuses to launch — users see "Signex is damaged and can't
be opened" or "cannot be verified" the moment they drag the app to
Applications and double-click.

Root cause: the DMG-packaged \`.app\` bundle in \`installer/macos/build-dmg.sh\`
was built with **no code signature at all**. On Apple Silicon, the
kernel refuses to exec any binary that doesn't carry at least an
ad-hoc signature — this is stricter than on Intel macOS and has been
the default since Big Sur on arm64.

## Fix

One-line addition to \`installer/macos/build-dmg.sh\` — ad-hoc sign
the bundle before DMG assembly:

\`\`\`bash
codesign --force --deep --sign - "\$APP_BUNDLE"
\`\`\`

\`--sign -\` is the ad-hoc identity — no Developer ID certificate,
no CI secrets, no Apple Developer Program fee. It only proves the
bundle hasn't been tampered with since build; it does not vouch for
the origin. That's the minimum the kernel needs to run the binary.

Users still see a one-time Gatekeeper prompt ("Apple could not
verify ...") because the DMG carries the \`com.apple.quarantine\`
xattr from being downloaded via a browser. The CHANGELOG and
release notes document the **right-click → Open** workaround for
first launch.

## Follow-up (not in this PR)

Proper fix is Developer ID signing + notarisation. Requires:

1. Apple Developer Program membership (\$99/year).
2. Developer ID Application certificate exported as \`.p12\`, base64
   encoded into a GitHub Secret (e.g. \`APPLE_DEVELOPER_ID_CERT\`).
3. An app-specific password / notary API key as another secret.
4. Workflow steps to import the cert into a temporary keychain,
   sign with \`--sign "Developer ID Application: ..."\`, then
   \`xcrun notarytool submit --wait\` and \`xcrun stapler staple\`.

Opening a separate tracking issue for that would be the right
next step — not urgent once this ad-hoc patch unblocks users.

## Files touched

- \`installer/macos/build-dmg.sh\` — the actual fix.
- \`CHANGELOG.md\` — new v0.7.1 section with problem + workaround note.
- \`README.md\` — version badge + Status line bumped to v0.7.1.
- \`.claude/CLAUDE.md\` — v0.7.1 row added to the Versioning ladder.

## After merge

Tag \`v0.7.1\` on main's new tip. The \`release.yml\` workflow will:

1. Rebuild \`signex-macos-aarch64-0.7.1.dmg\` with the ad-hoc sign
   step applied.
2. Pull the \`## [0.7.1]\` section from \`CHANGELOG.md\` as the
   GitHub Release body (includes the right-click → Open guidance).
3. Windows / Linux artifacts rebuild from the same tag with no
   behaviour change on those platforms.

## Test plan

- [ ] CI builds all four platform targets cleanly on the tag push.
- [ ] Download \`signex-macos-aarch64-0.7.1.dmg\`, install, right-click → Open. Should reach the main window.
- [ ] Confirm \`codesign --verify --verbose /Applications/Signex.app\` reports \`satisfies its Designated Requirement\` with \`adhoc\` signing.
- [ ] Windows + Linux artifacts unchanged behaviourally.