### PR TITLE
fix(ci): green main — courtyard test + cargo-deny advisories

### DIFF
--- a/crates/signex-app/src/library/editor/footprint/tests.rs
+++ b/crates/signex-app/src/library/editor/footprint/tests.rs
@@ -39,6 +39,10 @@ fn delete_pad_clears_selection() {
 #[test]
 fn auto_fit_courtyard_tracks_pads() {
     let mut s = FootprintEditorState::empty();
+    // Auto-fit defaults off (v0.26-I) — courtyard is authored
+    // explicitly. Enable it the way the active-bar toggle does
+    // before asserting it tracks the pad bbox.
+    s.toggle_auto_fit();
     s.add_pad_at(-2.0, -1.0);
     s.add_pad_at(2.0, 1.0);
     let c = s

--- a/deny.toml
+++ b/deny.toml
@@ -52,11 +52,27 @@ multiple-versions = "warn"
 deny = []
 
 [advisories]
-# Surface RUSTSEC advisories at "warn" — security advisories are
-# informational in CI (the workflow's continue-on-error: true).
-# Critical advisories should still be addressed.
+# Yanked crates are surfaced as warnings, not hard errors — the only
+# yanked entry (core2) is a deep transitive with no non-yanked release.
 yanked = "warn"
-ignore = []
+# Ignored advisories. Each entry is a transitive dependency for which
+# `cargo update` finds no safe upgrade; the only remedy would be a
+# major-version bump of `iced 0.14` or `tantivy 0.22`, which is out of
+# scope here. Re-evaluate when those upstreams move.
+ignore = [
+    # core2 unmaintained, all versions yanked. Pulled via
+    # bitstream-io -> rav1e -> ravif -> image -> iced (AVIF decode).
+    "RUSTSEC-2026-0105",
+    # core2 unsound Buf::read_exact. Same dead transitive path as
+    # above; not reachable from our usage.
+    "RUSTSEC-2026-0008",
+    # instant unmaintained (superseded by web-time). Pulled via
+    # measure_time -> tantivy; no safe upgrade until tantivy drops it.
+    "RUSTSEC-2024-0384",
+    # paste unmaintained proc-macro (superseded by pastey). Pulled via
+    # rav1e -> ravif -> image -> iced; no safe upgrade in this tree.
+    "RUSTSEC-2024-0436",
+]
 
 [sources]
 # Only crates.io and the official rust-lang git registry are allowed.


### PR DESCRIPTION
## CI green on main — courtyard test + cargo-deny advisories

Fixes the two pre-existing CI failures that surfaced on `main` after the v0.13.0 merge (CI only runs on dev/main; last green was v0.11.0).

### 1. Test `auto_fit_courtyard_tracks_pads`
The v0.26-I change defaulted `auto_fit_courtyard` to `false` (courtyard is now authored explicitly), and `recompute_courtyard` early-returns when the flag is off — so `courtyard_mm` stayed `None` and the stale test panicked. Fix: the test now calls `toggle_auto_fit()` (as the active-bar toggle does) before asserting the courtyard tracks the pad bbox. **Production code unchanged** — the v0.26-I default is intentional.

### 2. cargo-deny advisories
Four RUSTSEC advisories in unmaintained/yanked **transitive** deps with no safe upgrade: `core2` (RUSTSEC-2026-0105 yanked, -0008 unsound) via image/rav1e, `instant` (2024-0384) via tantivy, `paste` (2024-0436) via rav1e. `cargo update` finds no maintained versions; removing them needs a major bump of iced 0.14 / tantivy 0.22. Added a documented `[advisories] ignore` list to `deny.toml` (each ID + dependency path + rationale). **Cargo.lock unchanged.**

### Verified
- `cargo test -p signex-app --lib` → 144 passed, 0 failed
- `cargo deny --all-features check advisories` → ok
- `cargo deny --all-features check licenses` → ok
- `cargo check --workspace` → clean

---

### Self-declaration (Apache-clean invariants)
- **Source basis:** Signex-only; a test helper call + a deny.toml config block.
- **LLM-assisted:** Yes.
- **KiCad source consulted:** No. No `kicad` substring under `crates/`; no third-party-solver substrings under signex-sketch/bake.
