### PR TITLE
fix(render): use one em-size for schematic text size + offsets

### DIFF
--- a/crates/signex-engine/src/selection.rs
+++ b/crates/signex-engine/src/selection.rs
@@ -509,7 +509,8 @@ impl Engine {
                     "Position".into(),
                     format!("{:.2}, {:.2} mm", ref_text.position.x, ref_text.position.y),
                 ));
-                info.push(("Rotation".into(), format!("{:.0}°", ref_text.rotation)));
+                let effective_rot = (symbol.rotation + ref_text.rotation).rem_euclid(360.0);
+                info.push(("Rotation".into(), format!("{effective_rot:.0}°")));
                 info.push((
                     "Text Size".into(),
                     format!(
@@ -551,7 +552,8 @@ impl Engine {
                         value_text.position.x, value_text.position.y
                     ),
                 ));
-                info.push(("Rotation".into(), format!("{:.0}°", value_text.rotation)));
+                let effective_rot = (symbol.rotation + value_text.rotation).rem_euclid(360.0);
+                info.push(("Rotation".into(), format!("{effective_rot:.0}°")));
                 info.push((
                     "Text Size".into(),
                     format!(

--- a/crates/signex-render/src/lib.rs
+++ b/crates/signex-render/src/lib.rs
@@ -17,9 +17,13 @@ pub const IOSEVKA: iced::Font = iced::Font::with_name("Iosevka");
 pub use signex_types::schematic::SCHEMATIC_PT_TO_MM;
 pub use signex_types::schematic::SCHEMATIC_TEXT_MM;
 
-/// KiCad stroke font stores "size" as cap-height; Iced TrueType uses em-square.
-/// Cap height ≈ 72 % of em-square → scale up by 1/0.72 so visual sizes match KiCad.
-pub const STROKE_FONT_SCALE: f32 = 1.0 / 0.72;
+/// KiCad stroke font stores "size" as cap-height; Iced TrueType uses em-square
+/// (cap height ≈ 72 % of em). To render a stroke-font size at the same visual
+/// cap height, we draw it at em = size / 0.72. Use this value for BOTH the
+/// canvas font size AND any offset / hit-test math so they stay in sync —
+/// applying the scale only at render sites (as a separate multiplier on
+/// `screen_font`) silently breaks label/pin/text anchors.
+pub const SCHEMATIC_TEXT_EM_MM: f64 = SCHEMATIC_TEXT_MM / 0.72;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PowerPortStyle {

--- a/crates/signex-render/src/schematic/label.rs
+++ b/crates/signex-render/src/schematic/label.rs
@@ -27,9 +27,9 @@ pub fn draw_label(
     // All schematic canvas text renders at 10 pt (1.8 mm, cap-height basis)
     // regardless of what the source file declares. Overriding here instead of
     // mutating the stored value keeps save round-trips stable.
-    let font_size_mm = crate::SCHEMATIC_TEXT_MM;
+    let font_size_mm = crate::SCHEMATIC_TEXT_EM_MM;
     let _stored = label.font_size;
-    let screen_font = transform.world_len(font_size_mm).abs() * crate::STROKE_FONT_SCALE;
+    let screen_font = transform.world_len(font_size_mm).abs();
     if screen_font < 1.0 {
         return;
     }
@@ -180,7 +180,7 @@ fn draw_net_label(
     color: Color,
     screen_font: f32,
 ) {
-    let offset = schematic_text_offset_net(label, crate::SCHEMATIC_TEXT_MM);
+    let offset = schematic_text_offset_net(label, crate::SCHEMATIC_TEXT_EM_MM);
     draw_spin_text(frame, label, transform, color, screen_font, offset, false);
 }
 
@@ -423,7 +423,7 @@ pub enum SpinStyle {
 /// AABB for a port (Global/Hierarchical) that wraps the whole pentagon shape,
 /// anchored on the connection point and extending forward into the body.
 fn port_shape_aabb(label: &Label) -> signex_types::schematic::Aabb {
-    let fs = crate::SCHEMATIC_TEXT_MM;
+    let fs = crate::SCHEMATIC_TEXT_EM_MM;
     let h = fs * 1.4;
     let arrow_w = h * 0.5;
     let pad = fs * 0.3;
@@ -469,7 +469,7 @@ pub fn label_text_aabb(label: &Label) -> signex_types::schematic::Aabb {
     ) {
         return port_shape_aabb(label);
     }
-    let fs = crate::SCHEMATIC_TEXT_MM;
+    let fs = crate::SCHEMATIC_TEXT_EM_MM;
     // Tight text width — slightly under half the font size per glyph matches
     // the actual rendered widths for most monospace-ish labels.
     // Iced's `fill_text(size = S)` reserves roughly S of vertical space for

--- a/crates/signex-render/src/schematic/mod.rs
+++ b/crates/signex-render/src/schematic/mod.rs
@@ -965,8 +965,8 @@ fn draw_builtin_power(
     };
     let label_y = (pin_len + body_extent + 0.25) * dir;
     // 10 pt — the canvas-wide default — matching Altium.
-    let font_size_mm = crate::SCHEMATIC_TEXT_MM;
-    let screen_font = transform.world_len(font_size_mm).abs() * crate::STROKE_FONT_SCALE;
+    let font_size_mm = crate::SCHEMATIC_TEXT_EM_MM;
+    let screen_font = transform.world_len(font_size_mm).abs();
     if screen_font >= 1.0 {
         let (tx, ty) = instance_transform(sym, &signex_types::schematic::Point::new(0.0, label_y));
         let sp = transform.to_screen_point(tx, ty);

--- a/crates/signex-render/src/schematic/pin.rs
+++ b/crates/signex-render/src/schematic/pin.rs
@@ -182,8 +182,8 @@ fn draw_pin(
     // Small circle at the connection point (endpoint) — removed, KiCad doesn't draw this
 
     // Pin name is drawn near the symbol-side end of the pin.
-    let font_size_mm = crate::SCHEMATIC_TEXT_MM;
-    let screen_font = transform.world_len(font_size_mm).abs() * crate::STROKE_FONT_SCALE;
+    let font_size_mm = crate::SCHEMATIC_TEXT_EM_MM;
+    let screen_font = transform.world_len(font_size_mm).abs();
 
     if screen_font >= 1.0
         && lib.show_pin_names

--- a/crates/signex-render/src/schematic/selection.rs
+++ b/crates/signex-render/src/schematic/selection.rs
@@ -132,7 +132,7 @@ fn draw_text_prop_selection(
     transform: &ScreenTransform,
 ) {
     use signex_types::schematic::{HAlign, VAlign};
-    let fs = crate::SCHEMATIC_TEXT_MM;
+    let fs = crate::SCHEMATIC_TEXT_EM_MM;
     // `visible_char_count` drops KiCad `{slash}`-style escapes; Iosevka's
     // advance width is ≈0.55 em, so use the same coefficient the text
     // renderer uses below so bbox and glyphs line up.
@@ -200,9 +200,9 @@ fn draw_power_port_selection(frame: &mut canvas::Frame, sym: &Symbol, transform:
     } else {
         0.0
     };
-    let label_extent = crate::SCHEMATIC_TEXT_MM * 1.2; // cap + descender
+    let label_extent = crate::SCHEMATIC_TEXT_EM_MM * 1.2; // cap + descender
     let half_w =
-        1.8_f64.max(sym.value.chars().count() as f64 * crate::SCHEMATIC_TEXT_MM * 0.55 * 0.5);
+        1.8_f64.max(sym.value.chars().count() as f64 * crate::SCHEMATIC_TEXT_EM_MM * 0.55 * 0.5);
 
     // In lib-local Y (before Y-flip in instance_transform): the pin stub
     // starts at the anchor (y = 0) and extends toward the body. Keep the

--- a/crates/signex-render/src/schematic/symbol.rs
+++ b/crates/signex-render/src/schematic/symbol.rs
@@ -491,8 +491,7 @@ fn draw_graphic_text(
 
     // Force 10 pt (1.8 mm) for all symbol-embedded graphic text.
     let _stored = font_size;
-    let base_size = transform.world_len(crate::SCHEMATIC_TEXT_MM);
-    let size = base_size.abs() * crate::STROKE_FONT_SCALE;
+    let size = transform.world_len(crate::SCHEMATIC_TEXT_EM_MM).abs();
     if size < 1.0 {
         return;
     }

--- a/crates/signex-render/src/schematic/text.rs
+++ b/crates/signex-render/src/schematic/text.rs
@@ -190,9 +190,9 @@ pub fn draw_text_note(
     color: Color,
 ) {
     // Fixed 10 pt (1.8 mm) for all canvas text — matches Altium default.
-    let font_size_mm = crate::SCHEMATIC_TEXT_MM;
+    let font_size_mm = crate::SCHEMATIC_TEXT_EM_MM;
     let _stored = note.font_size;
-    let screen_font = transform.world_len(font_size_mm).abs() * crate::STROKE_FONT_SCALE;
+    let screen_font = transform.world_len(font_size_mm).abs();
     if screen_font < 1.0 {
         return;
     }
@@ -265,9 +265,9 @@ pub fn draw_text_prop(
     }
 
     // All symbol ref/val text renders at 10 pt (1.8 mm).
-    let font_size_mm = crate::SCHEMATIC_TEXT_MM;
+    let font_size_mm = crate::SCHEMATIC_TEXT_EM_MM;
     let _stored = prop.font_size;
-    let screen_font = transform.world_len(font_size_mm).abs() * crate::STROKE_FONT_SCALE;
+    let screen_font = transform.world_len(font_size_mm).abs();
     if screen_font < 1.0 {
         return;
     }


### PR DESCRIPTION
## Summary

Fixes a label/pin/field positioning regression introduced in 61728d8 (Apr 20) and papered over by tuning commits 2c1cdc4, b488cff, 5fe0dc8, fea63db. Text was rendered 39% larger than the offset math accounted for; labels floated above wires, port labels drifted away from arrows, hierarchical-label text slid past its anchor.

## Root cause

61728d8 introduced \`STROKE_FONT_SCALE = 1.0 / 0.72\` and multiplied it into \`screen_font\` at every render site (\`label.rs\`, \`pin.rs\`, \`text.rs\`, \`symbol.rs\`, \`schematic/mod.rs\`) so Iced's TrueType em-square output would visually match KiCad's stroke-font cap height. But the offset / hit-test math in \`schematic_text_offset_{net,hier,global}\`, \`approx_text_width_mm\`, \`port_shape_aabb\`, \`label_text_aabb\`, and \`selection.rs\` kept using the unscaled \`SCHEMATIC_TEXT_MM\`. Render used 1.764mm em, offsets used 1.27mm — the mismatch accumulated as visibly-off anchors.

## Fix

Collapse both inputs into one constant: \`SCHEMATIC_TEXT_EM_MM = SCHEMATIC_TEXT_MM / 0.72\`. Use it as the font size for BOTH \`world_len(...)\` and offset math in \`signex-render\`. \`SCHEMATIC_TEXT_MM\` itself stays 1.27mm for KiCad wire-format parse/write fidelity.

On-screen text size is unchanged: \`world_len(1.764 mm) ≡ old world_len(1.27) × 1/0.72\`. Only anchors move back to where they were before Apr 20.

\`STROKE_FONT_SCALE\` removed — only used by \`signex-render\` and superseded.

Also included: Properties panel "Rotation" readout for Reference / Value fields now composes with \`symbol.rotation\` (Altium convention — shows on-screen angle, not lib-frame angle). Previously a rotated symbol's field read \`0°\` even when visibly drawn at 90°.

## Scope discipline

SVG export (\`signex-output\`) has its own parallel offset path that still operates on \`SCHEMATIC_TEXT_MM\`. Canvas vs SVG alignment should be reviewed on next PDF export; out of scope for this fix to avoid expanding the blast radius into output code that #47 just touched. Tracked as part of #52 (move scale to parse/write boundary + per-font metrics).

## Test plan

- [x] \`cargo build --workspace\` — green
- [x] \`cargo test --workspace --no-fail-fast\` — all green (49 passing)
- [x] Manual verification on live schematic (launched release build):
  - [x] Net labels sit flush on wires at 0° / 90° / 180° / 270°
  - [x] Port labels (Global / Hierarchical) wrap pentagon correctly
  - [x] Power-port labels position correctly under body
  - [x] Pin names/numbers at rotated symbols aligned
  - [x] Reference / Value field selection rectangles wrap glyphs tightly
  - [x] Reference Field Rotation readout matches visible angle (Altium convention)

## Follow-up

#52 — move the cap-height ↔ em-square translation to the KiCad parse/write boundary and read cap height per-font via \`ttf-parser\`. Makes the renderer 1:1 with stored sizes and handles non-Iosevka fonts correctly.