### PR TITLE
fix(ci): green main — courtyard test + cargo-deny advisories

### DIFF
--- a/crates/signex-app/src/library/editor/footprint/tests.rs
+++ b/crates/signex-app/src/library/editor/footprint/tests.rs
@@ -39,6 +39,10 @@ fn delete_pad_clears_selection() {
 #[test]
 fn auto_fit_courtyard_tracks_pads() {
     let mut s = FootprintEditorState::empty();
+    // Auto-fit defaults off (v0.26-I) — courtyard is authored
+    // explicitly. Enable it the way the active-bar toggle does
+    // before asserting it tracks the pad bbox.
+    s.toggle_auto_fit();
     s.add_pad_at(-2.0, -1.0);
     s.add_pad_at(2.0, 1.0);
     let c = s

--- a/deny.toml
+++ b/deny.toml
@@ -52,11 +52,27 @@ multiple-versions = "warn"
 deny = []
 
 [advisories]
-# Surface RUSTSEC advisories at "warn" — security advisories are
-# informational in CI (the workflow's continue-on-error: true).
-# Critical advisories should still be addressed.
+# Yanked crates are surfaced as warnings, not hard errors — the only
+# yanked entry (core2) is a deep transitive with no non-yanked release.
 yanked = "warn"
-ignore = []
+# Ignored advisories. Each entry is a transitive dependency for which
+# `cargo update` finds no safe upgrade; the only remedy would be a
+# major-version bump of `iced 0.14` or `tantivy 0.22`, which is out of
+# scope here. Re-evaluate when those upstreams move.
+ignore = [
+    # core2 unmaintained, all versions yanked. Pulled via
+    # bitstream-io -> rav1e -> ravif -> image -> iced (AVIF decode).
+    "RUSTSEC-2026-0105",
+    # core2 unsound Buf::read_exact. Same dead transitive path as
+    # above; not reachable from our usage.
+    "RUSTSEC-2026-0008",
+    # instant unmaintained (superseded by web-time). Pulled via
+    # measure_time -> tantivy; no safe upgrade until tantivy drops it.
+    "RUSTSEC-2024-0384",
+    # paste unmaintained proc-macro (superseded by pastey). Pulled via
+    # rav1e -> ravif -> image -> iced; no safe upgrade in this tree.
+    "RUSTSEC-2024-0436",
+]
 
 [sources]
 # Only crates.io and the official rust-lang git registry are allowed.


### PR DESCRIPTION
## CI green on main — courtyard test + cargo-deny advisories

Promotes the CI fixes (PR #85) to `main`: stale `auto_fit_courtyard_tracks_pads` test now enables auto-fit before asserting, and 4 unfixable transitive RUSTSEC advisories (core2/instant/paste) are documented-ignored in `deny.toml`. Both pre-existing on the v0.13 backlog; comment/test/config only, no product behavior change.

Verified on PR #85: Test job passes, License Guard green, cargo-deny advisories+licenses ok.

---

### Self-declaration (Apache-clean invariants)
- **Source basis:** Signex-only; test helper call + deny.toml config.
- **LLM-assisted:** Yes.
- **KiCad source consulted:** No.
