### PR TITLE
chore(license-guard): rephrase sketcher → sketch in geom comments

### DIFF
--- a/crates/signex-sketch/src/geom/polylabel.rs
+++ b/crates/signex-sketch/src/geom/polylabel.rs
@@ -18,7 +18,7 @@
 //! O(n²) worst-case in the polygon vertex count for the
 //! point-to-polygon distance step; the recursion depth is
 //! bounded by `log2(bbox / precision)` so it converges quickly
-//! for typical sketcher polygons.
+//! for typical sketch polygons.
 
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;

--- a/crates/signex-sketch/src/geom/predicates.rs
+++ b/crates/signex-sketch/src/geom/predicates.rs
@@ -2,7 +2,7 @@
 //!
 //! These wrap the textbook formulae for orientation and signed area
 //! with a tolerance-aware sign so callers don't have to repeat the
-//! same `det.abs() < EPS` boilerplate everywhere. PCB sketcher
+//! same `det.abs() < EPS` boilerplate everywhere. PCB sketch
 //! tolerances live at the mm scale where IEEE-754 f64 has ~12
 //! decimal digits of headroom; the relative + absolute bound check
 //! below is enough without a multi-precision fallback.
@@ -37,7 +37,7 @@ impl Sign {
 }
 
 /// Default absolute tolerance for predicate sign decisions. 1e-9 mm
-/// = 1 fm at sketcher scale — well below any physical PCB feature
+/// = 1 fm at sketch scale — well below any physical PCB feature
 /// and well above f64 noise on typical operands.
 pub const DEFAULT_TOL: f64 = 1.0e-9;
 


### PR DESCRIPTION
## License Guard fix — `sketcher` → `sketch` in geom comments

Fast-follow after the v0.13.0 merge. The **License Guard** job
*"No SolveSpace / FreeCAD / planegcs / OpenCascade substrings in sketch
crates"* failed on `main` (run 26707720709) because three doc comments
under `crates/signex-sketch/src/geom/` contain the word `sketcher`
(forbidden — FreeCAD's solver module is named "Sketcher").

This pre-existed in the v0.13 backlog; License Guard only runs on
`dev`/`main`, so the `feature/library` branch never surfaced it until
the release merge.

### Fix (comment-only, no functional change)
- `geom/polylabel.rs:21` — "typical sketcher polygons" → "sketch"
- `geom/predicates.rs:5` — "PCB sketcher tolerances" → "sketch"
- `geom/predicates.rs:40` — "at sketcher scale" → "sketch"

Verified against the exact CI grep (now returns no matches). The
whitelisted product descriptions (Cargo.toml, lib.rs heading, bench
example) are untouched.

---

### Self-declaration (Apache-clean invariants)
- **Source basis:** Signex-only. Comment wording change only.
- **LLM-assisted:** Yes.
- **KiCad source consulted:** No.
