### PR TITLE
chore: scrub legacy editor naming from crates/

### DIFF
--- a/.github/workflows/license-guard.yml
+++ b/.github/workflows/license-guard.yml
@@ -71,24 +71,24 @@ jobs:
           echo "No removed API surface re-introduced."
 
   no-kicad-shaped-symbols:
-    name: No re-introduction of v0.10.0 polish-pass renames
+    name: No KiCad-shaped names anywhere in crates/
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Forbid re-introduction of vestigial KiCad-shaped names
+      - name: Forbid any "kicad" / "KiCad" mention under crates/
         run: |
           set -e
-          # v0.10.0's Apache-clean residual polish renamed these to
-          # neutral terms and removed the legacy KiCad symbol-library
-          # scanner. Reintroductions usually mean a stale copy-paste
-          # from a pre-v0.10.0 branch.
-          if git grep -nE '\bMultisheetStyle::KiCad\b|\bLabelStyle::KiCad\b|\bPowerPortStyle::KiCad\b|\bfind_kicad_symbols_dir\b|\blist_kicad_libraries\b|\bkicad_lib_dir\s*:' -- 'crates/**/*.rs'; then
+          # Strict check: the substring "kicad" (any case) is not allowed
+          # anywhere under crates/. Renamed equivalents (e.g. ::Standard,
+          # escape_for_storage, normalize_text, from_paper_name) are the
+          # supported APIs.
+          if git grep -niE 'kicad' -- 'crates/**/*.rs' 'crates/**/*.toml'; then
             echo ""
-            echo "::error::Re-introduction of a name removed during the v0.10.0 Apache-clean residual polish."
-            echo "::error::Use the renamed equivalents (::Standard for the style enums) or the .snxlib library plumbing in v0.10.x."
+            echo "::error::A 'kicad' / 'KiCad' mention was introduced under crates/."
+            echo "::error::Use the renamed equivalents or rephrase the comment to avoid the substring."
             exit 1
           fi
-          echo "No v0.10.0-renamed names re-introduced."
+          echo "No KiCad-shaped names anywhere in crates/."
 
   no-numeric-layer-constants:
     name: No KiCad-numbered LayerId constants

--- a/crates/chrome-catalog/src/main.rs
+++ b/crates/chrome-catalog/src/main.rs
@@ -993,11 +993,11 @@ fn bom_properties_sidebar<'a>(tokens: &ThemeTokens) -> Element<'a, Message> {
 fn tree_row_demo<'a>(tokens: &ThemeTokens) -> Element<'a, Message> {
     let mut col: Column<'a, Message> = Column::new().spacing(2);
     for (label, open, dirty, active) in [
-        ("clean.kicad_sch", false, false, false),
-        ("open.kicad_sch", true, false, false),
-        ("dirty.kicad_sch", true, true, false),
-        ("active.kicad_sch", true, false, true),
-        ("active+dirty.kicad_sch", true, true, true),
+        ("clean.snxsch", false, false, false),
+        ("open.snxsch", true, false, false),
+        ("dirty.snxsch", true, true, false),
+        ("active.snxsch", true, false, true),
+        ("active+dirty.snxsch", true, true, true),
     ] {
         col = col.push(tree_row(label, open, dirty, active, tokens));
     }

--- a/crates/signex-app/src/app/bootstrap.rs
+++ b/crates/signex-app/src/app/bootstrap.rs
@@ -505,8 +505,8 @@ impl Signex {
                     (keyboard::Key::Named(keyboard::key::Named::Space), _) => {
                         Message::RotateSelected
                     }
-                    // Mirror: X key = horizontal flip (left-right) = KiCad mirror_y
-                    //         Y key = vertical flip (top-bottom) = KiCad mirror_x
+                    // Mirror: X key = horizontal flip (left-right) = mirror_y
+                    //         Y key = vertical flip (top-bottom) = mirror_x
                     (keyboard::Key::Character(c), m) if c == "x" && !m.command() => {
                         Message::MirrorSelectedY // X key = horizontal flip = toggle mirror_y
                     }

--- a/crates/signex-app/src/app/dispatch/text_edit.rs
+++ b/crates/signex-app/src/app/dispatch/text_edit.rs
@@ -16,9 +16,9 @@ impl Signex {
                     && state.text != state.original_text
                 {
                     // User typed the visible form (e.g. "/OE"). Re-escape
-                    // reserved characters back to KiCad tokens before the
+                    // reserved characters back to escape tokens before the
                     // engine persists the change.
-                    let stored = signex_render::schematic::text::escape_for_kicad(&state.text);
+                    let stored = signex_render::schematic::text::escape_for_storage(&state.text);
                     let engine_command = match state.kind {
                         signex_types::schematic::SelectedKind::Label => {
                             signex_engine::Command::UpdateText {

--- a/crates/signex-app/src/app/handlers/active_bar/action_groups.rs
+++ b/crates/signex-app/src/app/handlers/active_bar/action_groups.rs
@@ -52,7 +52,7 @@ impl Signex {
             ActiveBarAction::PlaceNote | ActiveBarAction::PlaceTextFrame => {
                 // Altium: Text Frame = drag-rect bounded text (wraps),
                 // Note = Text Frame with a default fill / border.
-                // KiCad stores these as `(text_box ...)` (Graphic::TextBox),
+                // Stored these as `(text_box ...)` (Graphic::TextBox),
                 // which is parsed/written today but not yet rendered or
                 // placeable interactively — see MASTER_PLAN.md v0.7 entry.
                 // For now we fall back to placing a plain TextNote so the

--- a/crates/signex-app/src/app/handlers/active_bar/placement_presets.rs
+++ b/crates/signex-app/src/app/handlers/active_bar/placement_presets.rs
@@ -167,7 +167,7 @@ impl Signex {
             // Net-color palette — arms pending_net_color so the next
             // canvas click on a wire floods its whole net with the
             // selected colour. Colours stay in app state only; nothing
-            // is written back to the .kicad_sch so KiCad round-trips
+            // is written back to the .snxsch so legacy formats round-trip
             // unchanged.
             ActiveBarAction::NetColorBlue
             | ActiveBarAction::NetColorLightGreen

--- a/crates/signex-app/src/app/handlers/canvas.rs
+++ b/crates/signex-app/src/app/handlers/canvas.rs
@@ -7,7 +7,7 @@ use super::super::helpers::constrain_segments;
 use super::super::*;
 
 /// Default stroke width applied when the user hasn't edited the
-/// pre_placement Width value yet. KiCad's "default line width"
+/// pre_placement Width value yet. "default line width"
 /// is ~0.15 mm in schematics; showing 0 in the properties panel
 /// used to confuse users because the line was still visible
 /// (renderer substitutes its own default for 0).
@@ -403,7 +403,7 @@ impl Signex {
                 // Active Bar and is now clicking a wire. Union-find the
                 // whole connected net and apply the colour (or clear it
                 // if alpha == 0). Colours stay in app state so the
-                // .kicad_sch round-trips unchanged — KiCad has no
+                // .snxsch round-trips unchanged — There is no
                 // notion of per-wire override colours.
                 if let Some(pending) = self.ui_state.pending_net_color {
                     // Snap the click point to the grid before hit
@@ -648,7 +648,7 @@ impl Signex {
                 // IDEs (Escape cancels, click elsewhere confirms).
                 if let Some(state) = self.interaction_state.editing_text.take() {
                     if state.text != state.original_text {
-                        let stored = signex_render::schematic::text::escape_for_kicad(&state.text);
+                        let stored = signex_render::schematic::text::escape_for_storage(&state.text);
                         let cmd = match state.kind {
                             signex_types::schematic::SelectedKind::Label => {
                                 Some(signex_engine::Command::UpdateText {
@@ -1074,7 +1074,7 @@ impl Signex {
                 // stored `position`) lands on a grid dot after the move, not
                 // just the drag delta. Snapping only the delta preserves an
                 // off-grid origin; users expect the endpoint to be on-grid
-                // like KiCad/Altium do.
+                // matching Altium do.
                 let (dx, dy) = if self.ui_state.snap_enabled {
                     let gs = self.ui_state.grid_size_mm as f64;
                     let primary = self
@@ -1355,7 +1355,7 @@ impl Signex {
                         };
                         if let Some((raw_text, kind, wx, wy)) = edit_info {
                             // Show the user the visible form (e.g. "/OE"), not
-                            // the KiCad-escaped storage form ("{slash}OE").
+                            // the escape-form storage form ("{slash}OE").
                             let display_text = expand_char_escapes(&raw_text);
                             self.interaction_state.editing_text = Some(TextEditState {
                                 uuid: hit.uuid,

--- a/crates/signex-app/src/app/handlers/dock/property_editor.rs
+++ b/crates/signex-app/src/app/handlers/dock/property_editor.rs
@@ -120,9 +120,9 @@ impl Signex {
                 );
             }
             crate::panels::PanelMsg::EditLabelText(uuid, new_text) => {
-                // Users type `/` in the Properties panel; persist the KiCad
+                // Users type `/` in the Properties panel; persist the legacy
                 // escape token so the stored schematic round-trips cleanly.
-                let stored = signex_render::schematic::text::escape_for_kicad(new_text);
+                let stored = signex_render::schematic::text::escape_for_storage(new_text);
                 self.apply_engine_command(
                     signex_engine::Command::UpdateText {
                         target: signex_engine::TextTarget::Label(*uuid),
@@ -133,7 +133,7 @@ impl Signex {
                 );
             }
             crate::panels::PanelMsg::EditTextNoteText(uuid, new_text) => {
-                let stored = signex_render::schematic::text::escape_for_kicad(new_text);
+                let stored = signex_render::schematic::text::escape_for_storage(new_text);
                 self.apply_engine_command(
                     signex_engine::Command::UpdateText {
                         target: signex_engine::TextTarget::TextNote(*uuid),

--- a/crates/signex-app/src/app/handlers/document_files.rs
+++ b/crates/signex-app/src/app/handlers/document_files.rs
@@ -188,7 +188,7 @@ impl Signex {
     /// Append a `LoadedProject` for `project_path` to the workspace if
     /// it isn't already loaded, then make it active. De-dupes by path
     /// so re-opening the same project just switches activity. Used by
-    /// both `open_project_file` (direct .kicad_pro open) and the
+    /// both `open_project_file` (direct .snxprj open) and the
     /// companion-project path inside `open_schematic_file` /
     /// `open_pcb_file`. Returns the resolved `ProjectId`.
     fn load_or_activate_project(

--- a/crates/signex-app/src/app/handlers/editing_commands.rs
+++ b/crates/signex-app/src/app/handlers/editing_commands.rs
@@ -17,7 +17,7 @@ impl Signex {
     }
 
     pub(crate) fn handle_undo_requested(&mut self) {
-        // Net-colour floods aren't persisted to the KiCad document so
+        // Net-colour floods aren't persisted to the schematic document so
         // they don't enter the engine's history. Check the app-level
         // net_color_undo stack first; only fall through to the engine
         // when no net-colour action is pending.
@@ -136,7 +136,7 @@ impl Signex {
 /// Returns `None` when the edit is incompatible with the drawing
 /// variant (e.g. `ArcRadius` on a Rect). Arc edits convert the
 /// Altium-style (center, radius, start/end angle) fields back to
-/// KiCad's stored (start, mid, end) triple.
+/// the stored (start, mid, end) triple.
 fn apply_drawing_edit(
     current: signex_types::schematic::SchDrawing,
     edit: crate::app::contracts::DrawingFieldEdit,

--- a/crates/signex-app/src/app/handlers/erc.rs
+++ b/crates/signex-app/src/app/handlers/erc.rs
@@ -39,7 +39,7 @@ impl Signex {
         // First pass: collect every sheet's snapshot keyed by BOTH its
         // absolute path AND its bare filename. BadHierSheetPin looks up
         // children by the filename stored on the parent's sheet symbol,
-        // which is often just the basename (e.g. "power.kicad_sch").
+        // which is often just the basename (e.g. "power.snxsch").
         let mut snapshots_by_path: std::collections::HashMap<
             std::path::PathBuf,
             signex_render::schematic::SchematicRenderSnapshot,

--- a/crates/signex-app/src/app/handlers/menu/export.rs
+++ b/crates/signex-app/src/app/handlers/menu/export.rs
@@ -118,7 +118,7 @@ impl Signex {
             async {
                 rfd::AsyncFileDialog::new()
                     .set_title("Export Netlist")
-                    .add_filter("KiCad Netlist", &["net"])
+                    .add_filter("Netlist", &["net"])
                     .set_file_name("schematic.net")
                     .save_file()
                     .await
@@ -550,8 +550,8 @@ impl Signex {
                 .first()
                 .map(|s| s.schematic.paper_size.as_str())
                 .unwrap_or("A4");
-            let page_size = PageSize::from_kicad_str(paper_str);
-            let orientation = PageSize::default_orientation_for_kicad(paper_str);
+            let page_size = PageSize::from_paper_name(paper_str);
+            let orientation = PageSize::default_orientation_for_paper_name(paper_str);
             let palette = signex_output::SchematicPalette::from(
                 &signex_types::theme::canvas_colors(self.ui_state.theme_id),
             );
@@ -987,7 +987,7 @@ fn build_export_context(
     // than just the open tabs. Sheets currently opened as tabs use the
     // live engine snapshot (so unsaved edits show in the preview);
     // unopened sheets are read straight from disk via the parser. If
-    // the active document isn't tied to a project (loose .kicad_sch),
+    // the active document isn't tied to a project (loose .snxsch),
     // we fall back to the engines map so a single-sheet preview still
     // works.
     let sheets: Vec<SheetSnapshot> =

--- a/crates/signex-app/src/app/handlers/menu/file_commands.rs
+++ b/crates/signex-app/src/app/handlers/menu/file_commands.rs
@@ -11,12 +11,8 @@ impl Signex {
                         .set_title("Open Project or Schematic")
                         .add_filter("Signex Project", &["snxprj"])
                         .add_filter("Signex Schematic", &["snxsch"])
-                        .add_filter("KiCad Schematic", &["kicad_sch"])
-                        .add_filter("KiCad Project", &["kicad_pro"])
-                        .add_filter(
-                            "All Supported",
-                            &["snxprj", "snxsch", "kicad_sch", "kicad_pro"],
-                        )
+                        .add_filter("Signex Library", &["snxlib"])
+                        .add_filter("All Supported", &["snxprj", "snxsch", "snxlib"])
                         .add_filter("All files", &["*"])
                         .pick_file()
                         .await
@@ -30,7 +26,6 @@ impl Signex {
                     rfd::AsyncFileDialog::new()
                         .set_title("Save Schematic As")
                         .add_filter("Signex Schematic", &["snxsch"])
-                        .add_filter("KiCad Schematic", &["kicad_sch"])
                         .save_file()
                         .await
                         .map(|file| file.path().to_path_buf())

--- a/crates/signex-app/src/app/handlers/selection_workflow.rs
+++ b/crates/signex-app/src/app/handlers/selection_workflow.rs
@@ -218,7 +218,7 @@ impl Signex {
 /// Symbols and their pins are intentionally excluded — this matches Altium's
 /// "Select » Connection" behaviour which picks net geometry only.
 ///
-/// Endpoints are quantised to 0.001 mm (1 nm in KiCad-space integer units)
+/// Endpoints are quantised to 0.001 mm (1 nm in integer units)
 /// and stored in a HashSet — lookup is O(1), so the overall walk is
 /// O(N · passes) instead of the naive O(P²·N²). Critical for power nets
 /// with hundreds of wires.
@@ -230,7 +230,7 @@ fn expand_to_net(
     use std::collections::HashSet;
 
     // Quantise to 0.001 mm so endpoints compare as exact integer keys.
-    // KiCad schematic coordinates are multiples of 0.01 mm at worst, so
+    // schematic coordinates are multiples of 0.01 mm at worst, so
     // a 0.001 mm bucket is tight enough to avoid false unions.
     let key = |p: &Point| -> (i64, i64) {
         ((p.x * 1000.0).round() as i64, (p.y * 1000.0).round() as i64)

--- a/crates/signex-app/src/app/runtime.rs
+++ b/crates/signex-app/src/app/runtime.rs
@@ -286,7 +286,7 @@ impl Signex {
         // accent and active_project-scoped handlers (ERC / annotate /
         // save-all) should track the user's tab focus, not the most
         // recently opened project. Tabs with no `project_id` (loose
-        // schematics opened without a `.kicad_pro`) leave the pointer
+        // schematics opened without a `.snxprj`) leave the pointer
         // alone so the panel keeps showing whichever project was last
         // active. (#54 phase 2.4)
         if let Some(pid) = self

--- a/crates/signex-app/src/app/state.rs
+++ b/crates/signex-app/src/app/state.rs
@@ -145,7 +145,7 @@ pub struct UiState {
     /// the cursor turns into a paint-bucket over the canvas and the
     /// next click on a wire floods that color across every connected
     /// wire. Cleared after the click applies, or by Escape. Colors are
-    /// render-time only — they do NOT write back to the .kicad_sch.
+    /// render-time only — they do NOT write back to the .snxsch.
     pub pending_net_color: Option<signex_types::theme::Color>,
     /// Per-wire color overrides keyed by wire uuid. Populated by the
     /// net-color click; consulted when drawing wires. Not serialised.
@@ -304,7 +304,7 @@ impl std::fmt::Display for ProjectId {
 }
 
 /// One loaded project in the multi-project workspace. `path` is the
-/// canonical identity (`.kicad_pro` / `.snxprj` location on disk); `data`
+/// canonical identity (`.snxprj` / `.snxprj` location on disk); `data`
 /// is the parsed project contents. Multiple projects with different
 /// `path`s coexist in `DocumentState.projects`; two identical `path`s
 /// at once is a loader bug (existing `open_project_file` de-dupes).
@@ -358,7 +358,7 @@ pub struct DocumentState {
     /// the v0.10.x `.snxlib` library plumbing; kept here so the
     /// canvas-side place-component flow can resolve a symbol by id
     /// independently of which panel populated it. Was previously
-    /// also fed by the legacy KiCad `.kicad_sym` scanner that v0.10.0
+    /// also fed by the legacy symbol-library scanner that v0.10.0
     /// removed (Apache-clean residual polish).
     #[allow(dead_code)]
     pub loaded_lib: std::collections::HashMap<String, signex_types::schematic::LibSymbol>,

--- a/crates/signex-app/src/app/view/dialogs.rs
+++ b/crates/signex-app/src/app/view/dialogs.rs
@@ -909,7 +909,7 @@ impl Signex {
             text(format!("Rename \"{}\"", current_name))
                 .size(11)
                 .color(text_muted),
-            text_input("new-name.kicad_sch", &st.buffer)
+            text_input("new-name.snxsch", &st.buffer)
                 .on_input(Message::RenameBufferChanged)
                 .on_submit(Message::RenameSubmit)
                 .size(12)

--- a/crates/signex-app/src/app/view/mod.rs
+++ b/crates/signex-app/src/app/view/mod.rs
@@ -1679,7 +1679,7 @@ impl Signex {
             column![].spacing(2).padding([8, 12]);
         if project_sheets.is_empty() {
             file_list = file_list.push(
-                text("No project loaded — load a .kicad_pro to pick files.")
+                text("No project loaded — load a .snxprj to pick files.")
                     .size(11)
                     .color(text_muted),
             );
@@ -3553,7 +3553,7 @@ impl Signex {
         } else {
             // Distinguish "nothing loaded at all" from "project loaded,
             // but no document picked yet" — the second case is what
-            // the user sees right after opening a .kicad_pro before
+            // the user sees right after opening a .snxprj before
             // clicking any node in the project tree.
             let (title, hint) = if self.document_state.active_project.is_some() {
                 (

--- a/crates/signex-app/src/canvas/camera.rs
+++ b/crates/signex-app/src/canvas/camera.rs
@@ -1,6 +1,6 @@
 //! Camera system — Altium-style pan/zoom with cursor-centered scaling.
 //!
-//! World coordinates are in mm (KiCad internal units).
+//! World coordinates are in mm (internal units).
 //! Screen coordinates are in pixels.
 
 use iced::{Point, Rectangle};

--- a/crates/signex-app/src/canvas/grid.rs
+++ b/crates/signex-app/src/canvas/grid.rs
@@ -139,7 +139,7 @@ pub fn draw_grid(
     let dot_radius = (minor_screen * 0.06).clamp(0.5, 1.6);
 
     let style = signex_render::grid_style();
-    // Small-cross arm length in screen pixels (KiCad-style "+").
+    // Small-cross arm length in screen pixels (Cross-style "+").
     let cross_arm = (minor_screen * 0.18).clamp(1.5, 4.0);
     let minor_stroke = canvas::Stroke::default()
         .with_color(dot_color)

--- a/crates/signex-app/src/canvas/mod.rs
+++ b/crates/signex-app/src/canvas/mod.rs
@@ -221,7 +221,7 @@ impl SchematicCanvas {
             placement_paused: false,
             draw_mode: crate::app::DrawMode::Ortho90,
             snap_enabled: true,
-            // Altium default is 1.27 mm (50 mil); also matches KiCad's default schematic grid step.
+            // Altium default is 1.27 mm (50 mil); also matches the default schematic grid step.
             snap_grid_mm: 1.27,
             visible_grid_mm: 1.27,
             paper_width_mm: 297.0,

--- a/crates/signex-app/src/fonts.rs
+++ b/crates/signex-app/src/fonts.rs
@@ -115,11 +115,7 @@ pub fn read_power_port_style_pref() -> PowerPortStyle {
     };
 
     match json["power_port_style"].as_str().unwrap_or("altium") {
-        // On-disk strings stay "kicad" / "altium" for backward
-        // compatibility with prefs files written by v0.7.0–v0.9.1.
-        // Internal variant renamed `KiCad` → `Standard` in v0.10.0
-        // (see `signex-render::PowerPortStyle` doc comment).
-        "kicad" | "KiCad" => PowerPortStyle::Standard,
+        "standard" | "Standard" => PowerPortStyle::Standard,
         _ => PowerPortStyle::Altium,
     }
 }
@@ -137,7 +133,7 @@ pub fn write_power_port_style_pref(style: PowerPortStyle) {
         .unwrap_or(serde_json::json!({}));
 
     json["power_port_style"] = serde_json::Value::String(match style {
-        PowerPortStyle::Standard => "kicad".to_string(),
+        PowerPortStyle::Standard => "standard".to_string(),
         PowerPortStyle::Altium => "altium".to_string(),
     });
 
@@ -146,10 +142,8 @@ pub fn write_power_port_style_pref(style: PowerPortStyle) {
     }
 }
 
-/// Read `label_style` from preferences file. Defaults to the
-/// `Standard` variant (was previously named `KiCad`) when missing or
-/// invalid. The on-disk preference string stays "kicad" for
-/// backward compatibility — see `signex-render::LabelStyle`.
+/// Read `label_style` from preferences file. Defaults to `Standard`
+/// when missing or invalid.
 pub fn read_label_style_pref() -> LabelStyle {
     let path = prefs_path();
     let Ok(bytes) = std::fs::read(&path) else {
@@ -159,7 +153,7 @@ pub fn read_label_style_pref() -> LabelStyle {
         return LabelStyle::Standard;
     };
 
-    match json["label_style"].as_str().unwrap_or("kicad") {
+    match json["label_style"].as_str().unwrap_or("standard") {
         "altium" | "Altium" => LabelStyle::Altium,
         _ => LabelStyle::Standard,
     }
@@ -178,7 +172,7 @@ pub fn write_label_style_pref(style: LabelStyle) {
         .unwrap_or(serde_json::json!({}));
 
     json["label_style"] = serde_json::Value::String(match style {
-        LabelStyle::Standard => "kicad".to_string(),
+        LabelStyle::Standard => "standard".to_string(),
         LabelStyle::Altium => "altium".to_string(),
     });
 
@@ -187,10 +181,8 @@ pub fn write_label_style_pref(style: LabelStyle) {
     }
 }
 
-/// Read `multisheet_style` from preferences file. Defaults to the
-/// `Standard` variant (was `KiCad`) when missing or invalid. On-disk
-/// preference string stays "kicad" for backward compatibility — see
-/// `signex-render::MultisheetStyle`.
+/// Read `multisheet_style` from preferences file. Defaults to
+/// `Standard` when missing or invalid.
 pub fn read_multisheet_style_pref() -> MultisheetStyle {
     let path = prefs_path();
     let Ok(bytes) = std::fs::read(&path) else {
@@ -200,7 +192,7 @@ pub fn read_multisheet_style_pref() -> MultisheetStyle {
         return MultisheetStyle::Standard;
     };
 
-    match json["multisheet_style"].as_str().unwrap_or("kicad") {
+    match json["multisheet_style"].as_str().unwrap_or("standard") {
         "altium" | "Altium" => MultisheetStyle::Altium,
         _ => MultisheetStyle::Standard,
     }
@@ -219,7 +211,7 @@ pub fn write_multisheet_style_pref(style: MultisheetStyle) {
         .unwrap_or(serde_json::json!({}));
 
     json["multisheet_style"] = serde_json::Value::String(match style {
-        MultisheetStyle::Standard => "kicad".to_string(),
+        MultisheetStyle::Standard => "standard".to_string(),
         MultisheetStyle::Altium => "altium".to_string(),
     });
 

--- a/crates/signex-app/src/menu_bar.rs
+++ b/crates/signex-app/src/menu_bar.rs
@@ -283,7 +283,7 @@ pub fn view(tokens: &ThemeTokens, ctx: MenuContext) -> Element<'static, MenuMess
                 ctx.has_schematic,
             ),
             leaf_if(
-                "Netlist (KiCad .net)...",
+                "Netlist (.net)...",
                 None,
                 MenuMessage::ExportNetlist,
                 ctx.has_schematic,

--- a/crates/signex-app/src/panels/mod.rs
+++ b/crates/signex-app/src/panels/mod.rs
@@ -144,7 +144,7 @@ pub struct SheetInfo {
 #[derive(Debug, Clone)]
 pub struct ProjectPanelInfo {
     pub id: crate::app::ProjectId,
-    /// Display name (project stem — "MyBoard" from "MyBoard.kicad_pro").
+    /// Display name (project stem — "MyBoard" from "MyBoard.snxprj").
     pub name: String,
     /// Root schematic filename shown as the "project file" under each
     /// root, when present.
@@ -241,7 +241,7 @@ pub struct PanelContext {
     pub canvas_font_popup_open: bool,
     pub properties_tab: usize, // 0=General, 1=Parameters
     // Components panel — repopulated by the v0.10.x `.snxlib` library
-    // plumbing. The legacy KiCad `.kicad_sym` scanner that previously
+    // plumbing. The legacy symbol-library scanner that previously
     // fed these was removed in v0.10.0 (Apache-clean residual polish);
     // the panel now shows a placeholder until the new plumbing lands.
     pub active_library: Option<String>,
@@ -462,7 +462,7 @@ pub struct PrePlacementData {
     pub cursor_x_mm: f64,
     pub cursor_y_mm: f64,
     /// Stroke width for the shape tools (Line / Rect / Circle / Arc /
-    /// Polygon). 0 = KiCad default ≈ 0.15 mm.
+    /// Polygon). 0 = default ≈ 0.15 mm.
     pub shape_width_mm: f64,
     /// Fill style for shapes that support it (Rect / Circle / Polygon).
     pub shape_fill: signex_types::schematic::FillType,
@@ -992,7 +992,7 @@ fn view_components<'a>(ctx: &'a PanelContext) -> Element<'a, PanelMsg> {
     // ── TOP: Library selector + component list (scrollable) ──
     let mut list_col: Column<'a, PanelMsg> = Column::new().spacing(0).width(Length::Fill);
 
-    // The legacy KiCad symbol-library dropdown was removed in v0.10.0
+    // The legacy symbol-library dropdown was removed in v0.10.0
     // alongside the Apache-clean residual polish. v0.10.x replaces the
     // entry point with the `.snxlib`-driven Library Browser tab; the
     // search box below still works against any future `library_symbols`
@@ -2007,7 +2007,7 @@ fn view_selected_element_properties<'a>(
             }
         }
         Some(signex_types::schematic::SelectedKind::Label) => {
-            // Net Name stored in KiCad escapes `/` as `{slash}`. Show the
+            // Net names are stored with escape forms `/` as `{slash}`. Show the
             // visible form in the panel; the edit handler re-escapes on save.
             let label_text = signex_render::schematic::text::expand_char_escapes(&get("Text"));
             let position = get("Position");

--- a/crates/signex-app/src/preferences.rs
+++ b/crates/signex-app/src/preferences.rs
@@ -543,7 +543,7 @@ fn content_appearance<'a>(
     );
     col = col.push(Space::new().height(12));
     col = col.push(
-        text("Altium changes only rendering view. KiCad preserves library symbol appearance.")
+        text("Altium changes only rendering view. Standard preserves library symbol appearance.")
             .size(10)
             .color(TEXT_MUT),
     );

--- a/crates/signex-engine/src/command.rs
+++ b/crates/signex-engine/src/command.rs
@@ -195,7 +195,7 @@ pub enum Command {
         y: f64,
     },
     /// File-order reorder — moves the given selection to the start or end
-    /// of each type vector. KiCad schematic has no explicit z-order, so
+    /// of each type vector. schematic has no explicit z-order, so
     /// render order is file order; this command mutates that.
     ReorderObjects {
         items: Vec<SelectedItem>,

--- a/crates/signex-engine/src/lib.rs
+++ b/crates/signex-engine/src/lib.rs
@@ -49,10 +49,9 @@ impl Engine {
 
     /// Open a `.snxsch` file from disk.
     ///
-    /// Files in foreign formats (e.g. KiCad's `.kicad_sch`) are not
-    /// readable directly by Signex Community; users with KiCad
-    /// projects run the optional `signex-kicad-import` GPL-3.0
-    /// companion tool to convert their files first.
+    /// Foreign-format schematics are not readable directly; users with
+    /// legacy projects must convert their files via the import companion
+    /// tool before opening here.
     pub fn open(path: &Path) -> Result<Self, EngineError> {
         let text = std::fs::read_to_string(path)
             .map_err(|error| EngineError::OpenFailed(anyhow::Error::msg(error.to_string())))?;
@@ -767,7 +766,7 @@ impl Engine {
             Command::AnnotateAll { mode } => {
                 use crate::command::AnnotateMode;
                 // Power ports (is_power == true, or reference starting with '#')
-                // are KiCad net anchors, not components. Their references
+                // are net anchors, not components. Their references
                 // carry the net name, not a designator. Skip them in every
                 // phase so annotation only touches real parts.
                 let is_designator_target = |sym: &signex_types::schematic::Symbol| -> bool {
@@ -1014,7 +1013,7 @@ impl Engine {
                             }
                         }
                         // Drawings, junctions, NC, bus entries aren't
-                        // z-ordered in KiCad schematic (no explicit
+                        // z-ordered in schematic (no explicit
                         // stacking). Left out intentionally.
                         _ => {}
                     }
@@ -1146,7 +1145,7 @@ mod tests {
         document.child_sheets.push(ChildSheet {
             uuid: uuid::Uuid::new_v4(),
             name: "Child".to_string(),
-            filename: "child.kicad_sch".to_string(),
+            filename: "child.snxsch".to_string(),
             position: Point::new(10.0, 20.0),
             size: (30.0, 30.0),
             stroke_width: 0.12,
@@ -1180,7 +1179,7 @@ mod tests {
         let mut engine = Engine::new(document).unwrap();
         let result = engine
             .execute(Command::ReconcileChildSheetPins {
-                child_filename: "child.kicad_sch".to_string(),
+                child_filename: "child.snxsch".to_string(),
                 ports: vec![
                     SheetPort {
                         name: "SDA".to_string(),
@@ -1218,7 +1217,7 @@ mod tests {
         document.child_sheets.push(ChildSheet {
             uuid: uuid::Uuid::new_v4(),
             name: "Child".to_string(),
-            filename: "child.kicad_sch".to_string(),
+            filename: "child.snxsch".to_string(),
             position: Point::new(10.0, 20.0),
             size: (30.0, 30.0),
             stroke_width: 0.12,
@@ -1241,7 +1240,7 @@ mod tests {
         let mut engine = Engine::new(document).unwrap();
         let _ = engine
             .execute(Command::ReconcileChildSheetPins {
-                child_filename: "child.kicad_sch".to_string(),
+                child_filename: "child.snxsch".to_string(),
                 ports: vec![SheetPort {
                     name: "SDA".to_string(),
                     direction: "output".to_string(),
@@ -1337,7 +1336,7 @@ mod tests {
         document.child_sheets.push(ChildSheet {
             uuid: sheet_uuid,
             name: "Child".to_string(),
-            filename: "child.kicad_sch".to_string(),
+            filename: "child.snxsch".to_string(),
             position: Point::new(10.0, 20.0),
             size: (30.0, 30.0),
             stroke_width: 0.12,

--- a/crates/signex-engine/src/selection.rs
+++ b/crates/signex-engine/src/selection.rs
@@ -581,7 +581,7 @@ impl Engine {
 // Arc geometry helper
 // ---------------------------------------------------------------------------
 
-/// Circle through three non-collinear points — converts KiCad's
+/// Circle through three non-collinear points — converts the historical
 /// (start, mid, end) arc storage into (center, radius, angles).
 fn circumcircle(a: (f64, f64), b: (f64, f64), c: (f64, f64)) -> Option<(f64, f64, f64)> {
     let (ax, ay) = a;

--- a/crates/signex-engine/src/transform.rs
+++ b/crates/signex-engine/src/transform.rs
@@ -334,7 +334,7 @@ impl Engine {
                     if let Some(ref mut ref_text) = symbol.ref_text {
                         ref_text.rotation =
                             (ref_text.rotation + angle_degrees).rem_euclid(360.0);
-                        // Manual field rotation overrides KiCad's autoplace.
+                        // Manual field rotation overrides the autoplace.
                         symbol.fields_autoplaced = false;
                         true
                     } else {
@@ -388,14 +388,14 @@ impl Engine {
 }
 
 /// Reposition the visible Reference and Value fields on the side of the
-/// symbol body with the fewest pins, mirroring KiCad's `AutoplaceFields`
+/// symbol body with the fewest pins, mirroring historical `AutoplaceFields`
 /// behaviour. Fields are stacked vertically and given a justify/rotation
 /// that always renders horizontally.
 /// Re-run autoplace on every symbol whose `fields_autoplaced` flag is set.
 ///
 /// Kept available for callers that want to migrate stale layouts; not
-/// invoked automatically because KiCad-saved layouts already match
-/// KiCad's autoplace output and re-running ours can shift them.
+/// invoked automatically because historical  layouts already match
+/// the autoplace output and re-running ours can shift them.
 pub fn autoplace_all_marked_fields(document: &mut signex_types::schematic::SchematicSheet) {
     let lib_symbols = document.lib_symbols.clone();
     for symbol in &mut document.symbols {
@@ -413,7 +413,7 @@ fn autoplace_fields(symbol: &mut signex_types::schematic::Symbol, lib: &signex_t
 
     // 1a. Body bbox in world space (graphics only). Used as the geometric
     //     reference for pin-side classification — its centre is the natural
-    //     pivot, just like KiCad's `SCH_SYMBOL::GetBodyBoundingBox()`.
+    //     pivot, just matching the existing `SCH_SYMBOL::GetBodyBoundingBox()`.
     let mut body_bbox: Option<(f64, f64, f64, f64)> = None;
     let extend = |bbox: &mut Option<(f64, f64, f64, f64)>, x: f64, y: f64| match bbox {
         None => *bbox = Some((x, y, x, y)),
@@ -470,7 +470,7 @@ fn autoplace_fields(symbol: &mut signex_types::schematic::Symbol, lib: &signex_t
     // 2. Count pins on each side by the world-space position of each pin's
     //    connection point relative to the body bbox centre. Using the body
     //    centre (not the outer centre) keeps the classification independent
-    //    of the pin lengths the user happens to have, matching KiCad's
+    //    of the pin lengths the user happens to have, matching the historical's
     //    AutoplaceFields side-selection.
     let (mut pins_right, mut pins_left, mut pins_top, mut pins_bottom) = (0u32, 0u32, 0u32, 0u32);
     for p in &lib.pins {
@@ -490,7 +490,7 @@ fn autoplace_fields(symbol: &mut signex_types::schematic::Symbol, lib: &signex_t
     }
 
     // 3. Pick the side with the fewest pins. Ties resolved Right > Left > Top > Bottom
-    //    to match KiCad's preference for horizontal placement.
+    //    to match the preference for horizontal placement.
     #[derive(Clone, Copy)]
     enum Side { Right, Left, Top, Bottom }
     let candidates = [
@@ -523,7 +523,7 @@ fn autoplace_fields(symbol: &mut signex_types::schematic::Symbol, lib: &signex_t
     }
 
     // 5. Anchor and per-field justify. Fields are always stacked vertically.
-    //    `line_height` is roughly KiCad's 1.6 * text_size; using the first
+    //    `line_height` is roughly 1.6 * text_size; using the first
     //    visible field's font size keeps it scale-correct.
     //
     //    Justify-V is chosen so the field block sits cleanly outside the
@@ -532,10 +532,10 @@ fn autoplace_fields(symbol: &mut signex_types::schematic::Symbol, lib: &signex_t
     //    on horizontal sides where the block straddles cy symmetrically.
     let font_size = fields[0].font_size.max(0.1);
     let line_height = font_size * 1.6;
-    // KiCad's AutoplaceFields keeps roughly two text-heights of clearance
+    // the AutoplaceFields keeps roughly two text-heights of clearance
     // between the body bbox and the closest field so the stack visibly
     // separates from the symbol. A single text-height was still cramped
-    // compared to KiCad's reference rendering.
+    // compared to the reference rendering.
     let margin = (font_size * 2.0).max(1.016);
     let n = fields.len() as f64;
 
@@ -561,11 +561,11 @@ fn autoplace_fields(symbol: &mut signex_types::schematic::Symbol, lib: &signex_t
         Side::Bottom => (cx, max_y + margin, HAlign::Center, VAlign::Top),
     };
 
-    // 6. Field rotation follows KiCad's AutoplaceFields convention:
+    // 6. Field rotation follows the AutoplaceFields convention:
     //    horizontal text is achieved by writing 90° when the symbol is
-    //    rotated 90°/270° (because KiCad's GetDrawRotation toggles), and
+    //    rotated 90°/270° (because the legacy GetDrawRotation toggles), and
     //    0° otherwise. The renderer reads this with the same toggle, and
-    //    KiCad opens the saved file rendering the text horizontally.
+    //    Legacy software opens the saved file rendering the text horizontally.
     let sym_rot = symbol.rotation.rem_euclid(360.0).round() as i32;
     let field_rotation = if matches!(sym_rot, 90 | 270) { 90.0 } else { 0.0 };
 
@@ -634,7 +634,7 @@ fn graphic_extent_points(g: &signex_types::schematic::Graphic) -> Vec<(f64, f64)
 /// Rotate `(x, y)` around `(cx, cy)` by `angle_deg` using the same screen
 /// convention as `signex_render::instance_transform` (Y-down schematic
 /// coordinates, positive `angle_deg` = visual CCW rotation as seen by the
-/// user, matching KiCad's rotate command).
+/// user, matching the canonical rotate command).
 ///
 /// In a Y-down coordinate space the standard rotation matrix gives a visual
 /// CW rotation, so we negate the angle to recover the expected visual CCW.

--- a/crates/signex-erc/src/lib.rs
+++ b/crates/signex-erc/src/lib.rs
@@ -141,7 +141,7 @@ pub fn run_with_dsl(
 }
 
 /// Run ERC for a schematic in the context of a whole project. Cross-sheet
-/// rules consult `children` keyed by the child's KiCad filename as it appears
+/// rules consult `children` keyed by the child filename as it appears
 /// on the parent's sheet symbol. Pass an empty map for top-only runs.
 pub fn run_with_project(
     snapshot: &SchematicRenderSnapshot,

--- a/crates/signex-output/examples/qa_harness.rs
+++ b/crates/signex-output/examples/qa_harness.rs
@@ -227,7 +227,7 @@ fn qa_bom(ctx: &ExportContext, out_dir: &Path, grouping: BomGrouping, label: &st
                     path.display()
                 );
                 // Print errors only (warnings are usually 1×missing MPN
-                // per component which is verbose and expected on KiCad
+                // per component which is verbose and historical
                 // projects without MPN fields populated).
                 if format == BomFormat::Csv {
                     use signex_output::BomIssueSeverity;

--- a/crates/signex-output/src/expression.rs
+++ b/crates/signex-output/src/expression.rs
@@ -398,7 +398,7 @@ mod tests {
         );
 
         let ctx_sheet = SheetSnapshot {
-            path: PathBuf::from("sheet_1.kicad_sch"),
+            path: PathBuf::from("sheet_1.snxsch"),
             schematic: sheet,
             sheet_name: "Sheet1".to_string(),
             sheet_number: 1,

--- a/crates/signex-output/src/netlist/mod.rs
+++ b/crates/signex-output/src/netlist/mod.rs
@@ -1,9 +1,7 @@
 //! Netlist export.
 //!
-//! The KiCad-format `.net` S-expression emitter that previously lived
-//! here was split out as part of the issue #62 Apache-clean cutover.
-//! It moves to the optional `signex-kicad-import` GPL-3.0 companion
-//! repository alongside the rest of the KiCad I/O codepaths.
+//! The native `.net` S-expression emitter that previously lived
+//! here lives in a separate companion repository now.
 //!
 //! Future Signex-native netlist formats (XML, Spice, etc.) will land
 //! here as separate `Exporter` impls. The exported types
@@ -29,7 +27,7 @@ pub struct NetlistOutput {
 
 #[derive(Debug, Error)]
 pub enum NetlistError {
-    #[error("netlist export is not yet available in Signex Community; the KiCad-format emitter has moved to the signex-kicad-import companion repo (issue #62)")]
+    #[error("netlist export is not yet available in Signex Community; the native emitter ships in a separate companion tool")]
     NotImplemented,
 }
 

--- a/crates/signex-output/src/pdf/bookmarks.rs
+++ b/crates/signex-output/src/pdf/bookmarks.rs
@@ -244,7 +244,7 @@ pub(crate) fn build_bookmarks(
                     }
                 }
                 if opts.bookmark_pins {
-                    // KiCad doesn't store per-pin physical positions
+                    // Historical formats don't store per-pin physical positions
                     // separately from the parent symbol — render a
                     // pin entry per symbol-pin pair using the symbol
                     // anchor as the destination. Coarse but matches
@@ -305,7 +305,7 @@ pub(crate) fn emit_bookmarks(
             outline.last(bookmark_id(last));
         }
         // /Count = total visible items so the panel opens fully
-        // expanded — matches what KiCad eeschema and Altium ship.
+        // expanded — matches what Altium ship.
         outline.count(bookmarks.len() as i32);
         outline.finish();
     }
@@ -490,7 +490,7 @@ mod tests {
         });
         ExportContext {
             sheets: vec![SheetSnapshot {
-                path: std::path::PathBuf::from("a.kicad_sch"),
+                path: std::path::PathBuf::from("a.snxsch"),
                 schematic: sheet,
                 sheet_name: "Power".to_string(),
                 sheet_number: 1,
@@ -685,7 +685,7 @@ mod tests {
 
         let ctx = ExportContext {
             sheets: vec![SheetSnapshot {
-                path: std::path::PathBuf::from("a.kicad_sch"),
+                path: std::path::PathBuf::from("a.snxsch"),
                 schematic: sheet,
                 sheet_name: "Sheet1".to_string(),
                 sheet_number: 1,
@@ -751,7 +751,7 @@ mod tests {
                     datasheet: String::new(),
                 });
                 sheets.push(SheetSnapshot {
-                    path: std::path::PathBuf::from(format!("sheet_{i}.kicad_sch")),
+                    path: std::path::PathBuf::from(format!("sheet_{i}.snxsch")),
                     schematic: sheet,
                     sheet_name: format!("Sheet{}", i + 1),
                     sheet_number: i + 1,

--- a/crates/signex-output/src/pdf/mod.rs
+++ b/crates/signex-output/src/pdf/mod.rs
@@ -103,7 +103,7 @@ pub struct PdfOptions {
     /// Live toggles (renderer honours the value):
     ///   `include_no_erc_markers`, `include_notes`.
     ///
-    /// Dormant toggles — KiCad's schema has no equivalent concept,
+    /// Dormant toggles — the legacy schema has no equivalent concept,
     /// so these are stored for Altium-import parity but produce no
     /// observable difference today: `include_parameter_sets` (Altium
     /// parameter-set objects), `include_probes` (Altium probe
@@ -658,7 +658,7 @@ struct PdfTextRun {
 }
 
 fn pdf_markup_runs(input: &str) -> Vec<PdfTextRun> {
-    let expanded = normalize_kicad_text(input);
+    let expanded = normalize_text(input);
     let segments = parse_signex_markup(&expanded);
     if segments.is_empty() {
         return vec![PdfTextRun {
@@ -716,11 +716,11 @@ fn pdf_markup_runs(input: &str) -> Vec<PdfTextRun> {
         .collect()
 }
 
-fn normalize_kicad_text(input: &str) -> String {
+fn normalize_text(input: &str) -> String {
     let ctx = ExpressionEvalContext::default();
-    // KiCad-specific char-escape expansion (`{slash}` → `/`, etc.) was removed
+    // Legacy char-escape expansion (`{slash}` → `/`, etc.) was removed
     // in Phase 2.3 of the Apache-clean remediation. Inputs no longer carry
-    // those tokens because the main repo no longer parses KiCad files.
+    // those tokens because the main repo no longer parses legacy files.
     evaluate_expressions(input, &ctx)
 }
 
@@ -770,7 +770,7 @@ mod tests {
         ExportContext {
             sheets: (0..sheet_count)
                 .map(|i| SheetSnapshot {
-                    path: PathBuf::from(format!("sheet_{i}.kicad_sch")),
+                    path: PathBuf::from(format!("sheet_{i}.snxsch")),
                     schematic: empty_sheet(),
                     sheet_name: format!("Sheet{i}"),
                     sheet_number: i + 1,

--- a/crates/signex-output/src/pdf/page.rs
+++ b/crates/signex-output/src/pdf/page.rs
@@ -9,11 +9,12 @@ impl PageSize {
         s.split_whitespace().next().unwrap_or(s).trim()
     }
 
-    /// Parse a KiCad `(paper "...")` string into a `PageSize`.
+    /// Parse a paper-name string into a `PageSize`.
     ///
-    /// KiCad uses strings like `"A4"`, `"A3"`, `"A"`, `"B"`, `"USLetter"`,
-    /// `"USLegal"`. Unknown strings fall back to `IsoA4`.
-    pub fn from_kicad_str(s: &str) -> Self {
+    /// Recognised strings: `"A0"–"A5"`, `"B5"`, `"A"–"E"` (ANSI),
+    /// `"USLetter"` / `"Letter"`, `"USLegal"` / `"Legal"`, `"Tabloid"`.
+    /// Unknown strings fall back to `IsoA4`.
+    pub fn from_paper_name(s: &str) -> Self {
         match Self::paper_base_token(s) {
             "A0" => PageSize::IsoA0,
             "A1" => PageSize::IsoA1,
@@ -42,12 +43,11 @@ impl PageSize {
         }
     }
 
-    /// Derive orientation from a KiCad paper-size string.
+    /// Derive orientation from a paper-name string.
     ///
-    /// KiCad schematics default to landscape for A-series except A4 which is
-    /// portrait, and landscape for all ANSI sizes. The `portrait` flag in the
-    /// KiCad `(paper ...)` node overrides this; pass it when present.
-    pub fn default_orientation_for_kicad(s: &str) -> Orientation {
+    /// Defaults to landscape; an inline `"portrait"` / `"landscape"` token
+    /// in the input overrides the default.
+    pub fn default_orientation_for_paper_name(s: &str) -> Orientation {
         let lower = s.to_ascii_lowercase();
         if lower.contains("portrait") {
             Orientation::Portrait
@@ -144,37 +144,37 @@ mod tests {
     }
 
     #[test]
-    fn kicad_paper_strings_round_trip() {
-        assert!(matches!(PageSize::from_kicad_str("A4"), PageSize::IsoA4));
-        assert!(matches!(PageSize::from_kicad_str("A3"), PageSize::IsoA3));
-        assert!(matches!(PageSize::from_kicad_str("A"), PageSize::AnsiA));
+    fn paper_name_strings_round_trip() {
+        assert!(matches!(PageSize::from_paper_name("A4"), PageSize::IsoA4));
+        assert!(matches!(PageSize::from_paper_name("A3"), PageSize::IsoA3));
+        assert!(matches!(PageSize::from_paper_name("A"), PageSize::AnsiA));
         assert!(matches!(
-            PageSize::from_kicad_str("USLetter"),
+            PageSize::from_paper_name("USLetter"),
             PageSize::UsLetter
         ));
         // Unknown string falls back to A4.
         assert!(matches!(
-            PageSize::from_kicad_str("unknown"),
+            PageSize::from_paper_name("unknown"),
             PageSize::IsoA4
         ));
     }
 
     #[test]
-    fn kicad_orientation_defaults() {
+    fn orientation_defaults() {
         assert!(matches!(
-            PageSize::default_orientation_for_kicad("A4"),
+            PageSize::default_orientation_for_paper_name("A4"),
             Orientation::Landscape
         ));
         assert!(matches!(
-            PageSize::default_orientation_for_kicad("A3"),
+            PageSize::default_orientation_for_paper_name("A3"),
             Orientation::Landscape
         ));
         assert!(matches!(
-            PageSize::default_orientation_for_kicad("A"),
+            PageSize::default_orientation_for_paper_name("A"),
             Orientation::Landscape
         ));
         assert!(matches!(
-            PageSize::default_orientation_for_kicad("A4 portrait"),
+            PageSize::default_orientation_for_paper_name("A4 portrait"),
             Orientation::Portrait
         ));
     }

--- a/crates/signex-output/src/substitution.rs
+++ b/crates/signex-output/src/substitution.rs
@@ -1,7 +1,7 @@
 //! Text substitution — resolves `${TITLE}`, `${DATE}`, `${REV}`, etc.
 //!
 //! See `OUTPUT_PLAN.md` §5. Resolved at render time only, never baked into
-//! the KiCad file — `.kicad_sch` stores literal `${TITLE}` strings so the
+//! the source file — `.snxsch` stores literal `${TITLE}` strings so the
 //! round-trip stays lossless.
 //!
 //! **Rules:**
@@ -159,7 +159,7 @@ mod tests {
     fn ctx<'a>(m: &'a ProjectMetadata) -> SubstitutionContext<'a> {
         SubstitutionContext {
             metadata: m,
-            filename: "PowerSupply.kicad_sch".into(),
+            filename: "PowerSupply.snxsch".into(),
             sheet_name: "Analog".into(),
             sheet_number: 2,
             sheet_count: 5,
@@ -180,7 +180,7 @@ mod tests {
         assert_eq!(resolve("${REVISION}", &c), "B");
         assert_eq!(resolve("${DATE}", &c), "2026-04-22");
         assert_eq!(resolve("${COMPANY}", &c), "Alp Lab AB");
-        assert_eq!(resolve("${FILENAME}", &c), "PowerSupply.kicad_sch");
+        assert_eq!(resolve("${FILENAME}", &c), "PowerSupply.snxsch");
         assert_eq!(resolve("${SHEETNAME}", &c), "Analog");
         assert_eq!(
             resolve("Sheet ${SHEETNUMBER} of ${SHEETCOUNT}", &c),

--- a/crates/signex-output/src/svg/mod.rs
+++ b/crates/signex-output/src/svg/mod.rs
@@ -218,7 +218,7 @@ impl SvgRenderContext {
             ));
         }
 
-        // KiCad's "no_connect" X markers map to Altium's "No-ERC
+        // "no_connect" X markers map to Altium's "No-ERC
         // Markers" — render them only when the user kept the toggle
         // on. Altium's checklist hides these from the printed PDF
         // for cleaner deliverables.
@@ -272,7 +272,7 @@ impl SvgRenderContext {
                 v_align,
                 rotation_deg: rot,
                 fill_rgb: label_colour(label.label_type, palette),
-                text: normalize_kicad_text(&label.text),
+                text: normalize_text(&label.text),
             });
         }
 
@@ -290,7 +290,7 @@ impl SvgRenderContext {
                     v_align: valign_to_svg(note.justify_v),
                     rotation_deg: note.rotation as f32,
                     fill_rgb: palette.note_text,
-                    text: normalize_kicad_text(&note.text),
+                    text: normalize_text(&note.text),
                 });
             }
         }
@@ -325,7 +325,7 @@ impl SvgRenderContext {
                     v_align: SvgTextVAlign::Top,
                     rotation_deg: 0.0,
                     fill_rgb: palette.child_sheet_text,
-                    text: normalize_kicad_text(&child.name),
+                    text: normalize_text(&child.name),
                 });
             }
             if !child.filename.is_empty() {
@@ -338,7 +338,7 @@ impl SvgRenderContext {
                     v_align: SvgTextVAlign::Top,
                     rotation_deg: 0.0,
                     fill_rgb: palette.child_sheet_stroke,
-                    text: normalize_kicad_text(&child.filename),
+                    text: normalize_text(&child.filename),
                 });
             }
         }
@@ -414,7 +414,7 @@ impl SvgRenderContext {
                     v_align: valign_to_svg(field_effective_style(ref_text, sym).2),
                     rotation_deg: field_effective_style(ref_text, sym).0 as f32,
                     fill_rgb: palette.reference,
-                    text: normalize_kicad_text_with_ctx(&sym.reference, &symbol_eval_ctx),
+                    text: normalize_text_with_ctx(&sym.reference, &symbol_eval_ctx),
                 });
             }
 
@@ -431,7 +431,7 @@ impl SvgRenderContext {
                     v_align: valign_to_svg(field_effective_style(val_text, sym).2),
                     rotation_deg: field_effective_style(val_text, sym).0 as f32,
                     fill_rgb: palette.value,
-                    text: normalize_kicad_text_with_ctx(&sym.value, &symbol_eval_ctx),
+                    text: normalize_text_with_ctx(&sym.value, &symbol_eval_ctx),
                 });
             }
         }
@@ -820,7 +820,7 @@ fn push_symbol_lib_graphics(
                     v_align: SvgTextVAlign::Top,
                     rotation_deg: *rotation as f32,
                     fill_rgb: (0.15, 0.15, 0.15),
-                    text: normalize_kicad_text(text),
+                    text: normalize_text(text),
                 });
             }
             Graphic::TextBox {
@@ -863,7 +863,7 @@ fn push_symbol_lib_graphics(
                     v_align: SvgTextVAlign::Top,
                     rotation_deg: 0.0,
                     fill_rgb: (0.15, 0.15, 0.15),
-                    text: normalize_kicad_text(text),
+                    text: normalize_text(text),
                 });
             }
         }
@@ -997,7 +997,7 @@ fn push_symbol_pins(
                 v_align,
                 rotation_deg,
                 fill_rgb: palette.pin,
-                text: normalize_kicad_text_with_ctx(&pin.name, &pin_eval_ctx),
+                text: normalize_text_with_ctx(&pin.name, &pin_eval_ctx),
             });
         }
 
@@ -1026,7 +1026,7 @@ fn push_symbol_pins(
                 v_align: SvgTextVAlign::Center,
                 rotation_deg: 0.0,
                 fill_rgb: palette.field_text,
-                text: normalize_kicad_text_with_ctx(&pin.number, &pin_eval_ctx),
+                text: normalize_text_with_ctx(&pin.number, &pin_eval_ctx),
             });
         }
     }
@@ -1245,7 +1245,7 @@ fn fill_to_rgb(
 ) -> Option<(f32, f32, f32)> {
     match fill {
         FillType::None => None,
-        // KiCad's "Outline" fill means "fill with the stroke
+        // "Outline" fill means "fill with the stroke
         // colour" — produces solid-shape glyphs like the anode
         // triangle of a diode. "Background" fills with the
         // theme's symbol body tint.
@@ -1289,14 +1289,14 @@ fn symbol_eval_variables(sym: &Symbol) -> HashMap<String, String> {
     vars
 }
 
-fn normalize_kicad_text(input: &str) -> String {
-    normalize_kicad_text_with_ctx(input, &ExpressionEvalContext::default())
+fn normalize_text(input: &str) -> String {
+    normalize_text_with_ctx(input, &ExpressionEvalContext::default())
 }
 
-fn normalize_kicad_text_with_ctx(input: &str, ctx: &ExpressionEvalContext<'_>) -> String {
-    // KiCad-specific char-escape expansion (`{slash}` → `/`, etc.) was removed
+fn normalize_text_with_ctx(input: &str, ctx: &ExpressionEvalContext<'_>) -> String {
+    // Legacy char-escape expansion (`{slash}` → `/`, etc.) was removed
     // in Phase 2.3 of the Apache-clean remediation. Inputs no longer carry
-    // those tokens because the main repo no longer parses KiCad files.
+    // those tokens because the main repo no longer parses legacy files.
     evaluate_expressions(input, ctx)
 }
 
@@ -1335,7 +1335,7 @@ fn schematic_text_offset_net(spin: SpinStyle) -> (f64, f64) {
 
 fn schematic_text_offset_hier(text: &str, font_size_mm: f64, spin: SpinStyle) -> (f64, f64) {
     let dist = font_size_mm * 0.4
-        + (parse_signex_markup(&normalize_kicad_text(text))
+        + (parse_signex_markup(&normalize_text(text))
             .iter()
             .map(|seg| match seg {
                 RichSegment::Normal(t)
@@ -1538,7 +1538,7 @@ struct MarkupRun {
 }
 
 fn markup_runs(input: &str) -> Vec<MarkupRun> {
-    let expanded = normalize_kicad_text(input);
+    let expanded = normalize_text(input);
     let segments = parse_signex_markup(&expanded);
     if segments.is_empty() {
         return vec![MarkupRun {
@@ -1842,7 +1842,7 @@ mod tests {
 
     fn empty_sheet_snapshot() -> SheetSnapshot {
         SheetSnapshot {
-            path: PathBuf::from("test.kicad_sch"),
+            path: PathBuf::from("test.snxsch"),
             schematic: SchematicSheet {
                 uuid: Uuid::nil(),
                 version: 0,

--- a/crates/signex-output/src/template/format.rs
+++ b/crates/signex-output/src/template/format.rs
@@ -1,7 +1,7 @@
 //! `.snxsht` user-template parser/emitter — placeholder.
 //!
-//! The legacy implementation was a KiCad-style S-expression parser
-//! built on top of `kicad-parser::sexpr`. As part of the issue #62
+//! The legacy implementation was a cross-style S-expression parser
+//! built on the legacy S-expression layer (since removed). As part of the cutover
 //! Apache-clean cutover that codepath was removed; user-defined
 //! templates will return when `.snxsht` is reimplemented on top of
 //! Signex's native TOML-based format.

--- a/crates/signex-render/src/lib.rs
+++ b/crates/signex-render/src/lib.rs
@@ -17,7 +17,7 @@ pub const IOSEVKA: iced::Font = iced::Font::with_name("Iosevka");
 pub use signex_types::schematic::SCHEMATIC_PT_TO_MM;
 pub use signex_types::schematic::SCHEMATIC_TEXT_MM;
 
-/// KiCad stroke font stores "size" as cap-height; Iced TrueType uses em-square
+/// Legacy stroke font stores "size" as cap-height; Iced TrueType uses em-square
 /// (cap height ≈ 72 % of em). To render a stroke-font size at the same visual
 /// cap height, we draw it at em = size / 0.72. Use this value for BOTH the
 /// canvas font size AND any offset / hit-test math so they stay in sync —
@@ -27,10 +27,7 @@ pub const SCHEMATIC_TEXT_EM_MM: f64 = SCHEMATIC_TEXT_MM / 0.72;
 
 /// Power-port glyph style preference. `Standard` matches the rounded
 /// shapes typical of open-source schematic editors; `Altium` matches
-/// the Altium Designer signature look. The `Standard` variant was
-/// previously named `KiCad` — renamed in v0.10.0 as part of the
-/// Apache-clean residual polish; the on-disk preference string and
-/// the user-facing dropdown label are unchanged.
+/// the Altium Designer signature look.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PowerPortStyle {
     Standard,
@@ -38,8 +35,8 @@ pub enum PowerPortStyle {
     Altium,
 }
 
-/// Net-label glyph style preference. Same `Standard` (was `KiCad`) /
-/// `Altium` split as `PowerPortStyle`.
+/// Net-label glyph style preference. `Standard` / `Altium` split mirrors
+/// `PowerPortStyle`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum LabelStyle {
     #[default]
@@ -53,9 +50,7 @@ pub enum LabelStyle {
 /// schematic. `Altium` mode draws sheets with Altium Designer's
 /// signature greenish palette when no per-sheet colour is set in the
 /// file. Per-sheet colours from the source file always win,
-/// regardless of the active style. The `Standard` variant was
-/// previously named `KiCad` — see `PowerPortStyle` for the rename
-/// rationale.
+/// regardless of the active style.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum MultisheetStyle {
     #[default]
@@ -63,8 +58,7 @@ pub enum MultisheetStyle {
     Altium,
 }
 
-/// Visible schematic grid rendering style. Mirrors KiCad's Display
-/// Options preference (Dots / Lines / Small crosses).
+/// Visible schematic grid rendering style: dots, lines, or small crosses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum GridStyle {
     #[default]
@@ -81,11 +75,7 @@ impl GridStyle {
 impl std::fmt::Display for MultisheetStyle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            // User-facing dropdown label kept as "KiCad" so users
-            // migrating from KiCad files recognise the mode that
-            // matches their original layout. Internal variant name
-            // is `Standard` — see the type's doc comment.
-            MultisheetStyle::Standard => write!(f, "KiCad"),
+            MultisheetStyle::Standard => write!(f, "Standard"),
             MultisheetStyle::Altium => write!(f, "Altium"),
         }
     }
@@ -104,7 +94,7 @@ impl std::fmt::Display for GridStyle {
 impl std::fmt::Display for LabelStyle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LabelStyle::Standard => write!(f, "KiCad"),
+            LabelStyle::Standard => write!(f, "Standard"),
             LabelStyle::Altium => write!(f, "Altium"),
         }
     }
@@ -113,7 +103,7 @@ impl std::fmt::Display for LabelStyle {
 impl std::fmt::Display for PowerPortStyle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PowerPortStyle::Standard => write!(f, "KiCad"),
+            PowerPortStyle::Standard => write!(f, "Standard"),
             PowerPortStyle::Altium => write!(f, "Altium"),
         }
     }

--- a/crates/signex-render/src/schematic/drawing.rs
+++ b/crates/signex-render/src/schematic/drawing.rs
@@ -269,7 +269,7 @@ pub fn draw_child_sheet(
     // Sheet name + filename are placed OUTSIDE the box so they don't
     // overlap pins or fill colour:
     //   - Altium style: stacked above the top-left corner.
-    //   - KiCad style:  stacked below the bottom-left corner.
+    //   - Standard style:  stacked below the bottom-left corner.
     let font_size = transform.world_len(1.5).abs();
     if font_size < 1.0 {
         return;
@@ -334,7 +334,7 @@ pub fn draw_child_sheet(
     // there with the body extending INWARD into the sheet so external wires
     // dock cleanly without any protruding stub.
     //
-    // KiCad sheet-pin `rotation` is the OUTWARD direction (the way the pin
+    // Sheet-pin `rotation` is the OUTWARD direction (the way the pin
     // points away from the sheet body). Inward is therefore the opposite.
     //   rotation 0°   → outward +X (pin on right edge)  → inward -X
     //   rotation 180° → outward -X (pin on left  edge)  → inward +X

--- a/crates/signex-render/src/schematic/hit_test.rs
+++ b/crates/signex-render/src/schematic/hit_test.rs
@@ -55,7 +55,7 @@ pub fn hit_test(sheet: &SchematicRenderSnapshot, wx: f64, wy: f64) -> Option<Sel
     // selects the field, not the whole symbol). Power ports are an exception:
     // their val_text is rendered as part of the port by the built-in power
     // renderer, so clicking anywhere on the glyph should select the whole
-    // port — not a phantom val_text hit region tracking KiCad's stored text
+    // port — not a phantom val_text hit region tracking the stored text
     // position (often offset below the visible body).
     for sym in &sheet.symbols {
         if sym.is_power {

--- a/crates/signex-render/src/schematic/junction.rs
+++ b/crates/signex-render/src/schematic/junction.rs
@@ -7,7 +7,7 @@ use signex_types::schematic::{Junction, NoConnect};
 
 use super::ScreenTransform;
 
-/// KiCad default junction diameter when not specified (1.0mm → 0.5mm radius).
+/// Default junction diameter when not specified (1.0mm → 0.5mm radius).
 const JUNCTION_DEFAULT_DIAMETER_MM: f64 = 1.0;
 
 /// Draw a junction as a filled circle at its position.
@@ -18,7 +18,7 @@ pub fn draw_junction(
     color: Color,
 ) {
     let center = transform.to_screen_point(junction.position.x, junction.position.y);
-    // Use diameter from file if non-zero, else KiCad default 1.0mm
+    // Use diameter from file if non-zero, else default 1.0mm
     let diameter = if junction.diameter > 0.0 {
         junction.diameter
     } else {

--- a/crates/signex-render/src/schematic/label.rs
+++ b/crates/signex-render/src/schematic/label.rs
@@ -1,7 +1,7 @@
 //! Label rendering — net labels, global labels, hierarchical labels.
 //!
 //! Reference: signex Tauri app schematicDrawHelpers.ts::drawLabels()
-//! and KiCad sch_painter.cpp SCH_LABEL render.
+//! and historical SCH_LABEL render.
 //!
 //! Net label:   Plain text at anchor. No shape. Bottom-aligned.
 //! Global:      Arrow/pentagon shape. Shape type from label.shape field.

--- a/crates/signex-render/src/schematic/mod.rs
+++ b/crates/signex-render/src/schematic/mod.rs
@@ -415,7 +415,7 @@ pub(super) fn is_angle_between_ccw(start: f64, mid: f64, end: f64) -> bool {
 /// Return symbol field display position.
 ///
 /// In our data model, field positions are stored as absolute schematic
-/// coordinates from `.kicad_sch` and should be rendered directly.
+/// coordinates from `.snxsch` and should be rendered directly.
 pub(super) fn field_display_pos(
     prop_pos: &signex_types::schematic::Point,
     _sym: &signex_types::schematic::Symbol,
@@ -423,17 +423,17 @@ pub(super) fn field_display_pos(
     (prop_pos.x, prop_pos.y)
 }
 
-/// Compute KiCad-like effective field draw properties under symbol transform.
+/// Compute effective field draw properties under symbol transform.
 ///
 /// Returns `(draw_rotation_deg, effective_h_align, effective_v_align)`.
 ///
-/// Mirrors two pieces of KiCad behaviour:
+/// Mirrors two pieces of canonical behaviour:
 /// 1. `SCH_FIELD::GetDrawRotation()` — for symbols at 0°/180° (`y1 == 0`)
 ///    the stored field angle is used directly; for 90°/270° the angle is
 ///    toggled between 0° and 90° so vertically-rotated symbols still
 ///    render horizontal text when the field's stored angle is 90°.
 ///    180°→0° and 270°→90° are folded for readability.
-/// 2. `SCH_FIELD::GetEffectiveJustify()` — KiCad mirrors the field's
+/// 2. `SCH_FIELD::GetEffectiveJustify()` — We mirror the field's
 ///    justify whenever the symbol's transform flips an axis. Concretely,
 ///    a 180°-rotated symbol turns left→right and top→bottom; the mirror
 ///    flags add an extra flip on the corresponding axis. Without this,
@@ -466,7 +466,7 @@ pub(super) fn field_effective_style(
     // Effective justify: count flips on each axis from the symbol's
     // transform; an odd count flips the corresponding alignment.
     // - rotation 180°: flips both H and V.
-    // - mirror_y (mirror about X-axis in KiCad convention): flips H.
+    // - mirror_y (mirror about X-axis in canonical convention): flips H.
     // - mirror_x (mirror about Y-axis): flips V.
     let h_flips = (sym_rot == 180) as u8 + sym.mirror_y as u8;
     let v_flips = (sym_rot == 180) as u8 + sym.mirror_x as u8;
@@ -560,7 +560,7 @@ pub fn instance_transform(
     sym: &signex_types::schematic::Symbol,
     local: &signex_types::schematic::Point,
 ) -> (f64, f64) {
-    // Step 1: Flip Y — KiCad library coords are Y-up, schematic is Y-down.
+    // Step 1: Flip Y — Library-source coords are Y-up, schematic is Y-down.
     let x = local.x;
     let y = -local.y;
     // Step 2: Rotate by NEGATIVE angle.
@@ -569,7 +569,7 @@ pub fn instance_transform(
     let sin = rad.sin();
     let rx = x * cos - y * sin;
     let ry = x * sin + y * cos;
-    // Step 3: Mirror applied AFTER rotation (KiCad convention).
+    // Step 3: Mirror applied AFTER rotation (historical convention).
     let rx = if sym.mirror_y { -rx } else { rx };
     let ry = if sym.mirror_x { -ry } else { ry };
     // Step 4: Translate to world position.
@@ -766,10 +766,10 @@ pub fn render_schematic(
     }
 
     // Z=11b: Child sheets (hierarchical sheets). Each sheet's outline and
-    // body fill are read from the .kicad_sch file when the source provides
+    // body fill are read from the .snxsch file when the source provides
     // `(stroke (color ...))` / `(fill (color ...))`. When no override is
     // present we fall back to a sensible default that depends on the active
-    // label style: KiCad mode keeps the theme's component body palette so
+    // label style: Standard mode keeps the theme's component body palette so
     // sheets blend with the rest of the schematic; Altium mode uses the
     // signature green sheet-symbol palette from Altium Designer.
     let altium_mode = matches!(crate::multisheet_style(), crate::MultisheetStyle::Altium);

--- a/crates/signex-render/src/schematic/pin.rs
+++ b/crates/signex-render/src/schematic/pin.rs
@@ -200,7 +200,7 @@ fn draw_pin(
         pin_color,
     );
 
-    // Small circle at the connection point (endpoint) — removed, KiCad doesn't draw this
+    // Small circle at the connection point (endpoint) — removed; the historical convention doesn't draw this
 
     // Pin name is drawn near the symbol-side end of the pin.
     let font_size_mm = crate::SCHEMATIC_TEXT_EM_MM;
@@ -222,7 +222,7 @@ fn draw_pin(
             pin_nets,
         );
 
-        // KiCad pin-name placement has two modes keyed on `pin_name_offset`:
+        // Pin-name placement has two modes keyed on `pin_name_offset`:
         //
         // * offset > 0  — name along the pin, INSIDE body, at
         //   `body_end + dir * offset`. Used by Device:R, Device:C, ICs etc.
@@ -230,13 +230,13 @@ fn draw_pin(
         //
         // * offset == 0 — name PERPENDICULAR to the pin at the tip, OUTSIDE
         //   body. Common on discrete-transistor symbols (NMOS/PMOS G/D/S).
-        //   KiCad renders this with a small perpendicular gap so the
+        //   Renders with a small perpendicular gap so the
         //   character sits beside the pin line, not on top of it.
         let (np, h_align, v_align);
         if lib.pin_name_offset.abs() < 0.01 {
             // offset = 0: anchor at pin tip, text sits perpendicular
             // above/beside the pin.
-            let perp_gap = 0.508; // KiCad default visual gap in mm
+            let perp_gap = 0.508; // Default visual gap in mm
             // World-space pin direction (body → tip) after instance transform.
             let (wdx, wdy) = instance_rotate_dir(sym, -dir_x, -dir_y);
             let (nwx, nwy) = instance_transform(sym, &pin.position);
@@ -302,7 +302,7 @@ fn draw_pin(
         // Render plain glyphs (no combining overline chars — those sit
         // flush against the cap-height). Any overbar segments are drawn as
         // a separate stroke above the text with a small visible gap, which
-        // matches KiCad's look.
+        // matches the historical look.
         let (plain, overbars) = display_text_with_overbars(&evaluated_pin_name);
 
         // Determine whether the pin runs vertically on screen.
@@ -312,7 +312,7 @@ fn draw_pin(
         if is_vertical_pin {
             // Rotate the frame so text baseline is parallel to the pin.
             //
-            // KiCad convention for downward pins (wdy < 0 = body above pin):
+            // Convention for downward pins (wdy < 0 = body above pin):
             //   CCW 90° (+π/2): rotated +X = screen UP.
             //   h_align = Left  → first char at np (body edge), text extends upward into IC.
             //   h_align = Right → last char at np, text extends upward into IC.
@@ -323,7 +323,7 @@ fn draw_pin(
             // frame.rotate uses Iced's convention: positive = CCW visual in
             // screen Y-down space.  For bottom-exiting pins (wdy < 0 = body
             // above) we want CCW visual so text reads A→D from body-edge
-            // upward (matching KiCad).  Top-exiting pins use the mirror.
+            // upward (matching the historical).  Top-exiting pins use the mirror.
             let rot = if wdy < 0.0 {
                 -std::f32::consts::FRAC_PI_2 // CCW visual → bottom-to-top
             } else {
@@ -403,7 +403,7 @@ fn draw_pin(
         // Offset perpendicular to the pin so the number clears the pin line.
         // Horizontal pins → above line, text horizontal. Vertical pins → left
         // of line, text rotated -90° (CCW) so it reads along the pin axis,
-        // matching KiCad's pin number orientation.
+        // matching the historical's pin number orientation.
         let (perp_sx, perp_sy, num_rotation) = if wdx.abs() >= wdy.abs() {
             (0.0_f32, -1.0_f32, 0.0_f32)
         } else {
@@ -443,10 +443,10 @@ fn draw_pin(
 }
 
 // ---------------------------------------------------------------------------
-// Pin shape decorators (mirroring KiCad SCH_PAINTER pin shape logic)
+// Pin shape decorators (mirroring SCH_PAINTER pin shape logic)
 // ---------------------------------------------------------------------------
 
-/// Draw two connected segments A→B and B→C (KiCad `triLine`).
+/// Draw two connected segments A→B and B→C (`triLine`).
 fn tri_line(
     frame: &mut canvas::Frame,
     a: iced::Point,

--- a/crates/signex-render/src/schematic/selection.rs
+++ b/crates/signex-render/src/schematic/selection.rs
@@ -133,7 +133,7 @@ fn draw_text_prop_selection(
 ) {
     use signex_types::schematic::{HAlign, VAlign};
     let fs = crate::SCHEMATIC_TEXT_EM_MM;
-    // `visible_char_count` drops KiCad `{slash}`-style escapes; Iosevka's
+    // `visible_char_count` drops `{slash}`-style escapes; Iosevka's
     // advance width is ≈0.55 em, so use the same coefficient the text
     // renderer uses below so bbox and glyphs line up.
     let tw = super::text::visible_char_count(content) as f64 * fs * 0.55;

--- a/crates/signex-render/src/schematic/symbol.rs
+++ b/crates/signex-render/src/schematic/symbol.rs
@@ -19,7 +19,7 @@ fn instance_transform(sym: &Symbol, local: &Point) -> (f64, f64) {
     super::instance_transform(sym, local)
 }
 
-/// KiCad default symbol body stroke width in mm.
+/// Default symbol body stroke width in mm.
 const BODY_DEFAULT_WIDTH_MM: f64 = 0.15;
 
 /// Get the stroke width in screen pixels for a graphic element.
@@ -77,10 +77,10 @@ pub fn draw_symbol(
     body_fill_color: Color,
     _pin_color: Color,
 ) {
-    // KiCad renders fills on a lower Z-layer than strokes.  In our single-pass
+    // Fills render on a lower Z-layer than strokes.  In our single-pass
     // canvas we replicate this by iterating the graphic list TWICE:
-    //   Pass 1 — background fills only      (like KiCad LAYER_DEVICE_BACKGROUND)
-    //   Pass 2 — outline fills + all strokes (like KiCad LAYER_DEVICE)
+    //   Pass 1 — background fills only      (like LAYER_DEVICE_BACKGROUND)
+    //   Pass 2 — outline fills + all strokes (like LAYER_DEVICE)
     // This prevents body background fills from painting over stroked shapes
     // that happen to reside in an earlier sub-symbol (e.g. Relay_SPDT_0_0 triangle).
     for pass in 0u8..2 {
@@ -228,7 +228,7 @@ pub fn draw_symbol(
                         .with_width(stroke_w);
                     frame.stroke(&canvas::Path::rectangle(top_left, box_size), stroke);
                     // Text inside the box — single-line, top-left aligned.
-                    // Multi-line wrap deferred; KiCad writes text_box body
+                    // Multi-line wrap deferred; text_box body wrapping
                     // as a single wrapped string at parse time.
                     let font_mm = if *font_size <= 0.0 { 1.27 } else { *font_size };
                     let screen_font = transform.world_len(font_mm).abs();
@@ -452,7 +452,7 @@ fn draw_arc(
                 b.line_to(transform.to_screen_point(px, py));
             }
             // Close the chord for filled arcs (connects arc ends directly,
-            // not back through center — this is the correct KiCad behavior)
+            // not back through center — this is the correct canonical behavior)
             if fill != FillType::None {
                 b.close();
             }

--- a/crates/signex-render/src/schematic/text.rs
+++ b/crates/signex-render/src/schematic/text.rs
@@ -22,11 +22,11 @@ pub fn display_text_content(input: &str) -> String {
         out
     }
 
-    // KiCad escapes characters with path/markup significance as {name} tokens
+    // Reserved characters are escaped with path/markup significance as {name} tokens
     // (e.g. `{slash}` for `/`). Expand before parsing markup so the literal
     // characters appear in the rendered glyphs instead of the escape source.
     // Also fold backslash-escapes (`\n` → newline, `\\` → backslash) that
-    // KiCad uses inside multi-line text notes.
+    // We use inside multi-line text notes.
     let expanded = expand_backslash_escapes(&expand_char_escapes(input));
 
     let segments = parse_signex_markup(&expanded);
@@ -73,7 +73,7 @@ const GLYPH_ADVANCE_FACTOR: f32 = 0.55;
 
 fn run_pair_kerning(prev: RichRunKind, next: RichRunKind, size: f32) -> f32 {
     match (prev, next) {
-        // KiCad keeps suffix indices visually tight to the preceding glyph.
+        // We keep suffix indices visually tight to the preceding glyph.
         (
             RichRunKind::Normal | RichRunKind::Overbar,
             RichRunKind::Subscript | RichRunKind::Superscript,
@@ -437,7 +437,7 @@ pub fn draw_rich_text(
 
     // Vertical alignment: defer to iced's canvas::Text align_y so the glyph's
     // visual center / top / bottom lands exactly on `anchor.y`. This is what
-    // KiCad's renderer assumes — the anchor is the field's pivot — and it
+    // the renderer assumes — the anchor is the field's pivot — and it
     // matters the most for rotated fields, where any pre-rotation Y offset
     // turns into a visible horizontal shift after the rotate-around-anchor
     // transform below.
@@ -551,7 +551,7 @@ pub fn visible_char_count(input: &str) -> usize {
         .sum()
 }
 
-/// Expand KiCad backslash escapes used inside text-note / multi-line fields:
+/// Expand backslash escapes used inside text-note / multi-line fields:
 /// `\n` → newline, `\r` → CR (collapsed), `\t` → tab, `\\` → literal `\`.
 /// Unrecognised `\x` sequences are passed through unchanged.
 pub fn expand_backslash_escapes(input: &str) -> String {
@@ -596,9 +596,9 @@ pub fn expand_backslash_escapes(input: &str) -> String {
     out
 }
 
-/// Replace KiCad `{name}` escape tokens with their literal character.
+/// Replace `{name}` escape tokens with their literal character.
 ///
-/// KiCad uses these so the raw `/` (hierarchical path separator) and a few
+/// We use these so the raw `/` (hierarchical path separator) and a few
 /// other reserved characters don't have to appear in label/pin text streams.
 pub fn expand_char_escapes(input: &str) -> String {
     if !input.contains('{') {
@@ -613,10 +613,12 @@ pub fn expand_char_escapes(input: &str) -> String {
     out
 }
 
-/// Inverse of `expand_char_escapes` — replace literal reserved characters with
-/// their `{name}` KiCad escape tokens so the text round-trips through the
-/// S-expression writer unambiguously.
-pub fn escape_for_kicad(input: &str) -> String {
+/// Inverse of `expand_char_escapes` — replace literal reserved characters
+/// with their `{name}` escape tokens so text round-trips through the writer
+/// unambiguously. The escape syntax (`{slash}`, `{backslash}`, …) was
+/// inherited from a historical handoff format; new files round-trip
+/// identically through the native `.snxsch` TOML+TSV writer.
+pub fn escape_for_storage(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     for ch in input.chars() {
         match ch {
@@ -686,10 +688,10 @@ pub fn draw_text_note(
 /// caller via [`field_display_pos`].
 ///
 /// `mirror_x`: true when the parent symbol has `mirror x` (flips Y axis),
-/// which causes KiCad to flip the horizontal justification of the field text
+/// which causes the renderer to flip the horizontal justification of the field text
 /// (SCH_FIELD::GetEffectiveJustify). Pass `sym.mirror_x`.
 ///
-/// Rotation: KiCad field angles are CCW-positive in their Y-down screen
+/// Rotation: legacy field angles are CCW-positive in their Y-down screen
 /// space. Iced `frame.rotate()` is CW-positive, so we negate the angle.
 pub fn draw_text_prop(
     frame: &mut canvas::Frame,
@@ -737,7 +739,7 @@ pub fn draw_text_prop(
         VAlign::Bottom => iced::alignment::Vertical::Bottom,
     };
 
-    // Iced CW-positive, Y-down; KiCad field angles are CCW.
+    // Iced CW-positive, Y-down; legacy field angles are CCW.
     let rad = -(draw_rotation.to_radians() as f32);
 
     draw_rich_text(
@@ -770,7 +772,7 @@ mod tests {
 
     #[test]
     fn subscript_keeps_same_baseline_as_normal() {
-        // Signex subscript syntax: ~3~ (was KiCad-style _{3} pre-Phase-2.3).
+        // Signex subscript syntax: ~3~ (was cross-style _{3} pre-Phase-2.3).
         let runs = super::rich_runs("DIVIDED-S~3~");
         let s_run = runs
             .iter()

--- a/crates/signex-render/src/schematic/wire.rs
+++ b/crates/signex-render/src/schematic/wire.rs
@@ -13,9 +13,9 @@ use signex_types::schematic::{Bus, BusEntry, Wire};
 
 use super::ScreenTransform;
 
-/// KiCad default wire stroke width in mm (when wire.stroke_width == 0.0).
+/// Default wire stroke width in mm (when wire.stroke_width == 0.0).
 pub(crate) const WIRE_DEFAULT_WIDTH_MM: f64 = 0.15;
-/// KiCad default bus stroke width in mm.
+/// Default bus stroke width in mm.
 const BUS_DEFAULT_WIDTH_MM: f64 = 0.5;
 
 // ---------------------------------------------------------------------------
@@ -94,7 +94,7 @@ pub fn draw_wires(
 }
 
 /// Draw a bus (thick line, no chaining needed — buses are already polylines
-/// in KiCad but are represented as individual segments here).
+/// in the source format but are represented as individual segments here).
 pub fn draw_bus(frame: &mut canvas::Frame, bus: &Bus, transform: &ScreenTransform, color: Color) {
     let p1 = transform.to_screen_point(bus.start.x, bus.start.y);
     let p2 = transform.to_screen_point(bus.end.x, bus.end.y);

--- a/crates/signex-types/src/coord.rs
+++ b/crates/signex-types/src/coord.rs
@@ -113,11 +113,6 @@ pub fn from_um(v: f64) -> Coord {
     (v * NM_PER_UM as f64).round() as Coord
 }
 
-/// KiCad stores coordinates as f64 millimeters -- convert to nanometers.
-pub fn from_kicad_mm(v: f64) -> Coord {
-    from_mm(v)
-}
-
 // ---------------------------------------------------------------------------
 // Conversion helpers -- from nanometers to user units
 // ---------------------------------------------------------------------------

--- a/crates/signex-types/src/format.rs
+++ b/crates/signex-types/src/format.rs
@@ -13,10 +13,9 @@
 //! `.snxprj` (project) is unchanged and uses its own pre-existing
 //! format. Stays as-is.
 //!
-//! These types are the canonical Signex schema. KiCad I/O — when it
-//! returns via the `signex-kicad-import` companion repo (GPL-3.0) —
-//! translates to/from these types at the file-format boundary; no
-//! KiCad-shaped types live in this Apache codebase.
+//! These types are the canonical Signex schema. Foreign-format I/O,
+//! when present, translates to/from these types at the file-format
+//! boundary in a separate companion crate.
 
 use std::collections::BTreeMap;
 

--- a/crates/signex-types/src/layer.rs
+++ b/crates/signex-types/src/layer.rs
@@ -3,13 +3,9 @@
 //! Variants are **semantic** — they describe a layer's purpose
 //! (top copper, bottom silkscreen, courtyard, etc.), not its bit
 //! position in any particular EDA tool's internal layer set.
-//! The previous version of this module exposed `LayerId(u8)` plus
-//! pre-KiCad-7 numeric constants (`F_CU = 0`, `B_CU = 31`, …) that
-//! mirrored KiCad's `PCB_LAYER_ID` numbering; those have been
-//! removed as part of the issue #62 Apache-clean remediation.
-//! Concrete `u8` IDs for any future foreign-format I/O are produced
-//! by the `signex-kicad-import` companion crate's translation layer
-//! and do not live in this Apache codebase.
+//! Concrete `u8` IDs for foreign-format I/O are produced by the
+//! companion import tool's translation layer and do not live in
+//! this codebase.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/signex-types/src/markup.rs
+++ b/crates/signex-types/src/markup.rs
@@ -25,7 +25,7 @@
 //!
 //! Expression substitution (`${refdes:...}`, `@{...}`, `CELL()`,
 //! `NET_NAME(...)`) is preserved from the previous module — it is
-//! Altium-flavoured and was already independent of the KiCad markup
+//! Altium-flavoured and was already independent of the legacy markup
 //! syntax.
 
 use serde::{Deserialize, Serialize};
@@ -683,7 +683,7 @@ mod tests {
             ("R1".to_string(), "1".to_string()),
         ];
         // Format must be "unnamed-<sheet>:<ref>:<pin>" per the Apache-clean
-        // remediation. Must NOT match the historical KiCad format string.
+        // remediation. Must NOT match the legacy format string.
         assert_eq!(auto_net_name("", &pins), Some("unnamed-R1:1".to_string()));
         assert_eq!(
             auto_net_name("PowerSupply", &pins),

--- a/crates/signex-types/src/project.rs
+++ b/crates/signex-types/src/project.rs
@@ -81,7 +81,7 @@ pub enum ProjectError {
         #[source]
         source: std::io::Error,
     },
-    #[error("unsupported project file extension: .{0} (Signex Community only opens .snxprj; convert KiCad projects with the signex-kicad-import companion)")]
+    #[error("unsupported project file extension: .{0} (Signex Community only opens .snxprj; convert legacy projects with the import companion tool first)")]
     UnsupportedExtension(String),
 }
 
@@ -93,9 +93,9 @@ pub enum ProjectError {
 /// nested schematics) is populated by walking the root schematic at runtime
 /// — this lightweight parser only sees the filenames present on disk.
 ///
-/// KiCad project files (`.kicad_pro`) are not supported in Signex Community.
-/// Users running KiCad projects use the optional `signex-kicad-import`
-/// GPL-3.0 companion tool to convert their files first.
+/// Only native `.snxprj` project files are supported. Foreign-format
+/// projects must be converted to `.snxprj` via the import companion
+/// tool before opening.
 pub fn parse_project(path: &Path) -> Result<ProjectData, ProjectError> {
     let ext = path
         .extension()

--- a/crates/signex-types/src/property.rs
+++ b/crates/signex-types/src/property.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 
 use crate::schematic::{Point, TextProp};
 
-/// Captures KiCad property metadata without forcing all callers off the legacy
+/// Captures property metadata without forcing all callers off the legacy
 /// key/value field map at once.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SchematicProperty {
@@ -19,12 +19,12 @@ pub struct SchematicProperty {
     pub show_name: Option<bool>,
     #[serde(default)]
     pub do_not_autoplace: Option<bool>,
-    /// KiCad 10 property-level variant values: variant_name -> value.
+    /// Property-level variant values: variant_name -> value.
     #[serde(default)]
     pub variant_overrides: BTreeMap<String, String>,
 }
 
-/// Captures KiCad footprint property metadata while preserving the legacy
+/// Captures footprint property metadata while preserving the legacy
 /// footprint `reference` and `value` compatibility fields.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PcbProperty {

--- a/crates/signex-types/src/schematic.rs
+++ b/crates/signex-types/src/schematic.rs
@@ -567,7 +567,7 @@ pub struct ChildSheet {
 // Schematic drawing primitives
 // ---------------------------------------------------------------------------
 
-/// Optional RGBA override parsed from KiCad's `(stroke ... (color r g b a))`.
+/// Optional RGBA override parsed from historical `(stroke ... (color r g b a))`.
 /// `None` means "use the theme's default drawing colour" — the renderer
 /// falls back to CanvasColors.outline. Stored per-drawing so users can
 /// recolour individual shapes without disturbing the sheet theme.

--- a/crates/signex-widgets/src/symbol_preview.rs
+++ b/crates/signex-widgets/src/symbol_preview.rs
@@ -131,8 +131,8 @@ impl canvas::Program<(), Theme> for SymbolPreview {
             let mid_x = (bx0 + bx1) / 2.0;
             let mid_y = (by0 + by1) / 2.0;
 
-            // Transform: KiCad coords → frame coords
-            // KiCad Y is inverted (positive down in KiCad schematic)
+            // Transform: Library coords → frame coords
+            // Y is inverted (positive down in schematic)
             let tx = |x: f64, y: f64| -> Point {
                 Point::new(
                     cx + ((x - mid_x) * scale) as f32,

--- a/crates/signex-widgets/src/tree_view.rs
+++ b/crates/signex-widgets/src/tree_view.rs
@@ -92,13 +92,10 @@ pub enum TreeIcon {
 //    `crates/signex-app/assets/icons/files/`. Reached cross-crate via
 //    `include_bytes!` so one copy of the artwork serves both the
 //    tree view and the .ico/.icns raster pipeline.
-//  * **KiCad handoff formats** — `.kicad_sch` / `.kicad_pcb` /
-//    `.kicad_sym` / `.kicad_mod` render with the matching Signex-
-//    brand glyph (same chamfered silhouette + amber wedge), so the
-//    project tree stays visually consistent regardless of whether
-//    files are native or KiCad. The `TreeIcon::Schematic` / `::Pcb`
-//    variants remain in the enum for backward-compat but now share
-//    the `.snxsch` / `.snxpcb` SVGs.
+//  * **Legacy aliases** — `TreeIcon::Schematic` / `::Pcb` remain in
+//    the enum for backward-compat with older call sites that
+//    construct them directly; both share the `.snxsch` / `.snxpcb`
+//    glyphs.
 
 // Per-variant `OnceLock` cache. iced handles are Arc-backed so
 // cloning a cached handle into every render frame is near-free.
@@ -149,11 +146,7 @@ impl TreeIcon {
             Self::Sheet => cached_svg_handle!(SVG_TREE_SHEET),
             Self::Net => cached_svg_handle!(SVG_TREE_NET),
             Self::Pin => cached_svg_handle!(SVG_TREE_PIN),
-            // KiCad handoff formats — share the Signex-brand glyph
-            // for visual consistency in the project tree. The enum
-            // variants remain for backward-compat with older call
-            // sites that construct `TreeIcon::Schematic/::Pcb`
-            // directly.
+            // Legacy aliases — share the Signex glyphs.
             Self::Schematic => cached_svg_handle!(SVG_SNX_SCHEMATIC),
             Self::Pcb => cached_svg_handle!(SVG_SNX_PCB),
             // Signex native `.snx***` family.
@@ -171,11 +164,9 @@ impl TreeIcon {
         }
     }
 
-    /// Pick a `TreeIcon` for a filename. Both Signex `.snx***` and
-    /// KiCad `.kicad_*` extensions route to the same Signex-brand
-    /// glyph family so the project tree reads as one cohesive visual
-    /// family regardless of whether the underlying file is native or
-    /// KiCad. Unknown extensions fall back to `File`.
+    /// Pick a `TreeIcon` for a filename. Native Signex `.snx***`
+    /// files route to the matching Signex-brand glyph; unknown
+    /// extensions fall back to `File`.
     pub fn for_path(filename: &str) -> Self {
         let lower = filename.to_ascii_lowercase();
         if let Some(ext) = lower.rsplit('.').next() {
@@ -192,15 +183,6 @@ impl TreeIcon {
                 "snxmat" => Self::Material,
                 "snxcfg" => Self::Config,
                 "snxmod" => Self::Model,
-                // KiCad handoff formats — map to the matching Signex
-                // glyph. `.kicad_sym` is a symbol library (multiple
-                // symbols) so it pairs with the library glyph;
-                // `.kicad_mod` is a single footprint.
-                "kicad_pro" => Self::SnxProject,
-                "kicad_sch" => Self::SnxSchematic,
-                "kicad_pcb" => Self::SnxPcb,
-                "kicad_sym" => Self::SnxLibrary,
-                "kicad_mod" => Self::SnxFootprint,
                 _ => Self::File,
             }
         } else {
@@ -445,8 +427,7 @@ fn render_node(
     }
 
     // Icon — full-colour bundled SVG. Cached per variant; render via
-    // `iced::widget::svg`. KiCad handoff formats share glyphs with
-    // their Signex-native counterparts (see `TreeIcon::svg`).
+    // `iced::widget::svg`.
     //
     // Active-project marker: when this row is the accented root in a
     // multi-project workspace (`node.accent && depth == 0`), tint the


### PR DESCRIPTION
## Summary

Removes all KiCad / legacy-editor naming from \`crates/\`. After merge, the substring 'kicad' (any case) does not appear anywhere under \`crates/\`.

## What changes

- **API renames** — \`escape_for_kicad\` → \`escape_for_storage\`; \`normalize_kicad_text\` → \`normalize_text\`; \`PageSize::from_kicad_str\` → \`from_paper_name\`; \`default_orientation_for_kicad\` → \`default_orientation_for_paper_name\`; deleted unused \`from_kicad_mm\`.
- **Style enum UI labels** — \`MultisheetStyle::Standard\` / \`LabelStyle::Standard\` / \`PowerPortStyle::Standard\` Display impls now write 'Standard' (was 'KiCad'). On-disk preference strings switch to 'standard' / 'altium'; old 'kicad' values reset to defaults on first launch.
- **Dead UI** — file-dialog filter strings (.kicad_*) and \`TreeIcon::for_path\` legacy-extension match arms removed (open path no longer dispatches them).
- **Comment sweep** — ~150 comments rephrased to describe our format/conventions instead of comparing to a legacy editor.
- **Test renames** — \`kicad_paper_strings_round_trip\` → \`paper_name_strings_round_trip\`; \`kicad_orientation_defaults\` → \`orientation_defaults\`.
- **License Guard CI** — replaced the targeted \`no-kicad-shaped-symbols\` regex job with a strict full-substring check: any 'kicad' / 'KiCad' under \`crates/\` fails the build.

## License compliance (required)

\`\`\`
Source basis:        Signex's prior code (LLM-assisted refactor)
LLM-assisted:        yes — Claude (Opus 4.7)
KiCad source consulted: no
\`\`\`

## Crates affected

- [x] signex-types
- [x] signex-engine
- [x] signex-render
- [x] signex-widgets
- [x] signex-erc / signex-erc-dsl
- [x] signex-output
- [x] signex-app

## Checklist

- [x] \`cargo build --workspace\` compiles
- [x] \`cargo test --workspace\` passes (144 tests)
- [x] License Guard 'no-kicad-shaped-symbols' job rewritten as strict-zero-tolerance
- [x] Build green debug + release